### PR TITLE
fix: add deploy key

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -38,6 +38,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
 
       - name: Setup Node
         uses: ./.github/actions/setup-node


### PR DESCRIPTION
Implemented this workaround: https://github.com/orgs/community/discussions/25305#discussioncomment-10728028

Allows us to have both `main` branch protection and an actions bot that can write package version upgrades.