### PR TITLE
Handle execution states (vibe-kanban)

### DIFF
--- a/frontend/src/components/tasks/TaskDetailsPanel.tsx
+++ b/frontend/src/components/tasks/TaskDetailsPanel.tsx
@@ -592,7 +592,7 @@ export function TaskDetailsPanel({
             executionState.coding_agent_process_id
           ]
         : Object.values(attemptData.runningProcessDetails).find(
-            (process) => process.process_type === 'agent'
+            (process) => process.process_type === 'codingagent'
           );
 
       return (


### PR DESCRIPTION
Some execution states aren't handled in frontend/src/components/tasks/TaskDetailsPanel.tsx

For example I can see "Unknown execution state" when the state is CodingAgentFailed