### PR TITLE
Create task in new repo error (vibe-kanban)

### DIFF
--- a/backend/src/models/task_attempt.rs
+++ b/backend/src/models/task_attempt.rs
@@ -244,7 +244,10 @@ impl TaskAttempt {
                 // Handle new repositories without any commits
                 match repo.head() {
                     Ok(head_ref) => head_ref,
-                    Err(e) if e.class() == git2::ErrorClass::Reference && e.code() == git2::ErrorCode::UnbornBranch => {
+                    Err(e)
+                        if e.class() == git2::ErrorClass::Reference
+                            && e.code() == git2::ErrorCode::UnbornBranch =>
+                    {
                         // Repository has no commits yet, create an initial commit
                         let signature = repo.signature().unwrap_or_else(|_| {
                             // Fallback if no Git config is set
@@ -256,7 +259,7 @@ impl TaskAttempt {
                             tree_builder.write()?
                         };
                         let tree = repo.find_tree(tree_id)?;
-                        
+
                         // Create initial commit on main branch
                         let _commit_id = repo.commit(
                             Some("refs/heads/main"),
@@ -266,10 +269,10 @@ impl TaskAttempt {
                             &tree,
                             &[],
                         )?;
-                        
+
                         // Set HEAD to point to main branch
                         repo.set_head("refs/heads/main")?;
-                        
+
                         // Return reference to main branch
                         repo.find_reference("refs/heads/main")?
                     }


### PR DESCRIPTION
I get this error if running a task in a new repo:

2025-07-04T10:53:30.176563Z ERROR vibe_kanban::routes::tasks: Failed to create task attempt: Git error: reference 'refs/heads/main' not found; class=Reference (4); code=UnbornBranch (-9)
