### PR TITLE
feat: track package version for all events

### DIFF
--- a/backend/src/services/analytics.rs
+++ b/backend/src/services/analytics.rs
@@ -62,6 +62,7 @@ impl AnalyticsService {
                 "timestamp".to_string(),
                 json!(chrono::Utc::now().to_rfc3339()),
             );
+            props.insert("version".to_string(), json!(env!("CARGO_PKG_VERSION")));
         }
 
         let payload = json!({


### PR DESCRIPTION
Capture the Cargo package version and send as an additional property for all events. Allows us to run queries like:

```
SELECT * FROM events
WHERE properties.version = '0.0.37-ersion.3'
```