### PR TITLE
chore: lower log level of PR traces

### DIFF
--- a/backend/src/services/pr_monitor.rs
+++ b/backend/src/services/pr_monitor.rs
@@ -4,7 +4,7 @@ use chrono::Utc;
 use octocrab::{models::IssueState, Octocrab};
 use sqlx::SqlitePool;
 use tokio::{sync::RwLock, time::interval};
-use tracing::{debug, error, info, warn};
+use tracing::{debug, info, warn};
 use uuid::Uuid;
 
 use crate::models::{


### PR DESCRIPTION
We are currently spamming Sentry with thousands of these events. I believe that this is because the check runs in a loop, and the GitHub token will eventually lapse.