### PR TITLE
Toogle orphan cleanup (vibe-kanban)

### DIFF
--- a/backend/src/execution_monitor.rs
+++ b/backend/src/execution_monitor.rs
@@ -250,6 +250,11 @@ async fn check_externally_deleted_worktrees(pool: &sqlx::SqlitePool) {
 
 /// Find and delete orphaned worktrees that don't correspond to any task attempts
 async fn cleanup_orphaned_worktrees(pool: &sqlx::SqlitePool) {
+    // Check if orphan cleanup is disabled via environment variable
+    if std::env::var("DISABLE_WORKTREE_ORPHAN_CLEANUP").is_ok() {
+        tracing::debug!("Orphan worktree cleanup is disabled via DISABLE_WORKTREE_ORPHAN_CLEANUP environment variable");
+        return;
+    }
     let worktree_base_dir = crate::models::task_attempt::TaskAttempt::get_worktree_base_dir();
 
     // Check if base directory exists

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.41",
   "private": true,
   "scripts": {
-    "dev": "export FRONTEND_PORT=$(node scripts/setup-dev-environment.js frontend) && export BACKEND_PORT=$(node scripts/setup-dev-environment.js backend) && concurrently \"npm run backend:dev:watch\" \"npm run frontend:dev\"",
+    "dev": "export FRONTEND_PORT=$(node scripts/setup-dev-environment.js frontend) && export BACKEND_PORT=$(node scripts/setup-dev-environment.js backend) && export DISABLE_WORKTREE_ORPHAN_CLEANUP=1 && concurrently \"npm run backend:dev:watch\" \"npm run frontend:dev\"",
     "build": "npm run frontend:build && npm run backend:build",
     "build:single": "npm run frontend:build && npm run backend:build:single",
     "build:npm": "./build-npm-package.sh",


### PR DESCRIPTION
Fix vk dev server not starting because it cleans its own worktree.
Add an environment variable to disable worktree orphan cleanup. Default to cleanup, but set it such that worktrees aren't cleaned up when running vibe kanban from npm run dev.