### PR TITLE
feat: Check GitHub token on load

### DIFF
--- a/backend/src/routes/task_attempts.rs
+++ b/backend/src/routes/task_attempts.rs
@@ -407,6 +407,9 @@ pub async fn create_github_pr(
                 e
             );
             let message = match &e {
+                crate::models::task_attempt::TaskAttemptError::GitHubService(
+                    crate::services::GitHubServiceError::TokenInvalid,
+                ) => Some("github_token_invalid".to_string()),
                 crate::models::task_attempt::TaskAttemptError::Git(err)
                     if err.message().contains("status code: 403") =>
                 {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -22,7 +22,7 @@ import { GitHubLoginDialog } from '@/components/GitHubLoginDialog';
 const SentryRoutes = Sentry.withSentryReactRouterV6Routing(Routes);
 
 function AppContent() {
-  const { config, updateConfig, loading } = useConfig();
+  const { config, updateConfig, loading, githubTokenInvalid } = useConfig();
   const [showDisclaimer, setShowDisclaimer] = useState(false);
   const [showOnboarding, setShowOnboarding] = useState(false);
   const [showGitHubLogin, setShowGitHubLogin] = useState(false);
@@ -36,9 +36,12 @@ function AppContent() {
       }
       const notAuthenticated =
         !config.github?.username || !config.github?.token;
-      setShowGitHubLogin(notAuthenticated);
+      setShowGitHubLogin(notAuthenticated || githubTokenInvalid);
     }
-  }, [config]);
+    if (githubTokenInvalid) {
+      setShowGitHubLogin(true);
+    }
+  }, [config, githubTokenInvalid]);
 
   const handleDisclaimerAccept = async () => {
     if (!config) return;

--- a/frontend/src/components/GitHubLoginDialog.tsx
+++ b/frontend/src/components/GitHubLoginDialog.tsx
@@ -18,7 +18,7 @@ export function GitHubLoginDialog({
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }) {
-  const { config, loading } = useConfig();
+  const { config, loading, githubTokenInvalid } = useConfig();
   const [fetching, setFetching] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [deviceState, setDeviceState] = useState<null | {
@@ -31,7 +31,9 @@ export function GitHubLoginDialog({
   const [polling, setPolling] = useState(false);
   const [copied, setCopied] = useState(false);
 
-  const isAuthenticated = !!(config?.github?.username && config?.github?.token);
+  const isAuthenticated =
+    !!(config?.github?.username && config?.github?.token) &&
+    !githubTokenInvalid;
 
   const handleLogin = async () => {
     setFetching(true);

--- a/frontend/src/components/config-provider.tsx
+++ b/frontend/src/components/config-provider.tsx
@@ -14,6 +14,7 @@ interface ConfigContextType {
   updateAndSaveConfig: (updates: Partial<Config>) => void;
   saveConfig: () => Promise<boolean>;
   loading: boolean;
+  githubTokenInvalid: boolean;
 }
 
 const ConfigContext = createContext<ConfigContextType | undefined>(undefined);
@@ -25,6 +26,7 @@ interface ConfigProviderProps {
 export function ConfigProvider({ children }: ConfigProviderProps) {
   const [config, setConfig] = useState<Config | null>(null);
   const [loading, setLoading] = useState(true);
+  const [githubTokenInvalid, setGithubTokenInvalid] = useState(false);
 
   useEffect(() => {
     const loadConfig = async () => {
@@ -44,6 +46,26 @@ export function ConfigProvider({ children }: ConfigProviderProps) {
 
     loadConfig();
   }, []);
+
+  // Check GitHub token validity after config loads
+  useEffect(() => {
+    if (loading) return;
+    const checkToken = async () => {
+      try {
+        const response = await fetch('/api/auth/github/check');
+        const data: ApiResponse<null> = await response.json();
+        if (!data.success && data.message === 'github_token_invalid') {
+          setGithubTokenInvalid(true);
+        } else {
+          setGithubTokenInvalid(false);
+        }
+      } catch (err) {
+        // If the check fails, assume token is invalid
+        setGithubTokenInvalid(true);
+      }
+    };
+    checkToken();
+  }, [loading]);
 
   const updateConfig = useCallback((updates: Partial<Config>) => {
     setConfig((prev) => (prev ? { ...prev, ...updates } : null));
@@ -100,7 +122,14 @@ export function ConfigProvider({ children }: ConfigProviderProps) {
 
   return (
     <ConfigContext.Provider
-      value={{ config, updateConfig, saveConfig, loading, updateAndSaveConfig }}
+      value={{
+        config,
+        updateConfig,
+        saveConfig,
+        loading,
+        updateAndSaveConfig,
+        githubTokenInvalid,
+      }}
     >
       {children}
     </ConfigContext.Provider>


### PR DESCRIPTION
When the user starts vibe-kanban we send a request to check if their token is still valid and if not we ask users to sign in again with GitHub. In theory this shouldn't happen often as the tokens we use do not expire, but it can happen for some reason.