### PR TITLE
File selector files move around too much (vibe-kanban)

### DIFF
--- a/frontend/src/components/ui/file-search-textarea.tsx
+++ b/frontend/src/components/ui/file-search-textarea.tsx
@@ -198,14 +198,25 @@ export function FileSearchTextarea({
     const availableSpaceAbove = textareaRect.top - 32;
 
     // If not enough space below, position above
-    if (availableSpaceBelow < minDropdownHeight && availableSpaceAbove > availableSpaceBelow) {
+    if (
+      availableSpaceBelow < minDropdownHeight &&
+      availableSpaceAbove > availableSpaceBelow
+    ) {
       // Get actual height from rendered dropdown
-      const actualHeight = dropdownRef.current?.getBoundingClientRect().height || minDropdownHeight;
+      const actualHeight =
+        dropdownRef.current?.getBoundingClientRect().height ||
+        minDropdownHeight;
       finalTop = textareaRect.top - actualHeight - 4;
-      maxHeight = Math.min(maxDropdownHeight, Math.max(availableSpaceAbove, minDropdownHeight));
+      maxHeight = Math.min(
+        maxDropdownHeight,
+        Math.max(availableSpaceAbove, minDropdownHeight)
+      );
     } else {
       // Position below with available space
-      maxHeight = Math.min(maxDropdownHeight, Math.max(availableSpaceBelow, minDropdownHeight));
+      maxHeight = Math.min(
+        maxDropdownHeight,
+        Math.max(availableSpaceBelow, minDropdownHeight)
+      );
     }
 
     return { top: finalTop, left: finalLeft, maxHeight };


### PR DESCRIPTION
When using @ to search files, the results can appear in different places, can we try a different approach to positioning the results

frontend/src/components/ui/file-search-textarea.tsx