### PR TITLE
Fix amp version to allow --format=jsonl

### DIFF
--- a/backend/src/executors/amp.rs
+++ b/backend/src/executors/amp.rs
@@ -565,7 +565,7 @@ impl Executor for AmpFollowupExecutor {
         // Use shell command for cross-platform compatibility
         let (shell_cmd, shell_arg) = get_shell_command();
         let amp_command = format!(
-            "npx @sourcegraph/amp threads continue {} --format=jsonl",
+            "npx @sourcegraph/amp@0.0.1752148945-gd8844f threads continue {} --format=jsonl",
             self.thread_id
         );
 


### PR DESCRIPTION
Amp is deprecating --format=jsonl after version 0.0.1752148945-gd8844ff.
We should pin the version to keep jsonl output.