### PR TITLE
feat: Allow custom GitHub OAuth app client ID via environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,23 @@ This will start the frontend and backend with live reloading. A blank DB will be
 2. In the `npx-cli` folder run `npm pack`
 3. You can run your build with `npx [GENERATED FILE].tgz`
 
-### Custom GitHub OAuth App (Optional)
+
+### Environment Variables
+
+The following environment variables can be configured at build time or runtime:
+
+| Variable | Type | Default | Description |
+|----------|------|---------|-------------|
+| `GITHUB_CLIENT_ID` | Build-time | `Ov23li9bxz3kKfPOIsGm` | GitHub OAuth app client ID for authentication |
+| `POSTHOG_API_KEY` | Build-time | Empty | PostHog analytics API key (disables analytics if empty) |
+| `POSTHOG_API_ENDPOINT` | Build-time | Empty | PostHog analytics endpoint (disables analytics if empty) |
+| `BACKEND_PORT` | Runtime | `0` (auto-assign) | Backend server port |
+| `FRONTEND_PORT` | Runtime | `3000` | Frontend development server port |
+| `DISABLE_WORKTREE_ORPHAN_CLEANUP` | Runtime | Not set | Disable git worktree cleanup (for debugging) |
+
+**Build-time variables** must be set when running `pnpm run build`. **Runtime variables** are read when the application starts.
+
+#### Custom GitHub OAuth App (Optional)
 
 By default, Vibe Kanban uses Bloop AI's GitHub OAuth app for authentication. To use your own GitHub app for self-hosting or custom branding:
 

--- a/README.md
+++ b/README.md
@@ -73,3 +73,15 @@ This will start the frontend and backend with live reloading. A blank DB will be
 1. Run `build-npm-package.sh`
 2. In the `npx-cli` folder run `npm pack`
 3. You can run your build with `npx [GENERATED FILE].tgz`
+
+### Custom GitHub OAuth App (Optional)
+
+By default, Vibe Kanban uses Bloop AI's GitHub OAuth app for authentication. To use your own GitHub app for self-hosting or custom branding:
+
+1. Create a GitHub OAuth App at [GitHub Developer Settings](https://github.com/settings/developers)
+2. Enable "Device Flow" in the app settings
+3. Set scopes to include `user:email,repo`
+4. Build with your client ID:
+   ```bash
+   GITHUB_CLIENT_ID=your_client_id_here pnpm run build
+   ```

--- a/backend/src/routes/auth.rs
+++ b/backend/src/routes/auth.rs
@@ -34,8 +34,10 @@ struct DevicePollRequest {
 
 /// POST /auth/github/device/start
 async fn device_start() -> ResponseJson<ApiResponse<DeviceStartResponse>> {
+    let client_id = option_env!("GITHUB_CLIENT_ID").unwrap_or("Ov23li9bxz3kKfPOIsGm");
+    
     let params = [
-        ("client_id", "Ov23li9bxz3kKfPOIsGm"),
+        ("client_id", client_id),
         ("scope", "user:email,repo"),
     ];
     let client = reqwest::Client::new();
@@ -103,8 +105,10 @@ async fn device_poll(
     State(app_state): State<AppState>,
     Json(payload): Json<DevicePollRequest>,
 ) -> ResponseJson<ApiResponse<String>> {
+    let client_id = option_env!("GITHUB_CLIENT_ID").unwrap_or("Ov23li9bxz3kKfPOIsGm");
+    
     let params = [
-        ("client_id", "Ov23li9bxz3kKfPOIsGm"),
+        ("client_id", client_id),
         ("device_code", payload.device_code.as_str()),
         ("grant_type", "urn:ietf:params:oauth:grant-type:device_code"),
     ];

--- a/backend/src/routes/auth.rs
+++ b/backend/src/routes/auth.rs
@@ -35,11 +35,8 @@ struct DevicePollRequest {
 /// POST /auth/github/device/start
 async fn device_start() -> ResponseJson<ApiResponse<DeviceStartResponse>> {
     let client_id = option_env!("GITHUB_CLIENT_ID").unwrap_or("Ov23li9bxz3kKfPOIsGm");
-    
-    let params = [
-        ("client_id", client_id),
-        ("scope", "user:email,repo"),
-    ];
+
+    let params = [("client_id", client_id), ("scope", "user:email,repo")];
     let client = reqwest::Client::new();
     let res = client
         .post("https://github.com/login/device/code")
@@ -106,7 +103,7 @@ async fn device_poll(
     Json(payload): Json<DevicePollRequest>,
 ) -> ResponseJson<ApiResponse<String>> {
     let client_id = option_env!("GITHUB_CLIENT_ID").unwrap_or("Ov23li9bxz3kKfPOIsGm");
-    
+
     let params = [
         ("client_id", client_id),
         ("device_code", payload.device_code.as_str()),


### PR DESCRIPTION
Enable devs to use their own GitHub OAuth app instead of the hardcoded Bloop AI client ID when building Vibe Kanban from source.

### Changes

  - Modified `backend/src/routes/auth.rs` to use option_env!("GITHUB_CLIENT_ID") instead of hardcoded client ID
  - Follows the same pattern as the existing `POSTHOG_API_KEY` environment variable
  - Falls back to the original Bloop AI client ID (`Ov23li9bxz3kKfPOIsGm`) if no environment variable is set
  - updated `README.md` with a descriptive table of this setting and other settings

### Usage

  To build with your own GitHub OAuth app:

```bash
GITHUB_CLIENT_ID=your_client_id_here pnpm run build
```