### PR TITLE
Add Slash Command input for Create Attempt when CC is selected

### DIFF
--- a/backend/.sqlx/query-319be0883a2b806a09cf5b16675eb8e6d1d6af2d9053a11ca38a76f61f48e16b.json
+++ b/backend/.sqlx/query-319be0883a2b806a09cf5b16675eb8e6d1d6af2d9053a11ca38a76f61f48e16b.json
@@ -1,6 +1,6 @@
 {
   "db_name": "SQLite",
-  "query": "SELECT  id                AS \"id!: Uuid\",\n                       task_id           AS \"task_id!: Uuid\",\n                       worktree_path,\n                       branch,\n                       base_branch,\n                       merge_commit,\n                       executor,\n                       pr_url,\n                       pr_number,\n                       pr_status,\n                       pr_merged_at      AS \"pr_merged_at: DateTime<Utc>\",\n                       worktree_deleted  AS \"worktree_deleted!: bool\",\n                       setup_completed_at AS \"setup_completed_at: DateTime<Utc>\",\n                       created_at        AS \"created_at!: DateTime<Utc>\",\n                       updated_at        AS \"updated_at!: DateTime<Utc>\"\n               FROM    task_attempts\n               WHERE   task_id = $1\n               ORDER BY created_at DESC",
+  "query": "INSERT INTO task_attempts (id, task_id, worktree_path, branch, base_branch, merge_commit, executor, slash_command, pr_url, pr_number, pr_status, pr_merged_at, worktree_deleted, setup_completed_at)\n               VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)\n               RETURNING id as \"id!: Uuid\", task_id as \"task_id!: Uuid\", worktree_path, branch, base_branch, merge_commit, executor, slash_command, pr_url, pr_number, pr_status, pr_merged_at as \"pr_merged_at: DateTime<Utc>\", worktree_deleted as \"worktree_deleted!: bool\", setup_completed_at as \"setup_completed_at: DateTime<Utc>\", created_at as \"created_at!: DateTime<Utc>\", updated_at as \"updated_at!: DateTime<Utc>\"",
   "describe": {
     "columns": [
       {
@@ -39,48 +39,53 @@
         "type_info": "Text"
       },
       {
-        "name": "pr_url",
+        "name": "slash_command",
         "ordinal": 7,
         "type_info": "Text"
       },
       {
-        "name": "pr_number",
+        "name": "pr_url",
         "ordinal": 8,
+        "type_info": "Text"
+      },
+      {
+        "name": "pr_number",
+        "ordinal": 9,
         "type_info": "Integer"
       },
       {
         "name": "pr_status",
-        "ordinal": 9,
+        "ordinal": 10,
         "type_info": "Text"
       },
       {
         "name": "pr_merged_at: DateTime<Utc>",
-        "ordinal": 10,
+        "ordinal": 11,
         "type_info": "Datetime"
       },
       {
         "name": "worktree_deleted!: bool",
-        "ordinal": 11,
+        "ordinal": 12,
         "type_info": "Bool"
       },
       {
         "name": "setup_completed_at: DateTime<Utc>",
-        "ordinal": 12,
+        "ordinal": 13,
         "type_info": "Datetime"
       },
       {
         "name": "created_at!: DateTime<Utc>",
-        "ordinal": 13,
+        "ordinal": 14,
         "type_info": "Text"
       },
       {
         "name": "updated_at!: DateTime<Utc>",
-        "ordinal": 14,
+        "ordinal": 15,
         "type_info": "Text"
       }
     ],
     "parameters": {
-      "Right": 1
+      "Right": 14
     },
     "nullable": [
       true,
@@ -94,11 +99,12 @@
       true,
       true,
       true,
+      true,
       false,
       true,
       false,
       false
     ]
   },
-  "hash": "a9e93d5b09b29faf66e387e4d7596a792d81e75c4d3726e83c2963e8d7c9b56f"
+  "hash": "319be0883a2b806a09cf5b16675eb8e6d1d6af2d9053a11ca38a76f61f48e16b"
 }

--- a/backend/.sqlx/query-70919af7a0491ebdb1edc5d256d02a30032f956472d2df7f813daedc19887f5d.json
+++ b/backend/.sqlx/query-70919af7a0491ebdb1edc5d256d02a30032f956472d2df7f813daedc19887f5d.json
@@ -1,6 +1,6 @@
 {
   "db_name": "SQLite",
-  "query": "SELECT  id                AS \"id!: Uuid\",\n                       task_id           AS \"task_id!: Uuid\",\n                       worktree_path,\n                       branch,\n                       merge_commit,\n                       base_branch,\n                       executor,\n                       pr_url,\n                       pr_number,\n                       pr_status,\n                       pr_merged_at      AS \"pr_merged_at: DateTime<Utc>\",\n                       worktree_deleted  AS \"worktree_deleted!: bool\",\n                       setup_completed_at AS \"setup_completed_at: DateTime<Utc>\",\n                       created_at        AS \"created_at!: DateTime<Utc>\",\n                       updated_at        AS \"updated_at!: DateTime<Utc>\"\n               FROM    task_attempts\n               WHERE   id = $1",
+  "query": "SELECT  ta.id                AS \"id!: Uuid\",\n                       ta.task_id           AS \"task_id!: Uuid\",\n                       ta.worktree_path,\n                       ta.branch,\n                       ta.base_branch,\n                       ta.merge_commit,\n                       ta.executor,\n                       ta.slash_command,\n                       ta.pr_url,\n                       ta.pr_number,\n                       ta.pr_status,\n                       ta.pr_merged_at      AS \"pr_merged_at: DateTime<Utc>\",\n                       ta.worktree_deleted  AS \"worktree_deleted!: bool\",\n                       ta.setup_completed_at AS \"setup_completed_at: DateTime<Utc>\",\n                       ta.created_at        AS \"created_at!: DateTime<Utc>\",\n                       ta.updated_at        AS \"updated_at!: DateTime<Utc>\"\n               FROM    task_attempts ta\n               JOIN    tasks t ON ta.task_id = t.id\n               JOIN    projects p ON t.project_id = p.id\n               WHERE   ta.id = $1 AND t.id = $2 AND p.id = $3",
   "describe": {
     "columns": [
       {
@@ -24,12 +24,12 @@
         "type_info": "Text"
       },
       {
-        "name": "merge_commit",
+        "name": "base_branch",
         "ordinal": 4,
         "type_info": "Text"
       },
       {
-        "name": "base_branch",
+        "name": "merge_commit",
         "ordinal": 5,
         "type_info": "Text"
       },
@@ -39,56 +39,62 @@
         "type_info": "Text"
       },
       {
-        "name": "pr_url",
+        "name": "slash_command",
         "ordinal": 7,
         "type_info": "Text"
       },
       {
-        "name": "pr_number",
+        "name": "pr_url",
         "ordinal": 8,
+        "type_info": "Text"
+      },
+      {
+        "name": "pr_number",
+        "ordinal": 9,
         "type_info": "Integer"
       },
       {
         "name": "pr_status",
-        "ordinal": 9,
+        "ordinal": 10,
         "type_info": "Text"
       },
       {
         "name": "pr_merged_at: DateTime<Utc>",
-        "ordinal": 10,
+        "ordinal": 11,
         "type_info": "Datetime"
       },
       {
         "name": "worktree_deleted!: bool",
-        "ordinal": 11,
+        "ordinal": 12,
         "type_info": "Bool"
       },
       {
         "name": "setup_completed_at: DateTime<Utc>",
-        "ordinal": 12,
+        "ordinal": 13,
         "type_info": "Datetime"
       },
       {
         "name": "created_at!: DateTime<Utc>",
-        "ordinal": 13,
+        "ordinal": 14,
         "type_info": "Text"
       },
       {
         "name": "updated_at!: DateTime<Utc>",
-        "ordinal": 14,
+        "ordinal": 15,
         "type_info": "Text"
       }
     ],
     "parameters": {
-      "Right": 1
+      "Right": 3
     },
     "nullable": [
       true,
       false,
       false,
       false,
-      true,
       false,
+      true,
+      true,
       true,
       true,
       true,
@@ -100,5 +106,5 @@
       false
     ]
   },
-  "hash": "a6d2961718dbc3b1a925e549f49a159c561bef58c105529275f274b27e2eba5b"
+  "hash": "70919af7a0491ebdb1edc5d256d02a30032f956472d2df7f813daedc19887f5d"
 }

--- a/backend/.sqlx/query-8d3327c5e76a53f7788f8f6ad95e8d80386b2f758a31caf7726fc7f604f1a250.json
+++ b/backend/.sqlx/query-8d3327c5e76a53f7788f8f6ad95e8d80386b2f758a31caf7726fc7f604f1a250.json
@@ -1,6 +1,6 @@
 {
   "db_name": "SQLite",
-  "query": "INSERT INTO task_attempts (id, task_id, worktree_path, branch, base_branch, merge_commit, executor, pr_url, pr_number, pr_status, pr_merged_at, worktree_deleted, setup_completed_at)\n               VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)\n               RETURNING id as \"id!: Uuid\", task_id as \"task_id!: Uuid\", worktree_path, branch, base_branch, merge_commit, executor, pr_url, pr_number, pr_status, pr_merged_at as \"pr_merged_at: DateTime<Utc>\", worktree_deleted as \"worktree_deleted!: bool\", setup_completed_at as \"setup_completed_at: DateTime<Utc>\", created_at as \"created_at!: DateTime<Utc>\", updated_at as \"updated_at!: DateTime<Utc>\"",
+  "query": "SELECT  id                AS \"id!: Uuid\",\n                       task_id           AS \"task_id!: Uuid\",\n                       worktree_path,\n                       branch,\n                       base_branch,\n                       merge_commit,\n                       executor,\n                       slash_command,\n                       pr_url,\n                       pr_number,\n                       pr_status,\n                       pr_merged_at      AS \"pr_merged_at: DateTime<Utc>\",\n                       worktree_deleted  AS \"worktree_deleted!: bool\",\n                       setup_completed_at AS \"setup_completed_at: DateTime<Utc>\",\n                       created_at        AS \"created_at!: DateTime<Utc>\",\n                       updated_at        AS \"updated_at!: DateTime<Utc>\"\n               FROM    task_attempts\n               WHERE   task_id = $1\n               ORDER BY created_at DESC",
   "describe": {
     "columns": [
       {
@@ -39,48 +39,53 @@
         "type_info": "Text"
       },
       {
-        "name": "pr_url",
+        "name": "slash_command",
         "ordinal": 7,
         "type_info": "Text"
       },
       {
-        "name": "pr_number",
+        "name": "pr_url",
         "ordinal": 8,
+        "type_info": "Text"
+      },
+      {
+        "name": "pr_number",
+        "ordinal": 9,
         "type_info": "Integer"
       },
       {
         "name": "pr_status",
-        "ordinal": 9,
+        "ordinal": 10,
         "type_info": "Text"
       },
       {
         "name": "pr_merged_at: DateTime<Utc>",
-        "ordinal": 10,
+        "ordinal": 11,
         "type_info": "Datetime"
       },
       {
         "name": "worktree_deleted!: bool",
-        "ordinal": 11,
+        "ordinal": 12,
         "type_info": "Bool"
       },
       {
         "name": "setup_completed_at: DateTime<Utc>",
-        "ordinal": 12,
+        "ordinal": 13,
         "type_info": "Datetime"
       },
       {
         "name": "created_at!: DateTime<Utc>",
-        "ordinal": 13,
+        "ordinal": 14,
         "type_info": "Text"
       },
       {
         "name": "updated_at!: DateTime<Utc>",
-        "ordinal": 14,
+        "ordinal": 15,
         "type_info": "Text"
       }
     ],
     "parameters": {
-      "Right": 13
+      "Right": 1
     },
     "nullable": [
       true,
@@ -94,11 +99,12 @@
       true,
       true,
       true,
+      true,
       false,
       true,
       false,
       false
     ]
   },
-  "hash": "6e8b860b14decfc2227dc57213f38442943d3fbef5c8418fd6b634c6e0f5e2ea"
+  "hash": "8d3327c5e76a53f7788f8f6ad95e8d80386b2f758a31caf7726fc7f604f1a250"
 }

--- a/backend/.sqlx/query-a92f53c5f7fc766566af5e3e225df180a4d8a7bf687122b484ffe92726b4e1c3.json
+++ b/backend/.sqlx/query-a92f53c5f7fc766566af5e3e225df180a4d8a7bf687122b484ffe92726b4e1c3.json
@@ -1,6 +1,6 @@
 {
   "db_name": "SQLite",
-  "query": "SELECT  ta.id                AS \"id!: Uuid\",\n                       ta.task_id           AS \"task_id!: Uuid\",\n                       ta.worktree_path,\n                       ta.branch,\n                       ta.base_branch,\n                       ta.merge_commit,\n                       ta.executor,\n                       ta.pr_url,\n                       ta.pr_number,\n                       ta.pr_status,\n                       ta.pr_merged_at      AS \"pr_merged_at: DateTime<Utc>\",\n                       ta.worktree_deleted  AS \"worktree_deleted!: bool\",\n                       ta.setup_completed_at AS \"setup_completed_at: DateTime<Utc>\",\n                       ta.created_at        AS \"created_at!: DateTime<Utc>\",\n                       ta.updated_at        AS \"updated_at!: DateTime<Utc>\"\n               FROM    task_attempts ta\n               JOIN    tasks t ON ta.task_id = t.id\n               JOIN    projects p ON t.project_id = p.id\n               WHERE   ta.id = $1 AND t.id = $2 AND p.id = $3",
+  "query": "SELECT  id                AS \"id!: Uuid\",\n                       task_id           AS \"task_id!: Uuid\",\n                       worktree_path,\n                       branch,\n                       merge_commit,\n                       base_branch,\n                       executor,\n                       slash_command,\n                       pr_url,\n                       pr_number,\n                       pr_status,\n                       pr_merged_at      AS \"pr_merged_at: DateTime<Utc>\",\n                       worktree_deleted  AS \"worktree_deleted!: bool\",\n                       setup_completed_at AS \"setup_completed_at: DateTime<Utc>\",\n                       created_at        AS \"created_at!: DateTime<Utc>\",\n                       updated_at        AS \"updated_at!: DateTime<Utc>\"\n               FROM    task_attempts\n               WHERE   id = $1",
   "describe": {
     "columns": [
       {
@@ -24,12 +24,12 @@
         "type_info": "Text"
       },
       {
-        "name": "base_branch",
+        "name": "merge_commit",
         "ordinal": 4,
         "type_info": "Text"
       },
       {
-        "name": "merge_commit",
+        "name": "base_branch",
         "ordinal": 5,
         "type_info": "Text"
       },
@@ -39,54 +39,60 @@
         "type_info": "Text"
       },
       {
-        "name": "pr_url",
+        "name": "slash_command",
         "ordinal": 7,
         "type_info": "Text"
       },
       {
-        "name": "pr_number",
+        "name": "pr_url",
         "ordinal": 8,
+        "type_info": "Text"
+      },
+      {
+        "name": "pr_number",
+        "ordinal": 9,
         "type_info": "Integer"
       },
       {
         "name": "pr_status",
-        "ordinal": 9,
+        "ordinal": 10,
         "type_info": "Text"
       },
       {
         "name": "pr_merged_at: DateTime<Utc>",
-        "ordinal": 10,
+        "ordinal": 11,
         "type_info": "Datetime"
       },
       {
         "name": "worktree_deleted!: bool",
-        "ordinal": 11,
+        "ordinal": 12,
         "type_info": "Bool"
       },
       {
         "name": "setup_completed_at: DateTime<Utc>",
-        "ordinal": 12,
+        "ordinal": 13,
         "type_info": "Datetime"
       },
       {
         "name": "created_at!: DateTime<Utc>",
-        "ordinal": 13,
+        "ordinal": 14,
         "type_info": "Text"
       },
       {
         "name": "updated_at!: DateTime<Utc>",
-        "ordinal": 14,
+        "ordinal": 15,
         "type_info": "Text"
       }
     ],
     "parameters": {
-      "Right": 3
+      "Right": 1
     },
     "nullable": [
       true,
       false,
       false,
       false,
+      true,
       false,
       true,
       true,
@@ -100,5 +106,5 @@
       false
     ]
   },
-  "hash": "92e8bdbcd80c5ff3db7a35cf79492048803ef305cbdef0d0a1fe5dc881ca8c71"
+  "hash": "a92f53c5f7fc766566af5e3e225df180a4d8a7bf687122b484ffe92726b4e1c3"
 }

--- a/backend/migrations/20250714212924_add_task_attempt_slash_command.sql
+++ b/backend/migrations/20250714212924_add_task_attempt_slash_command.sql
@@ -1,0 +1,2 @@
+-- Add slash_command column to task_attempts table
+ALTER TABLE task_attempts ADD COLUMN slash_command TEXT DEFAULT NULL;

--- a/backend/src/executor.rs
+++ b/backend/src/executor.rs
@@ -258,6 +258,7 @@ pub trait Executor: Send + Sync {
         &self,
         pool: &sqlx::SqlitePool,
         task_id: Uuid,
+        attempt_id: Uuid,
         worktree_path: &str,
     ) -> Result<command_group::AsyncGroupChild, ExecutorError>;
 
@@ -286,7 +287,7 @@ pub trait Executor: Send + Sync {
         execution_process_id: Uuid,
         worktree_path: &str,
     ) -> Result<command_group::AsyncGroupChild, ExecutorError> {
-        let mut child = self.spawn(pool, task_id, worktree_path).await?;
+        let mut child = self.spawn(pool, task_id, attempt_id, worktree_path).await?;
 
         // Take stdout and stderr pipes for streaming
         let stdout = child

--- a/backend/src/executors/amp.rs
+++ b/backend/src/executors/amp.rs
@@ -198,6 +198,7 @@ impl Executor for AmpExecutor {
         &self,
         pool: &sqlx::SqlitePool,
         task_id: Uuid,
+        _attempt_id: Uuid,
         worktree_path: &str,
     ) -> Result<AsyncGroupChild, ExecutorError> {
         // Get the task to fetch its description
@@ -595,6 +596,7 @@ impl Executor for AmpFollowupExecutor {
         &self,
         _pool: &sqlx::SqlitePool,
         _task_id: Uuid,
+        _attempt_id: Uuid,
         worktree_path: &str,
     ) -> Result<AsyncGroupChild, ExecutorError> {
         use std::process::Stdio;

--- a/backend/src/executors/dev_server.rs
+++ b/backend/src/executors/dev_server.rs
@@ -20,6 +20,7 @@ impl Executor for DevServerExecutor {
         &self,
         pool: &sqlx::SqlitePool,
         task_id: Uuid,
+        _attempt_id: Uuid,
         worktree_path: &str,
     ) -> Result<AsyncGroupChild, ExecutorError> {
         // Validate the task and project exist

--- a/backend/src/executors/echo.rs
+++ b/backend/src/executors/echo.rs
@@ -18,6 +18,7 @@ impl Executor for EchoExecutor {
         &self,
         pool: &sqlx::SqlitePool,
         task_id: Uuid,
+        _attempt_id: Uuid,
         _worktree_path: &str,
     ) -> Result<AsyncGroupChild, ExecutorError> {
         // Get the task to fetch its description

--- a/backend/src/executors/gemini.rs
+++ b/backend/src/executors/gemini.rs
@@ -31,6 +31,7 @@ impl Executor for GeminiExecutor {
         &self,
         pool: &sqlx::SqlitePool,
         task_id: Uuid,
+        _attempt_id: Uuid,
         worktree_path: &str,
     ) -> Result<AsyncGroupChild, ExecutorError> {
         // Get the task to fetch its description
@@ -142,7 +143,7 @@ Task title: {}"#,
             );
         }
 
-        let mut child = self.spawn(pool, task_id, worktree_path).await?;
+        let mut child = self.spawn(pool, task_id, attempt_id, worktree_path).await?;
 
         tracing::info!(
             "Gemini process spawned successfully for attempt {}, PID: {:?}",
@@ -703,6 +704,7 @@ impl Executor for GeminiFollowupExecutor {
         &self,
         pool: &sqlx::SqlitePool,
         task_id: Uuid,
+        _attempt_id: Uuid,
         worktree_path: &str,
     ) -> Result<AsyncGroupChild, ExecutorError> {
         let task = self.load_task(pool, task_id).await?;
@@ -747,7 +749,7 @@ impl Executor for GeminiFollowupExecutor {
             );
         }
 
-        let mut child = self.spawn(pool, task_id, worktree_path).await?;
+        let mut child = self.spawn(pool, task_id, attempt_id, worktree_path).await?;
 
         tracing::info!(
             "Gemini followup process spawned successfully for attempt {}, PID: {:?}",

--- a/backend/src/executors/opencode.rs
+++ b/backend/src/executors/opencode.rs
@@ -23,6 +23,7 @@ impl Executor for OpencodeExecutor {
         &self,
         pool: &sqlx::SqlitePool,
         task_id: Uuid,
+        _attempt_id: Uuid,
         worktree_path: &str,
     ) -> Result<AsyncGroupChild, ExecutorError> {
         // Get the task to fetch its description
@@ -86,6 +87,7 @@ impl Executor for OpencodeFollowupExecutor {
         &self,
         _pool: &sqlx::SqlitePool,
         _task_id: Uuid,
+        _attempt_id: Uuid,
         worktree_path: &str,
     ) -> Result<AsyncGroupChild, ExecutorError> {
         use std::process::Stdio;

--- a/backend/src/executors/setup_script.rs
+++ b/backend/src/executors/setup_script.rs
@@ -26,6 +26,7 @@ impl Executor for SetupScriptExecutor {
         &self,
         pool: &sqlx::SqlitePool,
         task_id: Uuid,
+        _attempt_id: Uuid,
         worktree_path: &str,
     ) -> Result<AsyncGroupChild, ExecutorError> {
         // Validate the task and project exist

--- a/backend/src/mcp/task_server.rs
+++ b/backend/src/mcp/task_server.rs
@@ -11,7 +11,7 @@ use uuid::Uuid;
 
 use crate::models::{
     project::Project,
-    task::{CreateTask, Task, TaskStatus},
+    task::{CreateTask, Task, TaskStatus, UpdateTask},
 };
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -545,7 +545,7 @@ impl TaskServer {
             None
         };
 
-        let current_task =
+        let _current_task =
             match Task::find_by_id_and_project_id(&self.pool, task_uuid, project_uuid).await {
                 Ok(Some(task)) => task,
                 Ok(None) => {
@@ -571,17 +571,17 @@ impl TaskServer {
                 }
             };
 
-        let new_title = title.unwrap_or(current_task.title);
-        let new_description = description.or(current_task.description);
-        let new_status = status_enum.unwrap_or(current_task.status);
+        let update_data = UpdateTask {
+            title,
+            description,
+            status: status_enum,
+        };
 
         match Task::update(
             &self.pool,
             task_uuid,
             project_uuid,
-            new_title,
-            new_description,
-            new_status,
+            &update_data,
         )
         .await
         {

--- a/backend/src/models/task_attempt.rs
+++ b/backend/src/models/task_attempt.rs
@@ -94,6 +94,7 @@ pub struct TaskAttempt {
     pub base_branch: String, // Base branch this attempt is based on
     pub merge_commit: Option<String>,
     pub executor: Option<String>,  // Name of the executor to use
+    pub slash_command: Option<String>,  // Optional Claude Code slash command
     pub pr_url: Option<String>,    // GitHub PR URL
     pub pr_number: Option<i64>,    // GitHub PR number
     pub pr_status: Option<String>, // open, closed, merged
@@ -109,6 +110,7 @@ pub struct TaskAttempt {
 pub struct CreateTaskAttempt {
     pub executor: Option<String>, // Optional executor name (defaults to "echo")
     pub base_branch: Option<String>, // Optional base branch to checkout (defaults to current HEAD)
+    pub slash_command: Option<String>, // Optional Claude Code slash command
 }
 
 #[derive(Debug, Deserialize, TS)]
@@ -229,6 +231,7 @@ impl TaskAttempt {
                        ta.base_branch,
                        ta.merge_commit,
                        ta.executor,
+                       ta.slash_command,
                        ta.pr_url,
                        ta.pr_number,
                        ta.pr_status,
@@ -309,6 +312,7 @@ impl TaskAttempt {
                        merge_commit,
                        base_branch,
                        executor,
+                       slash_command,
                        pr_url,
                        pr_number,
                        pr_status,
@@ -338,6 +342,7 @@ impl TaskAttempt {
                        base_branch,
                        merge_commit,
                        executor,
+                       slash_command,
                        pr_url,
                        pr_number,
                        pr_status,
@@ -479,9 +484,9 @@ impl TaskAttempt {
         // Insert the record into the database
         Ok(sqlx::query_as!(
             TaskAttempt,
-            r#"INSERT INTO task_attempts (id, task_id, worktree_path, branch, base_branch, merge_commit, executor, pr_url, pr_number, pr_status, pr_merged_at, worktree_deleted, setup_completed_at)
-               VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
-               RETURNING id as "id!: Uuid", task_id as "task_id!: Uuid", worktree_path, branch, base_branch, merge_commit, executor, pr_url, pr_number, pr_status, pr_merged_at as "pr_merged_at: DateTime<Utc>", worktree_deleted as "worktree_deleted!: bool", setup_completed_at as "setup_completed_at: DateTime<Utc>", created_at as "created_at!: DateTime<Utc>", updated_at as "updated_at!: DateTime<Utc>""#,
+            r#"INSERT INTO task_attempts (id, task_id, worktree_path, branch, base_branch, merge_commit, executor, slash_command, pr_url, pr_number, pr_status, pr_merged_at, worktree_deleted, setup_completed_at)
+               VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+               RETURNING id as "id!: Uuid", task_id as "task_id!: Uuid", worktree_path, branch, base_branch, merge_commit, executor, slash_command, pr_url, pr_number, pr_status, pr_merged_at as "pr_merged_at: DateTime<Utc>", worktree_deleted as "worktree_deleted!: bool", setup_completed_at as "setup_completed_at: DateTime<Utc>", created_at as "created_at!: DateTime<Utc>", updated_at as "updated_at!: DateTime<Utc>""#,
             attempt_id,
             task_id,
             worktree_path_str,
@@ -489,6 +494,7 @@ impl TaskAttempt {
             resolved_base_branch,
             Option::<String>::None, // merge_commit is always None during creation
             data.executor,
+            data.slash_command,
             Option::<String>::None, // pr_url is None during creation
             Option::<i64>::None, // pr_number is None during creation
             Option::<String>::None, // pr_status is None during creation

--- a/frontend/src/components/tasks/TaskFormDialog.tsx
+++ b/frontend/src/components/tasks/TaskFormDialog.tsx
@@ -225,6 +225,7 @@ export function TaskFormDialog({
             />
           </div>
 
+
           {isEditMode && (
             <div>
               <Label htmlFor="task-status">Status</Label>

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -22,7 +22,7 @@ export type SoundConstants = { sound_files: Array<SoundFile>, sound_labels: Arra
 
 export type ConfigConstants = { editor: EditorConstants, sound: SoundConstants, };
 
-export type ExecutorConfig = { "type": "echo" } | { "type": "claude" } | { "type": "amp" } | { "type": "gemini" } | { "type": "opencode" };
+export type ExecutorConfig = { "type": "echo" } | { "type": "claude" } | { "type": "amp" } | { "type": "gemini" } | { "type": "opencode" } | { "type": "setupscript", script: string, };
 
 export type ExecutorConstants = { executor_types: Array<ExecutorConfig>, executor_labels: Array<string>, };
 
@@ -56,9 +56,9 @@ export type UpdateTask = { title: string | null, description: string | null, sta
 
 export type TaskAttemptStatus = "setuprunning" | "setupcomplete" | "setupfailed" | "executorrunning" | "executorcomplete" | "executorfailed";
 
-export type TaskAttempt = { id: string, task_id: string, worktree_path: string, branch: string, base_branch: string, merge_commit: string | null, executor: string | null, pr_url: string | null, pr_number: bigint | null, pr_status: string | null, pr_merged_at: string | null, worktree_deleted: boolean, setup_completed_at: string | null, created_at: string, updated_at: string, };
+export type TaskAttempt = { id: string, task_id: string, worktree_path: string, branch: string, base_branch: string, merge_commit: string | null, executor: string | null, slash_command: string | null, pr_url: string | null, pr_number: bigint | null, pr_status: string | null, pr_merged_at: string | null, worktree_deleted: boolean, setup_completed_at: string | null, created_at: string, updated_at: string, };
 
-export type CreateTaskAttempt = { executor: string | null, base_branch: string | null, };
+export type CreateTaskAttempt = { executor: string | null, base_branch: string | null, slash_command: string | null, };
 
 export type UpdateTaskAttempt = Record<string, never>;
 


### PR DESCRIPTION
- Add slash_command column to task_attempts table via migration
- Update TaskAttempt model to include slash_command field
- Update Claude executor to use task attempt slash command
- Add slash command input to CreateAttempt component (Claude executor only)
- Remove slash command from Task model and TaskFormDialog
- Update TypeScript types to reflect new structure
- Regenerate .sqlx files for clean database schema

This allows each task attempt to have its own optional slash command, providing flexibility for different execution strategies without cluttering the task creation interface.

<img width="802" height="475" alt="Screenshot 2025-07-14 at 10 15 58 PM" src="https://github.com/user-attachments/assets/1a1d1d3d-3f68-4fb3-ab28-7ec66e784b69" />

<img width="838" height="382" alt="Screenshot 2025-07-14 at 10 18 59 PM" src="https://github.com/user-attachments/assets/b761e80b-80b0-40cc-9614-8c74995d2415" />
