### PR TITLE
fix: update backend response for `/list` route

### DIFF
--- a/backend/src/routes/filesystem.rs
+++ b/backend/src/routes/filesystem.rs
@@ -20,6 +20,13 @@ pub struct DirectoryEntry {
     pub is_git_repo: bool,
 }
 
+#[derive(Debug, Serialize, TS)]
+#[ts(export)]
+pub struct DirectoryListResponse {
+    pub entries: Vec<DirectoryEntry>,
+    pub current_path: String,
+}
+
 #[derive(Debug, Deserialize)]
 pub struct ListDirectoryQuery {
     path: Option<String>,
@@ -27,7 +34,7 @@ pub struct ListDirectoryQuery {
 
 pub async fn list_directory(
     Query(query): Query<ListDirectoryQuery>,
-) -> Result<ResponseJson<ApiResponse<Vec<DirectoryEntry>>>, StatusCode> {
+) -> Result<ResponseJson<ApiResponse<DirectoryListResponse>>, StatusCode> {
     let path_str = query.path.unwrap_or_else(|| {
         // Default to user's home directory
         dirs::home_dir()
@@ -103,7 +110,10 @@ pub async fn list_directory(
 
             Ok(ResponseJson(ApiResponse {
                 success: true,
-                data: Some(directory_entries),
+                data: Some(DirectoryListResponse {
+                    entries: directory_entries,
+                    current_path: path.to_string_lossy().to_string(),
+                }),
                 message: None,
             }))
         }

--- a/frontend/src/components/ui/folder-picker.tsx
+++ b/frontend/src/components/ui/folder-picker.tsx
@@ -66,7 +66,14 @@ export function FolderPicker({
 
     try {
       const result = await fileSystemApi.list(path);
-      setEntries(result.entries || []);
+      
+      // Ensure result exists and has the expected structure
+      if (!result || typeof result !== 'object') {
+        throw new Error('Invalid response from file system API');
+      }
+      // Safely access entries, ensuring it's an array
+      const entries = Array.isArray(result.entries) ? result.entries : [];
+      setEntries(entries);
       const newPath = result.current_path || '';
       setCurrentPath(newPath);
       // Update manual path if we have a specific path (not for initial home directory load)
@@ -75,6 +82,8 @@ export function FolderPicker({
       }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load directory');
+      // Reset entries to empty array on error
+      setEntries([]);
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION
Adds a `DirectoryListResponse` struct that contains `current_path` as well as `Vec<DirectoryEntry>`. This fixes a bug where the frontend would crash after calling `/list`.