### PR TITLE
Rebase that changes base (vibe-kanban)

### DIFF
--- a/backend/.sqlx/query-ac5247c8d7fb86e4650c4b0eb9420031614c831b7b085083bac20c1af314c538.json
+++ b/backend/.sqlx/query-ac5247c8d7fb86e4650c4b0eb9420031614c831b7b085083bac20c1af314c538.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "UPDATE task_attempts SET base_branch = $1, updated_at = datetime('now') WHERE id = $2",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 2
+    },
+    "nullable": []
+  },
+  "hash": "ac5247c8d7fb86e4650c4b0eb9420031614c831b7b085083bac20c1af314c538"
+}

--- a/backend/src/models/task_attempt.rs
+++ b/backend/src/models/task_attempt.rs
@@ -8,7 +8,7 @@ use tracing::info;
 use ts_rs::TS;
 use uuid::Uuid;
 
-use super::{project::Project, task::Task};
+use super::{project::Project, task::Task, config::Config};
 use crate::services::{
     CreatePrRequest, GitHubRepoInfo, GitHubService, GitHubServiceError, GitService,
     GitServiceError, ProcessService,
@@ -539,12 +539,13 @@ impl TaskAttempt {
         worktree_path: &str,
         main_repo_path: &str,
         new_base_branch: Option<String>,
+        github_token: Option<&str>,
     ) -> Result<String, TaskAttemptError> {
         let git_service = GitService::new(main_repo_path)?;
         let worktree_path = Path::new(worktree_path);
 
         git_service
-            .rebase_branch(worktree_path, new_base_branch.as_deref())
+            .rebase_branch(worktree_path, new_base_branch.as_deref(), github_token)
             .map_err(TaskAttemptError::from)
     }
 
@@ -816,11 +817,18 @@ impl TaskAttempt {
         let worktree_path =
             Self::ensure_worktree_exists(pool, attempt_id, project_id, "rebase").await?;
 
+        // Load config to get GitHub token for authentication
+        let config = Config::load(&crate::utils::config_path())
+            .map_err(|e| TaskAttemptError::ValidationError(format!("Failed to load config: {}", e)))?;
+        
+        let github_token = config.github.token.or(config.github.pat);
+
         // Perform the git rebase operations (synchronous)
         let new_base_commit = Self::perform_rebase_operation(
             &worktree_path,
             &ctx.project.git_repo_path,
             effective_base_branch,
+            github_token.as_deref(),
         )?;
 
         // No need to update database as we now get base_commit live from git

--- a/backend/src/models/task_attempt.rs
+++ b/backend/src/models/task_attempt.rs
@@ -8,7 +8,7 @@ use tracing::info;
 use ts_rs::TS;
 use uuid::Uuid;
 
-use super::{config::Config, project::Project, task::Task};
+use super::{project::Project, task::Task};
 use crate::services::{
     CreatePrRequest, GitHubRepoInfo, GitHubService, GitHubServiceError, GitService,
     GitServiceError, ProcessService,

--- a/backend/src/models/task_attempt.rs
+++ b/backend/src/models/task_attempt.rs
@@ -834,9 +834,16 @@ impl TaskAttempt {
         // Update the database with the new base branch if it was changed
         if let Some(new_base_branch) = &effective_base_branch {
             if new_base_branch != &ctx.task_attempt.base_branch {
+                // For remote branches, store the local branch name in the database
+                let db_branch_name = if new_base_branch.starts_with("origin/") {
+                    new_base_branch.strip_prefix("origin/").unwrap()
+                } else {
+                    new_base_branch
+                };
+                
                 sqlx::query!(
                     "UPDATE task_attempts SET base_branch = $1, updated_at = datetime('now') WHERE id = $2",
-                    new_base_branch,
+                    db_branch_name,
                     attempt_id
                 )
                 .execute(pool)

--- a/backend/src/models/task_attempt.rs
+++ b/backend/src/models/task_attempt.rs
@@ -827,11 +827,23 @@ impl TaskAttempt {
         let new_base_commit = Self::perform_rebase_operation(
             &worktree_path,
             &ctx.project.git_repo_path,
-            effective_base_branch,
+            effective_base_branch.clone(),
             github_token.as_deref(),
         )?;
 
-        // No need to update database as we now get base_commit live from git
+        // Update the database with the new base branch if it was changed
+        if let Some(new_base_branch) = &effective_base_branch {
+            if new_base_branch != &ctx.task_attempt.base_branch {
+                sqlx::query!(
+                    "UPDATE task_attempts SET base_branch = $1, updated_at = datetime('now') WHERE id = $2",
+                    new_base_branch,
+                    attempt_id
+                )
+                .execute(pool)
+                .await?;
+            }
+        }
+
         Ok(new_base_commit)
     }
 

--- a/backend/src/services/git_service.rs
+++ b/backend/src/services/git_service.rs
@@ -1060,7 +1060,7 @@ impl GitService {
 
         // Prepare callbacks for authentication
         let mut callbacks = RemoteCallbacks::new();
-        callbacks.credentials(|url, username_from_url, _| {
+        callbacks.credentials(|_url, username_from_url, _| {
             // Try SSH agent first
             if let Some(username) = username_from_url {
                 if let Ok(cred) = Cred::ssh_key_from_agent(username) {

--- a/backend/src/services/git_service.rs
+++ b/backend/src/services/git_service.rs
@@ -1104,13 +1104,13 @@ impl GitService {
             let _ = repo.remote_delete(temp_remote_name);
 
             // Check fetch result
-            fetch_result.map_err(|e| GitServiceError::Git(e))?;
+            fetch_result.map_err(GitServiceError::Git)?;
         } else {
             // Fetch without authentication (might fail for private repos)
             let mut original_remote = repo.find_remote("origin")?;
             original_remote
                 .fetch(&[] as &[&str], None, None)
-                .map_err(|e| GitServiceError::Git(e))?;
+                .map_err(GitServiceError::Git)?;
         }
 
         Ok(())

--- a/frontend/src/components/tasks/BranchSelector.tsx
+++ b/frontend/src/components/tasks/BranchSelector.tsx
@@ -1,0 +1,134 @@
+import { useState, useMemo } from 'react';
+import { Button } from '@/components/ui/button.tsx';
+import {
+  ArrowDown,
+  GitBranch as GitBranchIcon,
+  Search,
+} from 'lucide-react';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu.tsx';
+import { Input } from '@/components/ui/input.tsx';
+import type { GitBranch } from 'shared/types.ts';
+
+type Props = {
+  branches: GitBranch[];
+  selectedBranch: string | null;
+  onBranchSelect: (branch: string) => void;
+  placeholder?: string;
+  className?: string;
+  excludeCurrentBranch?: boolean;
+};
+
+function BranchSelector({
+  branches,
+  selectedBranch,
+  onBranchSelect,
+  placeholder = "Select a branch",
+  className = "",
+  excludeCurrentBranch = false,
+}: Props) {
+  const [branchSearchTerm, setBranchSearchTerm] = useState('');
+
+  // Filter branches based on search term and options
+  const filteredBranches = useMemo(() => {
+    let filtered = branches;
+    
+    if (excludeCurrentBranch) {
+      filtered = filtered.filter(branch => !branch.is_current);
+    }
+    
+    if (branchSearchTerm.trim()) {
+      filtered = filtered.filter((branch) =>
+        branch.name.toLowerCase().includes(branchSearchTerm.toLowerCase())
+      );
+    }
+    
+    return filtered;
+  }, [branches, branchSearchTerm, excludeCurrentBranch]);
+
+  const displayName = useMemo(() => {
+    if (!selectedBranch) return placeholder;
+    
+    // For remote branches, show just the branch name without the remote prefix
+    if (selectedBranch.includes('/')) {
+      const parts = selectedBranch.split('/');
+      return parts[parts.length - 1];
+    }
+    return selectedBranch;
+  }, [selectedBranch, placeholder]);
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="outline"
+          size="sm"
+          className={`w-full justify-between text-xs ${className}`}
+        >
+          <div className="flex items-center gap-1.5">
+            <GitBranchIcon className="h-3 w-3" />
+            <span className="truncate">{displayName}</span>
+          </div>
+          <ArrowDown className="h-3 w-3" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent className="w-80">
+        <div className="p-2">
+          <div className="relative">
+            <Search className="absolute left-2 top-2.5 h-4 w-4 text-muted-foreground" />
+            <Input
+              placeholder="Search branches..."
+              value={branchSearchTerm}
+              onChange={(e) => setBranchSearchTerm(e.target.value)}
+              className="pl-8"
+            />
+          </div>
+        </div>
+        <DropdownMenuSeparator />
+        <div className="max-h-64 overflow-y-auto">
+          {filteredBranches.length === 0 ? (
+            <div className="p-2 text-sm text-muted-foreground text-center">
+              No branches found
+            </div>
+          ) : (
+            filteredBranches.map((branch) => (
+              <DropdownMenuItem
+                key={branch.name}
+                onClick={() => {
+                  onBranchSelect(branch.name);
+                  setBranchSearchTerm('');
+                }}
+                className={selectedBranch === branch.name ? 'bg-accent' : ''}
+              >
+                <div className="flex items-center justify-between w-full">
+                  <span className={branch.is_current ? 'font-medium' : ''}>
+                    {branch.name}
+                  </span>
+                  <div className="flex gap-1">
+                    {branch.is_current && (
+                      <span className="text-xs bg-green-100 text-green-800 px-1 rounded">
+                        current
+                      </span>
+                    )}
+                    {branch.is_remote && (
+                      <span className="text-xs bg-blue-100 text-blue-800 px-1 rounded">
+                        remote
+                      </span>
+                    )}
+                  </div>
+                </div>
+              </DropdownMenuItem>
+            ))
+          )}
+        </div>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+export default BranchSelector;

--- a/frontend/src/components/tasks/BranchSelector.tsx
+++ b/frontend/src/components/tasks/BranchSelector.tsx
@@ -1,10 +1,6 @@
 import { useState, useMemo, useRef } from 'react';
 import { Button } from '@/components/ui/button.tsx';
-import {
-  ArrowDown,
-  GitBranch as GitBranchIcon,
-  Search,
-} from 'lucide-react';
+import { ArrowDown, GitBranch as GitBranchIcon, Search } from 'lucide-react';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -34,8 +30,8 @@ function BranchSelector({
   branches,
   selectedBranch,
   onBranchSelect,
-  placeholder = "Select a branch",
-  className = "",
+  placeholder = 'Select a branch',
+  className = '',
   excludeCurrentBranch = false,
 }: Props) {
   const [branchSearchTerm, setBranchSearchTerm] = useState('');
@@ -44,20 +40,20 @@ function BranchSelector({
   // Filter branches based on search term and options
   const filteredBranches = useMemo(() => {
     let filtered = branches;
-    
+
     // Don't filter out current branch, we'll handle it in the UI
     if (branchSearchTerm.trim()) {
       filtered = filtered.filter((branch) =>
         branch.name.toLowerCase().includes(branchSearchTerm.toLowerCase())
       );
     }
-    
+
     return filtered;
   }, [branches, branchSearchTerm]);
 
   const displayName = useMemo(() => {
     if (!selectedBranch) return placeholder;
-    
+
     // For remote branches, show just the branch name without the remote prefix
     if (selectedBranch.includes('/')) {
       const parts = selectedBranch.split('/');
@@ -112,8 +108,9 @@ function BranchSelector({
             </div>
           ) : (
             filteredBranches.map((branch) => {
-              const isCurrentAndExcluded = excludeCurrentBranch && branch.is_current;
-              
+              const isCurrentAndExcluded =
+                excludeCurrentBranch && branch.is_current;
+
               const menuItem = (
                 <DropdownMenuItem
                   key={branch.name}
@@ -151,9 +148,7 @@ function BranchSelector({
                 return (
                   <TooltipProvider key={branch.name}>
                     <Tooltip>
-                      <TooltipTrigger asChild>
-                        {menuItem}
-                      </TooltipTrigger>
+                      <TooltipTrigger asChild>{menuItem}</TooltipTrigger>
                       <TooltipContent>
                         <p>Cannot rebase a branch onto itself</p>
                       </TooltipContent>

--- a/frontend/src/components/tasks/BranchSelector.tsx
+++ b/frontend/src/components/tasks/BranchSelector.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useRef } from 'react';
 import { Button } from '@/components/ui/button.tsx';
 import {
   ArrowDown,
@@ -33,6 +33,7 @@ function BranchSelector({
   excludeCurrentBranch = false,
 }: Props) {
   const [branchSearchTerm, setBranchSearchTerm] = useState('');
+  const searchInputRef = useRef<HTMLInputElement>(null);
 
   // Filter branches based on search term and options
   const filteredBranches = useMemo(() => {
@@ -62,6 +63,11 @@ function BranchSelector({
     return selectedBranch;
   }, [selectedBranch, placeholder]);
 
+  const handleBranchSelect = (branchName: string) => {
+    onBranchSelect(branchName);
+    setBranchSearchTerm('');
+  };
+
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -82,10 +88,16 @@ function BranchSelector({
           <div className="relative">
             <Search className="absolute left-2 top-2.5 h-4 w-4 text-muted-foreground" />
             <Input
+              ref={searchInputRef}
               placeholder="Search branches..."
               value={branchSearchTerm}
               onChange={(e) => setBranchSearchTerm(e.target.value)}
               className="pl-8"
+              onKeyDown={(e) => {
+                // Prevent the dropdown from closing when typing
+                e.stopPropagation();
+              }}
+              autoFocus
             />
           </div>
         </div>
@@ -99,10 +111,7 @@ function BranchSelector({
             filteredBranches.map((branch) => (
               <DropdownMenuItem
                 key={branch.name}
-                onClick={() => {
-                  onBranchSelect(branch.name);
-                  setBranchSearchTerm('');
-                }}
+                onClick={() => handleBranchSelect(branch.name)}
                 className={selectedBranch === branch.name ? 'bg-accent' : ''}
               >
                 <div className="flex items-center justify-between w-full">

--- a/frontend/src/components/tasks/TaskDetailsToolbar.tsx
+++ b/frontend/src/components/tasks/TaskDetailsToolbar.tsx
@@ -234,6 +234,7 @@ function TaskDetailsToolbar() {
                   creatingPR={creatingPR}
                   handleEnterCreateAttemptMode={handleEnterCreateAttemptMode}
                   availableExecutors={availableExecutors}
+                  branches={branches}
                 />
               ) : (
                 <div className="text-center py-8 flex-1">

--- a/frontend/src/components/tasks/Toolbar/CreateAttempt.tsx
+++ b/frontend/src/components/tasks/Toolbar/CreateAttempt.tsx
@@ -1,11 +1,6 @@
 import { Dispatch, SetStateAction, useContext } from 'react';
 import { Button } from '@/components/ui/button.tsx';
-import {
-  ArrowDown,
-  Play,
-  Settings2,
-  X,
-} from 'lucide-react';
+import { ArrowDown, Play, Settings2, X } from 'lucide-react';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -54,8 +49,6 @@ function CreateAttempt({
   const { task, projectId } = useContext(TaskDetailsContext);
   const { isAttemptRunning } = useContext(TaskAttemptDataContext);
   const { config } = useConfig();
-
-
 
   const onCreateNewAttempt = async (executor?: string, baseBranch?: string) => {
     try {

--- a/frontend/src/components/tasks/Toolbar/CreateAttempt.tsx
+++ b/frontend/src/components/tasks/Toolbar/CreateAttempt.tsx
@@ -1,10 +1,8 @@
-import { Dispatch, SetStateAction, useContext, useMemo, useState } from 'react';
+import { Dispatch, SetStateAction, useContext } from 'react';
 import { Button } from '@/components/ui/button.tsx';
 import {
   ArrowDown,
-  GitBranch as GitBranchIcon,
   Play,
-  Search,
   Settings2,
   X,
 } from 'lucide-react';
@@ -12,10 +10,8 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu.tsx';
-import { Input } from '@/components/ui/input.tsx';
 import type { GitBranch, TaskAttempt } from 'shared/types.ts';
 import { attemptsApi } from '@/lib/api.ts';
 import {
@@ -23,6 +19,7 @@ import {
   TaskDetailsContext,
 } from '@/components/context/taskDetailsContext.ts';
 import { useConfig } from '@/components/config-provider.tsx';
+import BranchSelector from '@/components/tasks/BranchSelector.tsx';
 
 type Props = {
   branches: GitBranch[];
@@ -58,17 +55,7 @@ function CreateAttempt({
   const { isAttemptRunning } = useContext(TaskAttemptDataContext);
   const { config } = useConfig();
 
-  const [branchSearchTerm, setBranchSearchTerm] = useState('');
 
-  // Filter branches based on search term
-  const filteredBranches = useMemo(() => {
-    if (!branchSearchTerm.trim()) {
-      return branches;
-    }
-    return branches.filter((branch) =>
-      branch.name.toLowerCase().includes(branchSearchTerm.toLowerCase())
-    );
-  }, [branches, branchSearchTerm]);
 
   const onCreateNewAttempt = async (executor?: string, baseBranch?: string) => {
     try {
@@ -122,81 +109,12 @@ function CreateAttempt({
                 Base branch
               </label>
             </div>
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  className="w-full justify-between text-xs"
-                >
-                  <div className="flex items-center gap-1.5">
-                    <GitBranchIcon className="h-3 w-3" />
-                    <span className="truncate">
-                      {createAttemptBranch
-                        ? createAttemptBranch.includes('/')
-                          ? createAttemptBranch.split('/').pop()
-                          : createAttemptBranch
-                        : 'current'}
-                    </span>
-                  </div>
-                  <ArrowDown className="h-3 w-3" />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent className="w-80">
-                <div className="p-2">
-                  <div className="relative">
-                    <Search className="absolute left-2 top-2.5 h-4 w-4 text-muted-foreground" />
-                    <Input
-                      placeholder="Search branches..."
-                      value={branchSearchTerm}
-                      onChange={(e) => setBranchSearchTerm(e.target.value)}
-                      className="pl-8"
-                    />
-                  </div>
-                </div>
-                <DropdownMenuSeparator />
-                <div className="max-h-64 overflow-y-auto">
-                  {filteredBranches.length === 0 ? (
-                    <div className="p-2 text-sm text-muted-foreground text-center">
-                      No branches found
-                    </div>
-                  ) : (
-                    filteredBranches.map((branch) => (
-                      <DropdownMenuItem
-                        key={branch.name}
-                        onClick={() => {
-                          setCreateAttemptBranch(branch.name);
-                          setBranchSearchTerm('');
-                        }}
-                        className={
-                          createAttemptBranch === branch.name ? 'bg-accent' : ''
-                        }
-                      >
-                        <div className="flex items-center justify-between w-full">
-                          <span
-                            className={branch.is_current ? 'font-medium' : ''}
-                          >
-                            {branch.name}
-                          </span>
-                          <div className="flex gap-1">
-                            {branch.is_current && (
-                              <span className="text-xs bg-green-100 text-green-800 px-1 rounded">
-                                current
-                              </span>
-                            )}
-                            {branch.is_remote && (
-                              <span className="text-xs bg-blue-100 text-blue-800 px-1 rounded">
-                                remote
-                              </span>
-                            )}
-                          </div>
-                        </div>
-                      </DropdownMenuItem>
-                    ))
-                  )}
-                </div>
-              </DropdownMenuContent>
-            </DropdownMenu>
+            <BranchSelector
+              branches={branches}
+              selectedBranch={createAttemptBranch}
+              onBranchSelect={setCreateAttemptBranch}
+              placeholder="current"
+            />
           </div>
 
           {/* Step 2: Choose Coding Agent */}

--- a/frontend/src/components/tasks/Toolbar/CurrentAttempt.tsx
+++ b/frontend/src/components/tasks/Toolbar/CurrentAttempt.tsx
@@ -680,7 +680,7 @@ function CurrentAttempt({
                 selectedBranch={selectedRebaseBranch}
                 onBranchSelect={setSelectedRebaseBranch}
                 placeholder="Select a base branch"
-                excludeCurrentBranch={true}
+                excludeCurrentBranch={false}
               />
             </div>
           </div>

--- a/frontend/src/components/tasks/Toolbar/CurrentAttempt.tsx
+++ b/frontend/src/components/tasks/Toolbar/CurrentAttempt.tsx
@@ -402,14 +402,8 @@ function CurrentAttempt({
         </div>
 
         <div>
-          <div className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-1">
-            Base Branch
-          </div>
-          <div className="flex items-center gap-1.5">
-            <GitBranchIcon className="h-3 w-3 text-muted-foreground" />
-            <span className="text-sm font-medium">
-              {branchStatus?.base_branch_name || selectedBranchDisplayName}
-            </span>
+          <div className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground uppercase tracking-wide mb-1">
+            <span>Base Branch</span>
             <TooltipProvider>
               <Tooltip>
                 <TooltipTrigger asChild>
@@ -418,7 +412,7 @@ function CurrentAttempt({
                     size="sm"
                     onClick={handleRebaseDialogOpen}
                     disabled={rebasing || branchStatusLoading || isAttemptRunning}
-                    className="h-6 w-6 p-0 hover:bg-muted"
+                    className="h-4 w-4 p-0 hover:bg-muted"
                   >
                     <Settings className="h-3 w-3" />
                   </Button>
@@ -428,6 +422,12 @@ function CurrentAttempt({
                 </TooltipContent>
               </Tooltip>
             </TooltipProvider>
+          </div>
+          <div className="flex items-center gap-1.5">
+            <GitBranchIcon className="h-3 w-3 text-muted-foreground" />
+            <span className="text-sm font-medium">
+              {branchStatus?.base_branch_name || selectedBranchDisplayName}
+            </span>
           </div>
         </div>
 

--- a/frontend/src/components/tasks/Toolbar/CurrentAttempt.tsx
+++ b/frontend/src/components/tasks/Toolbar/CurrentAttempt.tsx
@@ -30,13 +30,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog.tsx';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select.tsx';
+import BranchSelector from '@/components/tasks/BranchSelector.tsx';
 import { attemptsApi, executionProcessesApi } from '@/lib/api.ts';
 import {
   Dispatch,
@@ -679,28 +673,13 @@ function CurrentAttempt({
               <label htmlFor="base-branch" className="text-sm font-medium">
                 Base Branch
               </label>
-              <Select value={selectedRebaseBranch} onValueChange={setSelectedRebaseBranch}>
-                <SelectTrigger>
-                  <SelectValue placeholder="Select a base branch" />
-                </SelectTrigger>
-                <SelectContent>
-                  {branches
-                    .filter(branch => !branch.is_current)
-                    .map((branch) => (
-                      <SelectItem key={branch.name} value={branch.name}>
-                        <div className="flex items-center gap-2">
-                          <GitBranchIcon className="h-3 w-3" />
-                          {branch.name}
-                          {branch.is_remote && (
-                            <span className="text-xs text-muted-foreground">
-                              (remote)
-                            </span>
-                          )}
-                        </div>
-                      </SelectItem>
-                    ))}
-                </SelectContent>
-              </Select>
+              <BranchSelector
+                branches={branches}
+                selectedBranch={selectedRebaseBranch}
+                onBranchSelect={setSelectedRebaseBranch}
+                placeholder="Select a base branch"
+                excludeCurrentBranch={true}
+              />
             </div>
           </div>
 

--- a/frontend/src/components/tasks/Toolbar/CurrentAttempt.tsx
+++ b/frontend/src/components/tasks/Toolbar/CurrentAttempt.tsx
@@ -411,7 +411,9 @@ function CurrentAttempt({
                     variant="ghost"
                     size="sm"
                     onClick={handleRebaseDialogOpen}
-                    disabled={rebasing || branchStatusLoading || isAttemptRunning}
+                    disabled={
+                      rebasing || branchStatusLoading || isAttemptRunning
+                    }
                     className="h-4 w-4 p-0 hover:bg-muted"
                   >
                     <Settings className="h-3 w-3" />
@@ -667,7 +669,7 @@ function CurrentAttempt({
               Choose a new base branch to rebase this task attempt onto.
             </DialogDescription>
           </DialogHeader>
-          
+
           <div className="space-y-4">
             <div className="space-y-2">
               <label htmlFor="base-branch" className="text-sm font-medium">

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -373,12 +373,19 @@ export const attemptsApi = {
   rebase: async (
     projectId: string,
     taskId: string,
-    attemptId: string
+    attemptId: string,
+    newBaseBranch?: string
   ): Promise<void> => {
     const response = await makeRequest(
       `/api/projects/${projectId}/tasks/${taskId}/attempts/${attemptId}/rebase`,
       {
         method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          new_base_branch: newBaseBranch || null,
+        }),
       }
     );
     return handleApiResponse<void>(response);


### PR DESCRIPTION
The backend endpoint for rebasing should support changing the base branch. Next to the "BASE BRANCH" section in task details we should add a small icon which when clicked allows the user to choose a new base branch for the task attempt

frontend/src/components/tasks/TaskDetails
backend/src/routes/task_attempts.rs