### PR TITLE
Open project in IDE doesn't work (vibe-kanban)

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -150,6 +150,7 @@ export const projectsApi = {
   openEditor: async (id: string): Promise<void> => {
     const response = await makeRequest(`/api/projects/${id}/open-editor`, {
       method: 'POST',
+      body: JSON.stringify(null),
     });
     return handleApiResponse<void>(response);
   },


### PR DESCRIPTION
Open task attempt in IDE button does, but open project in IDE doesn't. It gives `Failed to parse the request body as JSON: EOF while parsing a value at line 1 column 0` as the frontend doesn't send any body with POST request