### PR TITLE
Use @react-nano/use-event-source library for SSE requests

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,7 +10,6 @@
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/modifiers": "^9.0.0",
-        "@microsoft/fetch-event-source": "^2.0.1",
         "@radix-ui/react-dropdown-menu": "^2.1.15",
         "@radix-ui/react-label": "^2.1.7",
         "@radix-ui/react-portal": "^1.1.9",
@@ -18,6 +17,7 @@
         "@radix-ui/react-separator": "^1.1.7",
         "@radix-ui/react-slot": "^1.2.3",
         "@radix-ui/react-tooltip": "^1.2.7",
+        "@react-nano/use-event-source": "^0.16.0",
         "@sentry/react": "^9.34.0",
         "@sentry/vite-plugin": "^3.5.0",
         "@tailwindcss/typography": "^0.5.16",
@@ -1133,12 +1133,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@microsoft/fetch-event-source": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/fetch-event-source/-/fetch-event-source-2.0.1.tgz",
-      "integrity": "sha512-W6CLUJ2eBMw3Rec70qrsEW0jOm/3twwJv21mrmj2yORiaVmVYGS4sSS5yUwvQc1ZlDLYGPnClVWmUUMagKNsfA==",
-      "license": "MIT"
-    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1896,6 +1890,15 @@
       "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.1.tgz",
       "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
       "license": "MIT"
+    },
+    "node_modules/@react-nano/use-event-source": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@react-nano/use-event-source/-/use-event-source-0.16.0.tgz",
+      "integrity": "sha512-XiflYfULRrUjWS1s1gGFBIbdsU56RVIbFT/9KnZwydlnUzQiRm6SVMHZI83g0fXnZpmS3Xh09WFZAfK7l36NGA==",
+      "license": "Zlib",
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
     },
     "node_modules/@remix-run/router": {
       "version": "1.23.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,6 @@
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/modifiers": "^9.0.0",
-    "@microsoft/fetch-event-source": "^2.0.1",
     "@radix-ui/react-dropdown-menu": "^2.1.15",
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-portal": "^1.1.9",
@@ -23,6 +22,7 @@
     "@radix-ui/react-separator": "^1.1.7",
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-tooltip": "^1.2.7",
+    "@react-nano/use-event-source": "^0.16.0",
     "@sentry/react": "^9.34.0",
     "@sentry/vite-plugin": "^3.5.0",
     "@tailwindcss/typography": "^0.5.16",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,9 +23,6 @@ importers:
       '@dnd-kit/modifiers':
         specifier: ^9.0.0
         version: 9.0.0(@dnd-kit/core@6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
-      '@microsoft/fetch-event-source':
-        specifier: ^2.0.1
-        version: 2.0.1
       '@radix-ui/react-dropdown-menu':
         specifier: ^2.1.15
         version: 2.1.15(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -47,6 +44,9 @@ importers:
       '@radix-ui/react-tooltip':
         specifier: ^1.2.7
         version: 1.2.7(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-nano/use-event-source':
+        specifier: ^0.16.0
+        version: 0.16.0(react@18.3.1)
       '@sentry/react':
         specifier: ^9.34.0
         version: 9.34.0(react@18.3.1)
@@ -626,9 +626,6 @@ packages:
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
 
-  '@microsoft/fetch-event-source@2.0.1':
-    resolution: {integrity: sha512-W6CLUJ2eBMw3Rec70qrsEW0jOm/3twwJv21mrmj2yORiaVmVYGS4sSS5yUwvQc1ZlDLYGPnClVWmUUMagKNsfA==}
-
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -991,6 +988,11 @@ packages:
 
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
+
+  '@react-nano/use-event-source@0.16.0':
+    resolution: {integrity: sha512-XiflYfULRrUjWS1s1gGFBIbdsU56RVIbFT/9KnZwydlnUzQiRm6SVMHZI83g0fXnZpmS3Xh09WFZAfK7l36NGA==}
+    peerDependencies:
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
 
   '@remix-run/router@1.23.0':
     resolution: {integrity: sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==}
@@ -3101,8 +3103,6 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
 
-  '@microsoft/fetch-event-source@2.0.1': {}
-
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -3443,6 +3443,10 @@ snapshots:
       '@types/react-dom': 18.3.7(@types/react@18.3.23)
 
   '@radix-ui/rect@1.1.1': {}
+
+  '@react-nano/use-event-source@0.16.0(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
 
   '@remix-run/router@1.23.0': {}
 


### PR DESCRIPTION
I've successfully replaced `@microsoft/fetch-event-source` with `@react-nano/use-event-source` in the NormalizedConversationViewer component. Here's what was accomplished:

**Changes made:**
1. **Replaced dependencies**: Removed `@microsoft/fetch-event-source` and installed `@react-nano/use-event-source`
2. **Simplified SSE implementation**: Replaced the complex manual SSE connection management with the `useEventSource` hook
3. **Reduced boilerplate**: Eliminated ~200 lines of connection management code including:
   - Manual AbortController management
   - Complex reconnection logic with exponential backoff
   - Error handling and cleanup functions
   - SSE connection lifecycle management

**Key improvements:**
- **Cleaner code**: The new implementation is much more declarative and easier to understand
- **Better React integration**: Uses hooks that handle SSE connection lifecycle automatically
- **Maintained functionality**: All existing features including batch ID tracking, duplicate prevention, and error handling are preserved
- **Type safety**: Fixed TypeScript errors and improved type annotations

**Code reduction:**
- Eliminated ~200 lines of boilerplate connection management code
- Simplified from multiple useEffect hooks and complex ref management to just 2 hooks
- Automatic connection cleanup and reconnection handled by the library

The component now uses the modern `@react-nano/use-event-source` library which provides a much cleaner API while maintaining all the original functionality for SSE streaming of conversation logs.