### PR TITLE
fix: distinguish between stopped and failed task attempts

### DIFF
--- a/backend/src/models/task_attempt.rs
+++ b/backend/src/models/task_attempt.rs
@@ -181,9 +181,11 @@ pub enum ExecutionState {
     SetupRunning,
     SetupComplete,
     SetupFailed,
+    SetupStopped,
     CodingAgentRunning,
     CodingAgentComplete,
     CodingAgentFailed,
+    CodingAgentStopped,
     Complete,
 }
 
@@ -1042,7 +1044,7 @@ impl TaskAttempt {
                                 ExecutionState::CodingAgentFailed
                             }
                             crate::models::execution_process::ExecutionProcessStatus::Killed => {
-                                ExecutionState::CodingAgentFailed
+                                ExecutionState::CodingAgentStopped
                             }
                         }
                     } else {
@@ -1053,7 +1055,7 @@ impl TaskAttempt {
                     ExecutionState::SetupFailed
                 }
                 crate::models::execution_process::ExecutionProcessStatus::Killed => {
-                    ExecutionState::SetupFailed
+                    ExecutionState::SetupStopped
                 }
             }
         } else if let Some(agent) = coding_agent_process {
@@ -1069,7 +1071,7 @@ impl TaskAttempt {
                     ExecutionState::CodingAgentFailed
                 }
                 crate::models::execution_process::ExecutionProcessStatus::Killed => {
-                    ExecutionState::CodingAgentFailed
+                    ExecutionState::CodingAgentStopped
                 }
             }
         } else {

--- a/frontend/src/components/tasks/TaskDetails/LogsTab.tsx
+++ b/frontend/src/components/tasks/TaskDetails/LogsTab.tsx
@@ -76,8 +76,8 @@ function LogsTab() {
     );
   }
 
-  // When setup failed, show error message and conversation
-  if (isSetupFailed) {
+  // When setup failed or was stopped
+  if (isSetupFailed || isSetupStopped) {
     const setupProcess = executionState.setup_process_id
       ? attemptData.runningProcessDetails[executionState.setup_process_id]
       : Object.values(attemptData.runningProcessDetails).find(
@@ -87,12 +87,16 @@ function LogsTab() {
     return (
       <div className="h-full overflow-y-auto">
         <div className="mb-4">
-          <p className="text-lg font-semibold mb-2 text-destructive">
-            Setup Script Failed
+          <p
+            className={`text-lg font-semibold mb-2 ${isSetupFailed ? 'text-destructive' : ''}`}
+          >
+            {isSetupFailed ? 'Setup Script Failed' : 'Setup Script Stopped'}
           </p>
-          <p className="text-muted-foreground mb-4">
-            The setup script encountered an error. Error details below:
-          </p>
+          {isSetupFailed && (
+            <p className="text-muted-foreground mb-4">
+              The setup script encountered an error. Error details below:
+            </p>
+          )}
         </div>
 
         {setupProcess && (
@@ -102,29 +106,8 @@ function LogsTab() {
     );
   }
 
-  // When setup was stopped by user, show stopped message
-  if (isSetupStopped) {
-    const setupProcess = executionState.setup_process_id
-      ? attemptData.runningProcessDetails[executionState.setup_process_id]
-      : Object.values(attemptData.runningProcessDetails).find(
-          (process) => process.process_type === 'setupscript'
-        );
-
-    return (
-      <div className="h-full overflow-y-auto">
-        <div className="mb-4">
-          <p className="text-lg font-semibold mb-2">Setup Script Stopped</p>
-        </div>
-
-        {setupProcess && (
-          <NormalizedConversationViewer executionProcess={setupProcess} />
-        )}
-      </div>
-    );
-  }
-
-  // When coding agent failed, show error message and conversation
-  if (isCodingAgentFailed) {
+  // When coding agent failed or was stopped
+  if (isCodingAgentFailed || isCodingAgentStopped) {
     const codingAgentProcess = executionState.coding_agent_process_id
       ? attemptData.runningProcessDetails[
           executionState.coding_agent_process_id
@@ -136,35 +119,18 @@ function LogsTab() {
     return (
       <div className="h-full overflow-y-auto">
         <div className="mb-4">
-          <p className="text-lg font-semibold mb-2 text-destructive">
-            Coding Agent Failed
+          <p
+            className={`text-lg font-semibold mb-2 ${isCodingAgentFailed ? 'text-destructive' : ''}`}
+          >
+            {isCodingAgentFailed
+              ? 'Coding Agent Failed'
+              : 'Coding Agent Stopped'}
           </p>
-          <p className="text-muted-foreground mb-4">
-            The coding agent encountered an error. Error details below:
-          </p>
-        </div>
-
-        {codingAgentProcess && (
-          <NormalizedConversationViewer executionProcess={codingAgentProcess} />
-        )}
-      </div>
-    );
-  }
-
-  // When coding agent was stopped by user, show stopped message
-  if (isCodingAgentStopped) {
-    const codingAgentProcess = executionState.coding_agent_process_id
-      ? attemptData.runningProcessDetails[
-          executionState.coding_agent_process_id
-        ]
-      : Object.values(attemptData.runningProcessDetails).find(
-          (process) => process.process_type === 'codingagent'
-        );
-
-    return (
-      <div className="h-full overflow-y-auto">
-        <div className="mb-4">
-          <p className="text-lg font-semibold mb-2">Coding Agent Stopped</p>
+          {isCodingAgentFailed && (
+            <p className="text-muted-foreground mb-4">
+              The coding agent encountered an error. Error details below:
+            </p>
+          )}
         </div>
 
         {codingAgentProcess && (

--- a/frontend/src/components/tasks/TaskDetails/LogsTab.tsx
+++ b/frontend/src/components/tasks/TaskDetails/LogsTab.tsx
@@ -54,12 +54,15 @@ function LogsTab() {
   const isSetupRunning = executionState.execution_state === 'SetupRunning';
   const isSetupComplete = executionState.execution_state === 'SetupComplete';
   const isSetupFailed = executionState.execution_state === 'SetupFailed';
+  const isSetupStopped = executionState.execution_state === 'SetupStopped';
   const isCodingAgentRunning =
     executionState.execution_state === 'CodingAgentRunning';
   const isCodingAgentComplete =
     executionState.execution_state === 'CodingAgentComplete';
   const isCodingAgentFailed =
     executionState.execution_state === 'CodingAgentFailed';
+  const isCodingAgentStopped =
+    executionState.execution_state === 'CodingAgentStopped';
   const isComplete = executionState.execution_state === 'Complete';
   const hasChanges = executionState.has_changes;
 
@@ -99,6 +102,27 @@ function LogsTab() {
     );
   }
 
+  // When setup was stopped by user, show stopped message
+  if (isSetupStopped) {
+    const setupProcess = executionState.setup_process_id
+      ? attemptData.runningProcessDetails[executionState.setup_process_id]
+      : Object.values(attemptData.runningProcessDetails).find(
+          (process) => process.process_type === 'setupscript'
+        );
+
+    return (
+      <div className="h-full overflow-y-auto">
+        <div className="mb-4">
+          <p className="text-lg font-semibold mb-2">Setup Script Stopped</p>
+        </div>
+
+        {setupProcess && (
+          <NormalizedConversationViewer executionProcess={setupProcess} />
+        )}
+      </div>
+    );
+  }
+
   // When coding agent failed, show error message and conversation
   if (isCodingAgentFailed) {
     const codingAgentProcess = executionState.coding_agent_process_id
@@ -127,12 +151,36 @@ function LogsTab() {
     );
   }
 
+  // When coding agent was stopped by user, show stopped message
+  if (isCodingAgentStopped) {
+    const codingAgentProcess = executionState.coding_agent_process_id
+      ? attemptData.runningProcessDetails[
+          executionState.coding_agent_process_id
+        ]
+      : Object.values(attemptData.runningProcessDetails).find(
+          (process) => process.process_type === 'codingagent'
+        );
+
+    return (
+      <div className="h-full overflow-y-auto">
+        <div className="mb-4">
+          <p className="text-lg font-semibold mb-2">Coding Agent Stopped</p>
+        </div>
+
+        {codingAgentProcess && (
+          <NormalizedConversationViewer executionProcess={codingAgentProcess} />
+        )}
+      </div>
+    );
+  }
+
   // When setup is complete but coding agent hasn't started, show waiting state
   if (
     isSetupComplete &&
     !isCodingAgentRunning &&
     !isCodingAgentComplete &&
     !isCodingAgentFailed &&
+    !isCodingAgentStopped &&
     !hasChanges
   ) {
     return (

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -92,7 +92,7 @@ export type WorktreeDiff = { files: Array<FileDiff>, };
 
 export type BranchStatus = { is_behind: boolean, commits_behind: number, commits_ahead: number, up_to_date: boolean, merged: boolean, has_uncommitted_changes: boolean, base_branch_name: string, };
 
-export type ExecutionState = "NotStarted" | "SetupRunning" | "SetupComplete" | "SetupFailed" | "CodingAgentRunning" | "CodingAgentComplete" | "CodingAgentFailed" | "Complete";
+export type ExecutionState = "NotStarted" | "SetupRunning" | "SetupComplete" | "SetupFailed" | "SetupStopped" | "CodingAgentRunning" | "CodingAgentComplete" | "CodingAgentFailed" | "CodingAgentStopped" | "Complete";
 
 export type TaskAttemptState = { execution_state: ExecutionState, has_changes: boolean, has_setup_script: boolean, setup_process_id: string | null, coding_agent_process_id: string | null, };
 


### PR DESCRIPTION
- Display different messages depending on whether a `TaskAttempt` errored or was stopped.