### PR TITLE
Error messages not showing in toolbar (vibe-kanban)

### DIFF
--- a/frontend/src/components/tasks/Toolbar/CurrentAttempt.tsx
+++ b/frontend/src/components/tasks/Toolbar/CurrentAttempt.tsx
@@ -347,7 +347,8 @@ function CurrentAttempt({
       // Refresh branch status after rebase
       fetchBranchStatus();
     } catch (err) {
-      setError('Failed to rebase branch');
+      // @ts-expect-error it is type ApiError
+      setError(err.message || 'Failed to rebase branch');
     } finally {
       setRebasing(false);
     }
@@ -368,7 +369,8 @@ function CurrentAttempt({
       fetchBranchStatus();
       setShowRebaseDialog(false);
     } catch (err) {
-      setError('Failed to rebase branch');
+      // @ts-expect-error it is type ApiError
+      setError(err.message || 'Failed to rebase branch');
     } finally {
       setRebasing(false);
     }


### PR DESCRIPTION
When I try to perform an action, for example rebase, if it fails it just says "failed to rebase branch" in the UI, but in the API logs I can see 

{
    "success": false,
    "data": null,
    "message": "Git service error: Merge conflicts: Rebase failed due to conflicts. Please resolve conflicts manually."
}

- First the response should not be success
- Second, this should be displayed to the user rather than the unhelpful generic message