### PR TITLE
Prevent response being created by non-generators (vibe-kanban)

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -42,11 +42,7 @@ use services::PrMonitorService;
 async fn echo_handler(
     Json(payload): Json<serde_json::Value>,
 ) -> ResponseJson<ApiResponse<serde_json::Value>> {
-    ResponseJson(ApiResponse {
-        success: true,
-        data: Some(payload),
-        message: Some("Echo successful".to_string()),
-    })
+    ResponseJson(ApiResponse::success(payload))
 }
 
 async fn static_handler(uri: axum::extract::Path<String>) -> impl IntoResponse {

--- a/backend/src/models/api_response.rs
+++ b/backend/src/models/api_response.rs
@@ -1,28 +1,35 @@
-use serde::Serialize;
-use ts_rs::TS;
+mod response {
+    use serde::Serialize;
+    use ts_rs::TS;
 
-#[derive(Debug, Serialize, TS)]
-#[ts(export)]
-pub struct ApiResponse<T> {
-    pub success: bool,
-    pub data: Option<T>,
-    pub message: Option<String>,
-}
-
-impl<T> ApiResponse<T> {
-    pub fn success(data: T) -> Self {
-        Self {
-            success: true,
-            data: Some(data),
-            message: None,
-        }
+    #[derive(Debug, Serialize, TS)]
+    #[ts(export)]
+    pub struct ApiResponse<T> {
+        success: bool,
+        data: Option<T>,
+        message: Option<String>,
     }
 
-    pub fn error(message: &str) -> Self {
-        Self {
-            success: false,
-            data: None,
-            message: Some(message.to_string()),
+    impl<T> ApiResponse<T> {
+        /// Creates a successful response, with `data` and no message.
+        pub fn success(data: T) -> Self {
+            ApiResponse {
+                success: true,
+                data: Some(data),
+                message: None,
+            }
+        }
+
+        /// Creates an error response, with `message` and no data.
+        pub fn error(message: &str) -> Self {
+            ApiResponse {
+                success: false,
+                data: None,
+                message: Some(message.to_string()),
+            }
         }
     }
 }
+
+// Re-export the type, but its fields remain private
+pub use response::ApiResponse;

--- a/backend/src/routes/auth.rs
+++ b/backend/src/routes/auth.rs
@@ -49,21 +49,13 @@ async fn device_start() -> ResponseJson<ApiResponse<DeviceStartResponse>> {
     let res = match res {
         Ok(r) => r,
         Err(e) => {
-            return ResponseJson(ApiResponse {
-                success: false,
-                data: None,
-                message: Some(format!("Failed to contact GitHub: {e}")),
-            });
+            return ResponseJson(ApiResponse::error(&format!("Failed to contact GitHub: {e}")));
         }
     };
     let json: serde_json::Value = match res.json().await {
         Ok(j) => j,
         Err(e) => {
-            return ResponseJson(ApiResponse {
-                success: false,
-                data: None,
-                message: Some(format!("Failed to parse GitHub response: {e}")),
-            });
+            return ResponseJson(ApiResponse::error(&format!("Failed to parse GitHub response: {e}")));
         }
     };
     if let (
@@ -79,23 +71,15 @@ async fn device_start() -> ResponseJson<ApiResponse<DeviceStartResponse>> {
         json.get("expires_in").and_then(|v| v.as_u64()),
         json.get("interval").and_then(|v| v.as_u64()),
     ) {
-        ResponseJson(ApiResponse {
-            success: true,
-            data: Some(DeviceStartResponse {
-                device_code: device_code.to_string(),
-                user_code: user_code.to_string(),
-                verification_uri: verification_uri.to_string(),
-                expires_in: expires_in.try_into().unwrap_or(600),
-                interval: interval.try_into().unwrap_or(5),
-            }),
-            message: None,
-        })
+        ResponseJson(ApiResponse::success(DeviceStartResponse {
+            device_code: device_code.to_string(),
+            user_code: user_code.to_string(),
+            verification_uri: verification_uri.to_string(),
+            expires_in: expires_in.try_into().unwrap_or(600),
+            interval: interval.try_into().unwrap_or(5),
+        }))
     } else {
-        ResponseJson(ApiResponse {
-            success: false,
-            data: None,
-            message: Some(format!("GitHub error: {}", json)),
-        })
+        ResponseJson(ApiResponse::error(&format!("GitHub error: {}", json)))
     }
 }
 
@@ -121,30 +105,18 @@ async fn device_poll(
     let res = match res {
         Ok(r) => r,
         Err(e) => {
-            return ResponseJson(ApiResponse {
-                success: false,
-                data: None,
-                message: Some(format!("Failed to contact GitHub: {e}")),
-            });
+            return ResponseJson(ApiResponse::error(&format!("Failed to contact GitHub: {e}")));
         }
     };
     let json: serde_json::Value = match res.json().await {
         Ok(j) => j,
         Err(e) => {
-            return ResponseJson(ApiResponse {
-                success: false,
-                data: None,
-                message: Some(format!("Failed to parse GitHub response: {e}")),
-            });
+            return ResponseJson(ApiResponse::error(&format!("Failed to parse GitHub response: {e}")));
         }
     };
     if let Some(error) = json.get("error").and_then(|v| v.as_str()) {
         // Not authorized yet, or other error
-        return ResponseJson(ApiResponse {
-            success: false,
-            data: None,
-            message: Some(error.to_string()),
-        });
+        return ResponseJson(ApiResponse::error(error));
     }
     let access_token = json.get("access_token").and_then(|v| v.as_str());
     if let Some(access_token) = access_token {
@@ -159,19 +131,11 @@ async fn device_poll(
             Ok(res) => match res.json().await {
                 Ok(json) => json,
                 Err(e) => {
-                    return ResponseJson(ApiResponse {
-                        success: false,
-                        data: None,
-                        message: Some(format!("Failed to parse GitHub user response: {e}")),
-                    });
+                    return ResponseJson(ApiResponse::error(&format!("Failed to parse GitHub user response: {e}")));
                 }
             },
             Err(e) => {
-                return ResponseJson(ApiResponse {
-                    success: false,
-                    data: None,
-                    message: Some(format!("Failed to fetch user info: {e}")),
-                });
+                return ResponseJson(ApiResponse::error(&format!("Failed to fetch user info: {e}")));
             }
         };
         let username = user_json
@@ -189,19 +153,11 @@ async fn device_poll(
             Ok(res) => match res.json().await {
                 Ok(json) => json,
                 Err(e) => {
-                    return ResponseJson(ApiResponse {
-                        success: false,
-                        data: None,
-                        message: Some(format!("Failed to parse GitHub emails response: {e}")),
-                    });
+                    return ResponseJson(ApiResponse::error(&format!("Failed to parse GitHub emails response: {e}")));
                 }
             },
             Err(e) => {
-                return ResponseJson(ApiResponse {
-                    success: false,
-                    data: None,
-                    message: Some(format!("Failed to fetch user emails: {e}")),
-                });
+                return ResponseJson(ApiResponse::error(&format!("Failed to fetch user emails: {e}")));
             }
         };
         let primary_email = emails_json
@@ -226,11 +182,7 @@ async fn device_poll(
             config.github_login_acknowledged = true; // Also acknowledge the GitHub login step
             let config_path = crate::utils::config_path();
             if config.save(&config_path).is_err() {
-                return ResponseJson(ApiResponse {
-                    success: false,
-                    data: None,
-                    message: Some("Failed to save config".to_string()),
-                });
+                return ResponseJson(ApiResponse::error("Failed to save config"));
             }
         }
         app_state.update_sentry_scope().await;
@@ -255,17 +207,9 @@ async fn device_poll(
                 .await;
         }
 
-        ResponseJson(ApiResponse {
-            success: true,
-            data: Some("GitHub login successful".to_string()),
-            message: None,
-        })
+        ResponseJson(ApiResponse::success("GitHub login successful".to_string()))
     } else {
-        ResponseJson(ApiResponse {
-            success: false,
-            data: None,
-            message: Some("No access token yet".to_string()),
-        })
+        ResponseJson(ApiResponse::error("No access token yet"))
     }
 }
 
@@ -283,23 +227,11 @@ async fn github_check_token(State(app_state): State<AppState>) -> ResponseJson<A
             .send()
             .await;
         match res {
-            Ok(r) if r.status().is_success() => ResponseJson(ApiResponse {
-                success: true,
-                data: None,
-                message: Some("GitHub token is valid".to_string()),
-            }),
-            _ => ResponseJson(ApiResponse {
-                success: false,
-                data: None,
-                message: Some("github_token_invalid".to_string()),
-            }),
+            Ok(r) if r.status().is_success() => ResponseJson(ApiResponse::success(())),
+            _ => ResponseJson(ApiResponse::error("github_token_invalid")),
         }
     } else {
-        ResponseJson(ApiResponse {
-            success: false,
-            data: None,
-            message: Some("github_token_invalid".to_string()),
-        })
+        ResponseJson(ApiResponse::error("github_token_invalid"))
     }
 }
 

--- a/backend/src/routes/config.rs
+++ b/backend/src/routes/config.rs
@@ -32,11 +32,7 @@ pub fn config_router() -> Router<AppState> {
 
 async fn get_config(State(app_state): State<AppState>) -> ResponseJson<ApiResponse<Config>> {
     let config = app_state.get_config().read().await;
-    ResponseJson(ApiResponse {
-        success: true,
-        data: Some(config.clone()),
-        message: Some("Config retrieved successfully".to_string()),
-    })
+    ResponseJson(ApiResponse::success(config.clone()))
 }
 
 async fn update_config(
@@ -55,17 +51,9 @@ async fn update_config(
                 .update_analytics_config(new_config.analytics_enabled.unwrap_or(true))
                 .await;
 
-            ResponseJson(ApiResponse {
-                success: true,
-                data: Some(new_config),
-                message: Some("Config updated successfully".to_string()),
-            })
+            ResponseJson(ApiResponse::success(new_config))
         }
-        Err(e) => ResponseJson(ApiResponse {
-            success: false,
-            data: None,
-            message: Some(format!("Failed to save config: {}", e)),
-        }),
+        Err(e) => ResponseJson(ApiResponse::error(&format!("Failed to save config: {}", e))),
     }
 }
 
@@ -82,11 +70,7 @@ async fn get_config_constants() -> ResponseJson<ApiResponse<ConfigConstants>> {
         sound: SoundConstants::new(),
     };
 
-    ResponseJson(ApiResponse {
-        success: true,
-        data: Some(constants),
-        message: Some("Config constants retrieved successfully".to_string()),
-    })
+    ResponseJson(ApiResponse::success(constants))
 }
 
 #[derive(Debug, Deserialize)]
@@ -128,11 +112,7 @@ async fn get_mcp_servers(
     let executor_config = match resolve_executor_config(query.executor, &saved_config) {
         Ok(config) => config,
         Err(message) => {
-            return ResponseJson(ApiResponse {
-                success: false,
-                data: None,
-                message: Some(message),
-            });
+            return ResponseJson(ApiResponse::error(&message));
         }
     };
 
@@ -140,11 +120,7 @@ async fn get_mcp_servers(
     let config_path = match executor_config.config_path() {
         Some(path) => path,
         None => {
-            return ResponseJson(ApiResponse {
-                success: false,
-                data: None,
-                message: Some("Could not determine config file path".to_string()),
-            });
+            return ResponseJson(ApiResponse::error("Could not determine config file path"));
         }
     };
 
@@ -154,17 +130,9 @@ async fn get_mcp_servers(
                 "servers": servers,
                 "config_path": config_path.to_string_lossy().to_string()
             });
-            ResponseJson(ApiResponse {
-                success: true,
-                data: Some(response_data),
-                message: Some("MCP servers retrieved successfully".to_string()),
-            })
+            ResponseJson(ApiResponse::success(response_data))
         }
-        Err(e) => ResponseJson(ApiResponse {
-            success: false,
-            data: None,
-            message: Some(format!("Failed to read MCP servers: {}", e)),
-        }),
+        Err(e) => ResponseJson(ApiResponse::error(&format!("Failed to read MCP servers: {}", e))),
     }
 }
 
@@ -181,11 +149,7 @@ async fn update_mcp_servers(
     let executor_config = match resolve_executor_config(query.executor, &saved_config) {
         Ok(config) => config,
         Err(message) => {
-            return ResponseJson(ApiResponse {
-                success: false,
-                data: None,
-                message: Some(message),
-            });
+            return ResponseJson(ApiResponse::error(&message));
         }
     };
 
@@ -193,25 +157,13 @@ async fn update_mcp_servers(
     let config_path = match executor_config.config_path() {
         Some(path) => path,
         None => {
-            return ResponseJson(ApiResponse {
-                success: false,
-                data: None,
-                message: Some("Could not determine config file path".to_string()),
-            });
+            return ResponseJson(ApiResponse::error("Could not determine config file path"));
         }
     };
 
     match update_mcp_servers_in_config(&config_path, &executor_config, new_servers).await {
-        Ok(message) => ResponseJson(ApiResponse {
-            success: true,
-            data: Some(message.clone()),
-            message: Some(message),
-        }),
-        Err(e) => ResponseJson(ApiResponse {
-            success: false,
-            data: None,
-            message: Some(format!("Failed to update MCP servers: {}", e)),
-        }),
+        Ok(message) => ResponseJson(ApiResponse::success(message)),
+        Err(e) => ResponseJson(ApiResponse::error(&format!("Failed to update MCP servers: {}", e))),
     }
 }
 

--- a/backend/src/routes/filesystem.rs
+++ b/backend/src/routes/filesystem.rs
@@ -56,19 +56,11 @@ pub async fn list_directory(
     let path = Path::new(&path_str);
 
     if !path.exists() {
-        return Ok(ResponseJson(ApiResponse {
-            success: false,
-            data: None,
-            message: Some("Directory does not exist".to_string()),
-        }));
+        return Ok(ResponseJson(ApiResponse::error("Directory does not exist")));
     }
 
     if !path.is_dir() {
-        return Ok(ResponseJson(ApiResponse {
-            success: false,
-            data: None,
-            message: Some("Path is not a directory".to_string()),
-        }));
+        return Ok(ResponseJson(ApiResponse::error("Path is not a directory")));
     }
 
     match fs::read_dir(path) {
@@ -108,22 +100,14 @@ pub async fn list_directory(
                 _ => a.name.to_lowercase().cmp(&b.name.to_lowercase()),
             });
 
-            Ok(ResponseJson(ApiResponse {
-                success: true,
-                data: Some(DirectoryListResponse {
-                    entries: directory_entries,
-                    current_path: path.to_string_lossy().to_string(),
-                }),
-                message: None,
-            }))
+            Ok(ResponseJson(ApiResponse::success(DirectoryListResponse {
+                entries: directory_entries,
+                current_path: path.to_string_lossy().to_string(),
+            })))
         }
         Err(e) => {
             tracing::error!("Failed to read directory: {}", e);
-            Ok(ResponseJson(ApiResponse {
-                success: false,
-                data: None,
-                message: Some(format!("Failed to read directory: {}", e)),
-            }))
+            Ok(ResponseJson(ApiResponse::error(&format!("Failed to read directory: {}", e))))
         }
     }
 }
@@ -137,15 +121,7 @@ pub async fn validate_git_path(
     // Check if path exists and is a git repo
     let is_valid_git_repo = path.exists() && path.is_dir() && path.join(".git").exists();
 
-    Ok(ResponseJson(ApiResponse {
-        success: true,
-        data: Some(is_valid_git_repo),
-        message: if is_valid_git_repo {
-            Some("Valid git repository".to_string())
-        } else {
-            Some("Not a valid git repository".to_string())
-        },
-    }))
+    Ok(ResponseJson(ApiResponse::success(is_valid_git_repo)))
 }
 
 pub async fn create_git_repo(
@@ -158,21 +134,13 @@ pub async fn create_git_repo(
     if !path.exists() {
         if let Err(e) = fs::create_dir_all(path) {
             tracing::error!("Failed to create directory: {}", e);
-            return Ok(ResponseJson(ApiResponse {
-                success: false,
-                data: None,
-                message: Some(format!("Failed to create directory: {}", e)),
-            }));
+            return Ok(ResponseJson(ApiResponse::error(&format!("Failed to create directory: {}", e))));
         }
     }
 
     // Check if it's already a git repo
     if path.join(".git").exists() {
-        return Ok(ResponseJson(ApiResponse {
-            success: true,
-            data: Some(()),
-            message: Some("Directory is already a git repository".to_string()),
-        }));
+        return Ok(ResponseJson(ApiResponse::success(())));
     }
 
     // Initialize git repository
@@ -183,28 +151,16 @@ pub async fn create_git_repo(
     {
         Ok(output) => {
             if output.status.success() {
-                Ok(ResponseJson(ApiResponse {
-                    success: true,
-                    data: Some(()),
-                    message: Some("Git repository initialized successfully".to_string()),
-                }))
+                Ok(ResponseJson(ApiResponse::success(())))
             } else {
                 let error_msg = String::from_utf8_lossy(&output.stderr);
                 tracing::error!("Git init failed: {}", error_msg);
-                Ok(ResponseJson(ApiResponse {
-                    success: false,
-                    data: None,
-                    message: Some(format!("Git init failed: {}", error_msg)),
-                }))
+                Ok(ResponseJson(ApiResponse::error(&format!("Git init failed: {}", error_msg))))
             }
         }
         Err(e) => {
             tracing::error!("Failed to run git init: {}", e);
-            Ok(ResponseJson(ApiResponse {
-                success: false,
-                data: None,
-                message: Some(format!("Failed to run git init: {}", e)),
-            }))
+            Ok(ResponseJson(ApiResponse::error(&format!("Failed to run git init: {}", e))))
         }
     }
 }

--- a/backend/src/routes/health.rs
+++ b/backend/src/routes/health.rs
@@ -3,9 +3,5 @@ use axum::response::Json;
 use crate::models::ApiResponse;
 
 pub async fn health_check() -> Json<ApiResponse<String>> {
-    Json(ApiResponse {
-        success: true,
-        data: Some("OK".to_string()),
-        message: Some("Service is healthy".to_string()),
-    })
+    Json(ApiResponse::success("OK".to_string()))
 }

--- a/backend/src/routes/tasks.rs
+++ b/backend/src/routes/tasks.rs
@@ -20,11 +20,7 @@ pub async fn get_project_tasks(
     State(app_state): State<AppState>,
 ) -> Result<ResponseJson<ApiResponse<Vec<TaskWithAttemptStatus>>>, StatusCode> {
     match Task::find_by_project_id_with_attempt_status(&app_state.db_pool, project.id).await {
-        Ok(tasks) => Ok(ResponseJson(ApiResponse {
-            success: true,
-            data: Some(tasks),
-            message: None,
-        })),
+        Ok(tasks) => Ok(ResponseJson(ApiResponse::success(tasks))),
         Err(e) => {
             tracing::error!("Failed to fetch tasks for project {}: {}", project.id, e);
             Err(StatusCode::INTERNAL_SERVER_ERROR)
@@ -35,11 +31,7 @@ pub async fn get_project_tasks(
 pub async fn get_task(
     Extension(task): Extension<Task>,
 ) -> Result<ResponseJson<ApiResponse<Task>>, StatusCode> {
-    Ok(ResponseJson(ApiResponse {
-        success: true,
-        data: Some(task),
-        message: None,
-    }))
+    Ok(ResponseJson(ApiResponse::success(task)))
 }
 
 pub async fn create_task(
@@ -72,11 +64,7 @@ pub async fn create_task(
                 )
                 .await;
 
-            Ok(ResponseJson(ApiResponse {
-                success: true,
-                data: Some(task),
-                message: Some("Task created successfully".to_string()),
-            }))
+            Ok(ResponseJson(ApiResponse::success(task)))
         }
         Err(e) => {
             tracing::error!("Failed to create task: {}", e);
@@ -168,11 +156,7 @@ pub async fn create_task_and_start(
                 }
             });
 
-            Ok(ResponseJson(ApiResponse {
-                success: true,
-                data: Some(task),
-                message: Some("Task created and started successfully".to_string()),
-            }))
+            Ok(ResponseJson(ApiResponse::success(task)))
         }
         Err(e) => {
             tracing::error!("Failed to create task attempt: {}", e);
@@ -206,11 +190,7 @@ pub async fn update_task(
     )
     .await
     {
-        Ok(task) => Ok(ResponseJson(ApiResponse {
-            success: true,
-            data: Some(task),
-            message: Some("Task updated successfully".to_string()),
-        })),
+        Ok(task) => Ok(ResponseJson(ApiResponse::success(task))),
         Err(e) => {
             tracing::error!("Failed to update task: {}", e);
             Err(StatusCode::INTERNAL_SERVER_ERROR)
@@ -265,11 +245,7 @@ pub async fn delete_task(
             if rows_affected == 0 {
                 Err(StatusCode::NOT_FOUND)
             } else {
-                Ok(ResponseJson(ApiResponse {
-                    success: true,
-                    data: None,
-                    message: Some("Task deleted successfully".to_string()),
-                }))
+                Ok(ResponseJson(ApiResponse::success(())))
             }
         }
         Err(e) => {


### PR DESCRIPTION
Currently API responses are created using the success and error generators, and also using manual creation of the ApiResponse struct.

Let's enforce using generators and refactor the code by updating backend/src/models/api_response.rs to:

```
mod response {
    use serde::Serialize;
    use ts_rs::TS;

    #[derive(Debug, Serialize, TS)]
    #[ts(export)]
    pub struct ApiResponse<T> {
        success: bool,
        data: Option<T>,
        message: Option<String>,
    }

    impl<T> ApiResponse<T> {
        /// Creates a successful response, with `data` and no message.
        pub fn success(data: T) -> Self {
            ApiResponse {
                success: true,
                data: Some(data),
                message: None,
            }
        }

        /// Creates an error response, with `message` and no data.
        pub fn error(message: &str) -> Self {
            ApiResponse {
                success: false,
                data: None,
                message: Some(message.to_string()),
            }
        }
    }
}

// Re-export the type, but its fields remain private
pub use response::ApiResponse;
```

Then we can check for cargo errors and refactor the code incrementally until all the patterns have been changed to the generators