### PR TITLE
Error messages not showing in toolbar (vibe-kanban)

### DIFF
--- a/backend/src/services/git_service.rs
+++ b/backend/src/services/git_service.rs
@@ -287,7 +287,7 @@ impl GitService {
         Ok(())
     }
 
-    /// Perform a squash merge of task branch into base branch
+    /// Perform a squash merge of task branch into base branch, but fail on conflicts
     fn perform_squash_merge(
         &self,
         repo: &Repository,
@@ -297,14 +297,29 @@ impl GitService {
         commit_message: &str,
         base_branch_name: &str,
     ) -> Result<git2::Oid, GitServiceError> {
-        // Create a single commit that squashes all changes from task branch
+        // Attempt an in-memory merge to detect conflicts
+        let mut merge_opts = git2::MergeOptions::new();
+        let mut index = repo.merge_commits(base_commit, task_commit, Some(&mut merge_opts))?;
+
+        // If there are conflicts, return an error
+        if index.has_conflicts() {
+            return Err(GitServiceError::MergeConflicts(
+                "Merge failed due to conflicts. Please resolve conflicts manually.".to_string(),
+            ));
+        }
+
+        // Write the merged tree back to the repository
+        let tree_id = index.write_tree_to(repo)?;
+        let tree = repo.find_tree(tree_id)?;
+
+        // Create a squash commit: use merged tree with base_commit as sole parent
         let squash_commit_id = repo.commit(
-            None,                 // Don't update any reference yet
-            signature,            // Author
-            signature,            // Committer
-            commit_message,       // Custom message
-            &task_commit.tree()?, // Use the tree from task branch (all changes)
-            &[base_commit],       // Single parent: base branch commit
+            None,           // Don't update any reference yet
+            signature,      // Author
+            signature,      // Committer
+            commit_message, // Custom message
+            &tree,          // Merged tree content
+            &[base_commit], // Single parent: base branch commit
         )?;
 
         // Update the base branch reference to point to the new commit

--- a/backend/src/services/git_service.rs
+++ b/backend/src/services/git_service.rs
@@ -298,8 +298,8 @@ impl GitService {
         base_branch_name: &str,
     ) -> Result<git2::Oid, GitServiceError> {
         // Attempt an in-memory merge to detect conflicts
-        let mut merge_opts = git2::MergeOptions::new();
-        let mut index = repo.merge_commits(base_commit, task_commit, Some(&mut merge_opts))?;
+        let merge_opts = git2::MergeOptions::new();
+        let mut index = repo.merge_commits(base_commit, task_commit, Some(&merge_opts))?;
 
         // If there are conflicts, return an error
         if index.has_conflicts() {

--- a/frontend/src/components/tasks/Toolbar/CurrentAttempt.tsx
+++ b/frontend/src/components/tasks/Toolbar/CurrentAttempt.tsx
@@ -346,7 +346,7 @@ function CurrentAttempt({
       // Refresh branch status after rebase
       fetchBranchStatus();
     } catch (err) {
-      setError('Failed to rebase branch');
+      setError(err instanceof Error ? err.message : 'Failed to rebase branch');
     } finally {
       setRebasing(false);
     }
@@ -367,7 +367,7 @@ function CurrentAttempt({
       fetchBranchStatus();
       setShowRebaseDialog(false);
     } catch (err) {
-      setError('Failed to rebase branch');
+      setError(err instanceof Error ? err.message : 'Failed to rebase branch');
     } finally {
       setRebasing(false);
     }


### PR DESCRIPTION
When I try to perform an action, for example rebase, if it fails it just says "failed to rebase branch" in the UI, but in the API logs I can see 

{
    "success": false,
    "data": null,
    "message": "Git service error: Merge conflicts: Rebase failed due to conflicts. Please resolve conflicts manually."
}

- First the response should not be success
- Second, this should be displayed to the user rather than the unhelpful generic message