### PR TITLE
Adds SST OpenCode model selection for task execution

### DIFF
--- a/backend/src/executor.rs
+++ b/backend/src/executor.rs
@@ -441,6 +441,10 @@ impl FromStr for ExecutorConfig {
 
 impl ExecutorConfig {
     pub fn create_executor(&self) -> Box<dyn Executor> {
+        self.create_executor_with_model(None)
+    }
+
+    pub fn create_executor_with_model(&self, model: Option<String>) -> Box<dyn Executor> {
         match self {
             ExecutorConfig::Echo => Box::new(EchoExecutor),
             ExecutorConfig::Claude => Box::new(ClaudeExecutor::new()),
@@ -449,7 +453,7 @@ impl ExecutorConfig {
             ExecutorConfig::Gemini => Box::new(GeminiExecutor),
             ExecutorConfig::ClaudeCodeRouter => Box::new(CCRExecutor::new()),
             ExecutorConfig::CharmOpencode => Box::new(CharmOpencodeExecutor),
-            ExecutorConfig::SstOpencode => Box::new(SstOpencodeExecutor::new()),
+            ExecutorConfig::SstOpencode => Box::new(SstOpencodeExecutor::new_with_model(model)),
             ExecutorConfig::SetupScript { script } => {
                 Box::new(SetupScriptExecutor::new(script.clone()))
             }

--- a/backend/src/executors/sst_opencode.rs
+++ b/backend/src/executors/sst_opencode.rs
@@ -226,11 +226,20 @@ impl Default for SstOpencodeExecutor {
 }
 
 impl SstOpencodeExecutor {
-    /// Create a new SstOpencodeExecutor with default settings
+    /// Create a new SstOpencodeExecutor with optional model
     pub fn new() -> Self {
+        Self::new_with_model(None)
+    }
+
+    pub fn new_with_model(model: Option<String>) -> Self {
+        let mut command = "npx -y opencode-ai@latest run --print-logs".to_string();
+        if let Some(m) = model {
+            command.push_str(" --model ");
+            command.push_str(&m);
+        }
         Self {
             executor_type: "SST Opencode".to_string(),
-            command: "npx -y opencode-ai@latest run --print-logs".to_string(),
+            command,
         }
     }
 }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -35,7 +35,8 @@ use middleware::{
 };
 use models::{ApiResponse, Config};
 use routes::{
-    auth, config, filesystem, health, projects, stream, task_attempts, task_templates, tasks,
+    auth, config, filesystem, health, opencode, projects, stream, task_attempts, task_templates,
+    tasks,
 };
 use services::PrMonitorService;
 
@@ -197,6 +198,7 @@ fn main() -> anyhow::Result<()> {
             let base_routes = Router::new()
                 .merge(stream::stream_router())
                 .merge(filesystem::filesystem_router())
+                .merge(opencode::opencode_router())
                 .merge(config::config_router())
                 .merge(auth::auth_router())
                 .route("/sounds/:filename", get(serve_sound_file))

--- a/backend/src/routes/mod.rs
+++ b/backend/src/routes/mod.rs
@@ -7,3 +7,4 @@ pub mod stream;
 pub mod task_attempts;
 pub mod task_templates;
 pub mod tasks;
+pub mod opencode;

--- a/backend/src/routes/opencode.rs
+++ b/backend/src/routes/opencode.rs
@@ -1,0 +1,28 @@
+use axum::{routing::get, Json, Router};
+use tokio::process::Command;
+
+use crate::{app_state::AppState, models::ApiResponse};
+
+pub fn opencode_router() -> Router<AppState> {
+    Router::new().route("/opencode/models", get(get_models))
+}
+
+pub async fn get_models() -> Json<ApiResponse<Vec<String>>> {
+    let output = Command::new("opencode").arg("models").output().await;
+    match output {
+        Ok(out) if out.status.success() => {
+            let stdout = String::from_utf8_lossy(&out.stdout);
+            let models = stdout
+                .lines()
+                .map(|l| l.trim().to_string())
+                .filter(|l| !l.is_empty())
+                .collect();
+            Json(ApiResponse::success(models))
+        }
+        Ok(out) => {
+            let err = String::from_utf8_lossy(&out.stderr);
+            Json(ApiResponse::error(&format!("Failed to list models: {}", err)))
+        }
+        Err(e) => Json(ApiResponse::error(&format!("Failed to run opencode: {}", e))),
+    }
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -628,3 +628,10 @@ export const mcpServersApi = {
     }
   },
 };
+
+export const opencodeApi = {
+  getModels: async (): Promise<string[]> => {
+    const response = await makeRequest('/api/opencode/models');
+    return handleApiResponse<string[]>(response);
+  },
+};


### PR DESCRIPTION
When SST Opencode is the selected coding agent, all available models are listed (via `opencode models` command) and the user can select which one to use for the task when it starts (via `opencode --model provider/model-id` command).

Resolves #266 

I had put up another PR before but other updates caused merge conflicts; this is a new up-to-date PR