### PR TITLE
Update cleanup script copy (vibe-kanban)

### DIFF
--- a/frontend/src/components/projects/project-form-fields.tsx
+++ b/frontend/src/components/projects/project-form-fields.tsx
@@ -222,8 +222,8 @@ export function ProjectFormFields({
         />
         <p className="text-sm text-muted-foreground">
           This script will run after coding agent execution is complete. Use it
-          for cleanup tasks like stopping processes, clearing caches, or other
-          post-execution cleanup.
+          for quality assurance tasks like running linters, formatters, tests,
+          or other validation steps.
         </p>
       </div>
 


### PR DESCRIPTION
In the settings where you update cleanup script the copy currently reads:

This script will run after coding agent execution is complete. Use it for cleanup tasks like stopping processes, clearing caches, or other post-execution cleanup.

Please change this to have better examples like running linters, formatters and validations