### PR TITLE
Execute Plan: Stream more patches to the FE (vibe-kanban)

### DIFF
--- a/backend/src/routes/stream.rs
+++ b/backend/src/routes/stream.rs
@@ -69,6 +69,48 @@ pub async fn normalized_logs_stream(
         let since = query.since_batch_id.unwrap_or(1);
         let mut fallback_batch_id: u64 = since + 1;
 
+        // Fast catch-up phase for resumable streaming
+        if let Some(since_batch) = query.since_batch_id {
+            if !is_gemini {
+                // Load current process state to get all available entries
+                if let Ok(Some(proc)) = ExecutionProcess::find_by_id(&app_state.db_pool, process_id).await {
+                    if let Some(stdout) = &proc.stdout {
+                        // Create executor and normalize logs to get all entries
+                        if let Some(executor) = proc.executor_type
+                            .as_deref()
+                            .unwrap_or("unknown")
+                            .parse::<crate::executor::ExecutorConfig>()
+                            .ok()
+                            .map(|cfg| cfg.create_executor())
+                        {
+                            if let Ok(normalized) = executor.normalize_logs(stdout, &proc.working_directory) {
+                            // Send all entries after since_batch_id immediately
+                            let start_entry = since_batch as usize;
+                            let catch_up_entries = normalized.entries.get(start_entry..).unwrap_or(&[]);
+                            
+                            for (i, entry) in catch_up_entries.iter().enumerate() {
+                                let batch_data = BatchData {
+                                    batch_id: since_batch + 1 + i as u64,
+                                    patches: vec![serde_json::json!({
+                                        "op": "add",
+                                        "path": "/entries/-", 
+                                        "value": entry
+                                    })],
+                                };
+                                yield Ok(Event::default().event("patch").data(serde_json::to_string(&batch_data).unwrap_or_default()));
+                            }
+                            
+                                // Update cursors to current state
+                                last_entry_count = normalized.entries.len();
+                                fallback_batch_id = since_batch + 1 + catch_up_entries.len() as u64;
+                                last_len = stdout.len();
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
         loop {
             interval.tick().await;
 
@@ -156,10 +198,10 @@ pub async fn normalized_logs_stream(
                 }
 
                 // 5. Compute patches for any new entries
-                let new_entries = [&normalized.entries[last_entry_count - 1]];
-                if new_entries.is_empty() {
+                if last_entry_count >= normalized.entries.len() {
                     continue;
                 }
+                let new_entries = [&normalized.entries[last_entry_count]];
                 let patches: Vec<Value> = new_entries
                     .iter()
                     .map(|entry| serde_json::json!({

--- a/backend/src/routes/stream.rs
+++ b/backend/src/routes/stream.rs
@@ -87,19 +87,19 @@ pub async fn normalized_logs_stream(
                             // Send all entries after since_batch_id immediately
                             let start_entry = since_batch as usize;
                             let catch_up_entries = normalized.entries.get(start_entry..).unwrap_or(&[]);
-                            
+
                             for (i, entry) in catch_up_entries.iter().enumerate() {
                                 let batch_data = BatchData {
                                     batch_id: since_batch + 1 + i as u64,
                                     patches: vec![serde_json::json!({
                                         "op": "add",
-                                        "path": "/entries/-", 
+                                        "path": "/entries/-",
                                         "value": entry
                                     })],
                                 };
                                 yield Ok(Event::default().event("patch").data(serde_json::to_string(&batch_data).unwrap_or_default()));
                             }
-                            
+
                                 // Update cursors to current state
                                 last_entry_count = normalized.entries.len();
                                 fallback_batch_id = since_batch + 1 + catch_up_entries.len() as u64;


### PR DESCRIPTION
## Updated Plan: Fast Catch-Up for Resumable Streaming

### Core Problem
When a client reconnects with `since_batch_id`, non-Gemini executors must iterate through the polling loop **one entry at a time** to catch up to the current state. This is extremely slow for processes with many entries.

### Root Cause Analysis
**Lines 72-73**: The loop always calls `interval.tick().await` before processing, meaning:
- If there are 500 entries to catch up on, it takes 500 × poll_interval (50+ seconds at 100ms)
- Each iteration processes only 1 entry (`last_entry_count += 1` at line 182)
- No fast-path for historical data that already exists

### Solution: Add Pre-Loop Catch-Up Phase

**Key Insight**: Historical entries don't need polling - they already exist in the normalized logs.

**Implementation Strategy:**

1. **Before entering the polling loop**: If `since_batch_id` is provided, immediately process all existing entries
2. **Fast batch sending**: Send multiple historical batches without polling delays
3. **Seamless transition**: After catch-up, enter normal polling mode for new entries

### Specific Changes Required

**File:** `backend/src/routes/stream.rs`

**Add before line 72 (before the polling loop):**

```rust
// Fast catch-up phase for resumable streaming
if let Some(since_batch) = query.since_batch_id {
    // Load current process state to get all available entries
    if let Ok(Some(proc)) = ExecutionProcess::find_by_id(&app_state.db_pool, process_id).await {
        if let Some(stdout) = &proc.stdout {
            // Create executor and normalize logs to get all entries
            if let Ok(executor_config) = proc.executor_type.as_deref().unwrap_or("unknown").parse::<crate::executor::ExecutorConfig>() {
                if let Some(executor) = executor_config.create_executor() {
                    if let Ok(normalized) = executor.normalize_logs(stdout, &proc.working_directory) {
                        // Send all entries after since_batch_id immediately
                        let start_entry = (since_batch as usize).saturating_sub(1);
                        let catch_up_entries = &normalized.entries[start_entry..];
                        
                        for (i, entry) in catch_up_entries.iter().enumerate() {
                            let batch_data = BatchData {
                                batch_id: since_batch + i as u64,
                                patches: vec![serde_json::json!({
                                    "op": "add",
                                    "path": "/entries/-", 
                                    "value": entry
                                })],
                            };
                            yield Ok(Event::default().event("patch").data(serde_json::to_string(&batch_data).unwrap_or_default()));
                        }
                        
                        // Update cursors to current state
                        last_entry_count = normalized.entries.len();
                        fallback_batch_id = since_batch + catch_up_entries.len() as u64;
                    }
                }
            }
        }
    }
}
```

### Expected Performance Improvement
- **Before**: Resuming from batch 100 with 500 total entries = 400 × 100ms = 40 seconds
- **After**: Immediate catch-up of all 400 entries = ~100ms

This eliminates the polling bottleneck for historical data while maintaining real-time polling for new entries.