### PR TITLE
Execute Plan: Rebase onto different branch update (vibe-kanban)

### DIFF
--- a/backend/src/models/task_attempt.rs
+++ b/backend/src/models/task_attempt.rs
@@ -546,7 +546,11 @@ impl TaskAttempt {
         let worktree_path = Path::new(worktree_path);
 
         git_service
-            .rebase_branch(worktree_path, new_base_branch.as_deref(), old_base_branch.as_deref())
+            .rebase_branch(
+                worktree_path,
+                new_base_branch.as_deref(),
+                old_base_branch.as_deref(),
+            )
             .map_err(TaskAttemptError::from)
     }
 

--- a/backend/src/models/task_attempt.rs
+++ b/backend/src/models/task_attempt.rs
@@ -546,11 +546,7 @@ impl TaskAttempt {
         let worktree_path = Path::new(worktree_path);
 
         git_service
-            .rebase_branch(
-                worktree_path,
-                new_base_branch.as_deref(),
-                &old_base_branch,
-            )
+            .rebase_branch(worktree_path, new_base_branch.as_deref(), &old_base_branch)
             .map_err(TaskAttemptError::from)
     }
 

--- a/backend/src/models/task_attempt.rs
+++ b/backend/src/models/task_attempt.rs
@@ -540,12 +540,13 @@ impl TaskAttempt {
         worktree_path: &str,
         main_repo_path: &str,
         new_base_branch: Option<String>,
+        old_base_branch: Option<String>,
     ) -> Result<String, TaskAttemptError> {
         let git_service = GitService::new(main_repo_path)?;
         let worktree_path = Path::new(worktree_path);
 
         git_service
-            .rebase_branch(worktree_path, new_base_branch.as_deref())
+            .rebase_branch(worktree_path, new_base_branch.as_deref(), old_base_branch.as_deref())
             .map_err(TaskAttemptError::from)
     }
 
@@ -812,6 +813,14 @@ impl TaskAttempt {
         // Load context with full validation
         let ctx = TaskAttempt::load_context(pool, attempt_id, task_id, project_id).await?;
 
+        // Determine if we're rebasing to a different branch
+        let old_base_branch = if new_base_branch.is_some() {
+            // If rebasing to a different branch, pass the current base branch as old base
+            Some(ctx.task_attempt.base_branch.clone())
+        } else {
+            None
+        };
+
         // Use the stored base branch if no new base branch is provided
         let effective_base_branch =
             new_base_branch.or_else(|| Some(ctx.task_attempt.base_branch.clone()));
@@ -820,11 +829,11 @@ impl TaskAttempt {
         let worktree_path =
             Self::ensure_worktree_exists(pool, attempt_id, project_id, "rebase").await?;
 
-        // Perform the git rebase operations (synchronous)
         let new_base_commit = Self::perform_rebase_operation(
             &worktree_path,
             &ctx.project.git_repo_path,
             effective_base_branch.clone(),
+            old_base_branch,
         )?;
 
         // Update the database with the new base branch if it was changed

--- a/backend/src/services/git_service.rs
+++ b/backend/src/services/git_service.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use git2::{
-    build::CheckoutBuilder, BranchType, Cred, DiffOptions, Error as GitError, FetchOptions,
+    build::CheckoutBuilder, BranchType, CherrypickOptions, Cred, DiffOptions, Error as GitError, FetchOptions,
     RebaseOptions, RemoteCallbacks, Repository, WorktreeAddOptions,
 };
 use regex;
@@ -334,6 +334,7 @@ impl GitService {
         &self,
         worktree_path: &Path,
         new_base_branch: Option<&str>,
+        old_base_branch: Option<&str>,
     ) -> Result<String, GitServiceError> {
         let worktree_repo = Repository::open(worktree_path)?;
         let main_repo = self.open_repo()?;
@@ -403,47 +404,89 @@ impl GitService {
             .find_branch(local_branch_name, BranchType::Local)
             .map_err(|_| GitServiceError::BranchNotFound(local_branch_name.to_string()))?;
 
-        let base_commit_id = base_branch.get().peel_to_commit()?.id();
+        let new_base_commit_id = base_branch.get().peel_to_commit()?.id();
 
         // Get the HEAD commit of the worktree (the changes to rebase)
         let head = worktree_repo.head()?;
+        let task_branch_commit_id = head.peel_to_commit()?.id();
 
-        // Set up rebase
-        let mut rebase_opts = RebaseOptions::new();
         let signature = worktree_repo.signature()?;
 
-        // Start the rebase
-        let head_annotated = worktree_repo.reference_to_annotated_commit(&head)?;
-        let base_annotated = worktree_repo.find_annotated_commit(base_commit_id)?;
+        // Perform smart rebase if old_base_branch is provided
+        if let Some(old_base_branch_name) = old_base_branch {
+            // Find the old base branch
+            let old_base_branch = if old_base_branch_name.starts_with("origin/") {
+                // Remote branch - get local tracking branch name
+                let remote_branch_name = old_base_branch_name.strip_prefix("origin/").unwrap();
+                main_repo
+                    .find_branch(remote_branch_name, BranchType::Local)
+                    .map_err(|_| GitServiceError::BranchNotFound(remote_branch_name.to_string()))?
+            } else {
+                // Local branch
+                main_repo
+                    .find_branch(old_base_branch_name, BranchType::Local)
+                    .map_err(|_| GitServiceError::BranchNotFound(old_base_branch_name.to_string()))?
+            };
 
-        let mut rebase = worktree_repo.rebase(
-            Some(&head_annotated),
-            Some(&base_annotated),
-            None, // onto (use upstream if None)
-            Some(&mut rebase_opts),
-        )?;
+            let old_base_commit_id = old_base_branch.get().peel_to_commit()?.id();
 
-        // Process each rebase operation
-        while let Some(operation) = rebase.next() {
-            let _operation = operation?;
+            // Find commits unique to the task branch
+            let unique_commits = Self::find_unique_commits(
+                &worktree_repo,
+                task_branch_commit_id,
+                old_base_commit_id,
+                new_base_commit_id,
+            )?;
 
-            // Check for conflicts
-            let index = worktree_repo.index()?;
-            if index.has_conflicts() {
-                // For now, abort the rebase on conflicts
-                rebase.abort()?;
-                return Err(GitServiceError::MergeConflicts(
-                    "Rebase failed due to conflicts. Please resolve conflicts manually."
-                        .to_string(),
-                ));
+            if !unique_commits.is_empty() {
+                // Reset HEAD to the new base branch
+                let new_base_commit = worktree_repo.find_commit(new_base_commit_id)?;
+                worktree_repo.reset(&new_base_commit.as_object(), git2::ResetType::Hard, None)?;
+
+                // Cherry-pick the unique commits
+                Self::cherry_pick_commits(&worktree_repo, &unique_commits, &signature)?;
+            } else {
+                // No unique commits to rebase, just reset to new base
+                let new_base_commit = worktree_repo.find_commit(new_base_commit_id)?;
+                worktree_repo.reset(&new_base_commit.as_object(), git2::ResetType::Hard, None)?;
+            }
+        } else {
+            // Fall back to standard rebase for backward compatibility
+            let mut rebase_opts = RebaseOptions::new();
+
+            // Start the rebase
+            let head_annotated = worktree_repo.reference_to_annotated_commit(&head)?;
+            let base_annotated = worktree_repo.find_annotated_commit(new_base_commit_id)?;
+
+            let mut rebase = worktree_repo.rebase(
+                Some(&head_annotated),
+                Some(&base_annotated),
+                None, // onto (use upstream if None)
+                Some(&mut rebase_opts),
+            )?;
+
+            // Process each rebase operation
+            while let Some(operation) = rebase.next() {
+                let _operation = operation?;
+
+                // Check for conflicts
+                let index = worktree_repo.index()?;
+                if index.has_conflicts() {
+                    // For now, abort the rebase on conflicts
+                    rebase.abort()?;
+                    return Err(GitServiceError::MergeConflicts(
+                        "Rebase failed due to conflicts. Please resolve conflicts manually."
+                            .to_string(),
+                    ));
+                }
+
+                // Commit the rebased operation
+                rebase.commit(None, &signature, None)?;
             }
 
-            // Commit the rebased operation
-            rebase.commit(None, &signature, None)?;
+            // Finish the rebase
+            rebase.finish(None)?;
         }
-
-        // Finish the rebase
-        rebase.finish(None)?;
 
         // Get the final commit ID after rebase
         let final_head = worktree_repo.head()?;
@@ -1181,6 +1224,88 @@ impl GitService {
         remote
             .fetch(&[] as &[&str], Some(&mut fetch_opts), None)
             .map_err(GitServiceError::Git)?;
+        Ok(())
+    }
+
+    /// Find the merge-base between two commits
+    fn get_merge_base(repo: &Repository, commit1: git2::Oid, commit2: git2::Oid) -> Result<git2::Oid, GitServiceError> {
+        repo.merge_base(commit1, commit2)
+            .map_err(GitServiceError::Git)
+    }
+
+    /// Find commits that are unique to the task branch (not in either base branch)
+    fn find_unique_commits(
+        repo: &Repository,
+        task_branch_commit: git2::Oid,
+        old_base_commit: git2::Oid,
+        new_base_commit: git2::Oid,
+    ) -> Result<Vec<git2::Oid>, GitServiceError> {
+        // Find merge-base between task branch and old base branch
+        let task_old_base_merge_base = Self::get_merge_base(repo, task_branch_commit, old_base_commit)?;
+        
+        // Find merge-base between old base and new base
+        let old_new_base_merge_base = Self::get_merge_base(repo, old_base_commit, new_base_commit)?;
+
+        // Get all commits from task branch back to the merge-base with old base
+        let mut walker = repo.revwalk()?;
+        walker.push(task_branch_commit)?;
+        walker.hide(task_old_base_merge_base)?;
+        
+        let mut task_commits = Vec::new();
+        for commit_id in walker {
+            let commit_id = commit_id?;
+            
+            // Check if this commit is not in the old base branch lineage
+            // (i.e., it's not between old_new_base_merge_base and old_base_commit)
+            let is_in_old_base = repo.graph_descendant_of(commit_id, old_new_base_merge_base)
+                .unwrap_or(false) && repo.graph_descendant_of(old_base_commit, commit_id).unwrap_or(false);
+            
+            if !is_in_old_base {
+                task_commits.push(commit_id);
+            }
+        }
+        
+        // Reverse to get chronological order for cherry-picking
+        task_commits.reverse();
+        Ok(task_commits)
+    }
+
+    /// Cherry-pick specific commits onto a new base
+    fn cherry_pick_commits(
+        repo: &Repository,
+        commits: &[git2::Oid],
+        signature: &git2::Signature,
+    ) -> Result<(), GitServiceError> {
+        for &commit_id in commits {
+            let commit = repo.find_commit(commit_id)?;
+            
+            // Cherry-pick the commit
+            let mut cherrypick_opts = CherrypickOptions::new();
+            repo.cherrypick(&commit, Some(&mut cherrypick_opts))?;
+            
+            // Check for conflicts
+            let mut index = repo.index()?;
+            if index.has_conflicts() {
+                return Err(GitServiceError::MergeConflicts(
+                    format!("Cherry-pick failed due to conflicts on commit {}", commit_id)
+                ));
+            }
+            
+            // Commit the cherry-pick
+            let tree_id = index.write_tree()?;
+            let tree = repo.find_tree(tree_id)?;
+            let head_commit = repo.head()?.peel_to_commit()?;
+            
+            repo.commit(
+                Some("HEAD"),
+                signature,
+                signature,
+                &commit.message().unwrap_or("Cherry-picked commit"),
+                &tree,
+                &[&head_commit],
+            )?;
+        }
+        
         Ok(())
     }
 }

--- a/backend/src/services/git_service.rs
+++ b/backend/src/services/git_service.rs
@@ -423,9 +423,7 @@ impl GitService {
             // Local branch
             main_repo
                 .find_branch(old_base_branch, BranchType::Local)
-                .map_err(|_| {
-                    GitServiceError::BranchNotFound(old_base_branch.to_string())
-                })?
+                .map_err(|_| GitServiceError::BranchNotFound(old_base_branch.to_string()))?
         };
 
         let old_base_commit_id = old_base_branch_ref.get().peel_to_commit()?.id();


### PR DESCRIPTION
# Plan to Fix Rebase onto Different Branch Issue

## Problem Summary
When rebasing a task branch onto a different base branch, unintended commits appear if the old base branch is itself based on the new base branch. The current rebase includes all commits from the merge-base, not just the task-specific commits.

## Root Cause
The issue is in `backend/src/services/git_service.rs:rebase_branch()` around lines 418-424. The current implementation uses a standard Git rebase that includes all commits between the task branch and the new base branch.

## Solution Strategy
Replace the current rebase logic with a **smart rebase** that:
1. Identifies the actual old base branch from the database
2. Calculates commits unique to the task branch (not in either base)
3. Cherry-picks only those unique commits onto the new base

## Implementation Plan

### 1. Update `rebase_branch()` Method
**File**: `backend/src/services/git_service.rs`

- Add `old_base_branch` parameter to the method signature
- Implement commit range calculation logic:
  - Find merge-base between task branch and old base branch
  - Find merge-base between old base branch and new base branch  
  - Identify commits unique to task branch only
- Replace standard rebase with cherry-pick of unique commits
- Maintain existing conflict detection and error handling

### 2. Update TaskAttempt Model
**File**: `backend/src/models/task_attempt.rs`

- Modify `rebase_attempt()` method (line 805-851) to pass the current base branch to the Git service
- Ensure the old base branch is retrieved from the database before calling rebase

### 3. Update API Endpoint
**File**: `backend/src/routes/task_attempts.rs`

- No changes needed - the API contract remains the same
- The fix is internal to the implementation

### 4. Add Helper Methods
**File**: `backend/src/services/git_service.rs`

- `find_unique_commits()`: Calculate commits unique to task branch
- `cherry_pick_commits()`: Apply specific commits to new base
- `get_merge_base()`: Find common ancestor between branches

### 5. Testing Strategy
- Test scenario: old_base → new_base → task_branch
- Verify only task-specific commits are included after rebase
- Ensure no regression in normal rebase cases
- Test conflict handling remains functional

## Expected Outcome
After rebasing `task_branch` from `old_base_branch` to `new_base_branch`, only commits that were added specifically to the task branch (not inherited from either base branch) will appear in the history.

## Implementation Steps
1. Add helper methods for commit analysis
2. Update `rebase_branch()` with smart rebase logic
3. Modify `TaskAttempt::rebase_attempt()` to pass old base branch
4. Test with various branch relationship scenarios
5. Verify UI behavior remains unchanged