### PR TITLE
feat: copy the worktree path in the sidebar on click (vibe-kanban)

### DIFF
--- a/frontend/src/components/tasks/Toolbar/CurrentAttempt.tsx
+++ b/frontend/src/components/tasks/Toolbar/CurrentAttempt.tsx
@@ -591,18 +591,22 @@ function CurrentAttempt({
             Open in {editorDisplayName}
           </Button>
         </div>
-        <div 
+        <div
           className={`text-xs font-mono px-2 py-1 rounded break-all cursor-pointer transition-all duration-300 flex items-center gap-2 ${
-            copied 
-              ? 'bg-green-100 text-green-800 border border-green-300' 
+            copied
+              ? 'bg-green-100 text-green-800 border border-green-300'
               : 'text-muted-foreground bg-muted hover:bg-muted/80'
           }`}
           onClick={handleCopyWorktreePath}
-          title={copied ? "Copied!" : "Click to copy worktree path"}
+          title={copied ? 'Copied!' : 'Click to copy worktree path'}
         >
           {copied && <Check className="h-3 w-3 text-green-600" />}
-          <span className={copied ? 'text-green-800' : ''}>{selectedAttempt.worktree_path}</span>
-          {copied && <span className="text-green-700 font-medium">Copied!</span>}
+          <span className={copied ? 'text-green-800' : ''}>
+            {selectedAttempt.worktree_path}
+          </span>
+          {copied && (
+            <span className="text-green-700 font-medium">Copied!</span>
+          )}
         </div>
       </div>
 


### PR DESCRIPTION
Can now click on the worktree path and it will be copied to the clipboard.