### PR TITLE
chore: define executors with MCP configuration

### DIFF
--- a/backend/src/bin/generate_types.rs
+++ b/backend/src/bin/generate_types.rs
@@ -45,6 +45,15 @@ export const EDITOR_LABELS: Record<string, string> = {
     "custom": "Custom"
 };
 
+export const MCP_SUPPORTED_EXECUTORS: string[] = [
+    "claude",
+    "amp",
+    "gemini",
+    "sst-opencode",
+    "charm-opencode",
+    "claude-code-router"
+];
+
 export const SOUND_FILES: SoundFile[] = [
     "abstract-sound1",
     "abstract-sound2",

--- a/backend/src/executor.rs
+++ b/backend/src/executor.rs
@@ -495,7 +495,7 @@ impl ExecutorConfig {
             ExecutorConfig::CharmOpencode => Some(vec!["mcpServers"]),
             ExecutorConfig::SstOpencode => Some(vec!["mcp"]),
             ExecutorConfig::Claude => Some(vec!["mcpServers"]),
-            ExecutorConfig::ClaudePlan => Some(vec!["mcpServers"]),
+            ExecutorConfig::ClaudePlan => None, // Claude Plan shares Claude config
             ExecutorConfig::Amp => Some(vec!["amp", "mcpServers"]), // Nested path for Amp
             ExecutorConfig::Gemini => Some(vec!["mcpServers"]),
             ExecutorConfig::ClaudeCodeRouter => Some(vec!["mcpServers"]),

--- a/frontend/src/pages/McpServers.tsx
+++ b/frontend/src/pages/McpServers.tsx
@@ -18,7 +18,11 @@ import { Label } from '@/components/ui/label';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Textarea } from '@/components/ui/textarea';
 import { Loader2 } from 'lucide-react';
-import { EXECUTOR_TYPES, EXECUTOR_LABELS } from 'shared/types';
+import {
+  EXECUTOR_TYPES,
+  EXECUTOR_LABELS,
+  MCP_SUPPORTED_EXECUTORS,
+} from 'shared/types';
 import { useConfig } from '@/components/config-provider';
 import { mcpServersApi } from '../lib/api';
 
@@ -35,7 +39,12 @@ export function McpServers() {
   // Initialize selected MCP executor when config loads
   useEffect(() => {
     if (config?.executor?.type && !selectedMcpExecutor) {
-      setSelectedMcpExecutor(config.executor.type);
+      // If current executor supports MCP, use it; otherwise use first available MCP executor
+      if (MCP_SUPPORTED_EXECUTORS.includes(config.executor.type)) {
+        setSelectedMcpExecutor(config.executor.type);
+      } else {
+        setSelectedMcpExecutor(MCP_SUPPORTED_EXECUTORS[0] || 'claude');
+      }
     }
   }, [config?.executor?.type, selectedMcpExecutor]);
 
@@ -314,7 +323,9 @@ export function McpServers() {
                   <SelectValue placeholder="Select executor" />
                 </SelectTrigger>
                 <SelectContent>
-                  {EXECUTOR_TYPES.map((type) => (
+                  {EXECUTOR_TYPES.filter((type) =>
+                    MCP_SUPPORTED_EXECUTORS.includes(type)
+                  ).map((type) => (
                     <SelectItem key={type} value={type}>
                       {EXECUTOR_LABELS[type]}
                     </SelectItem>

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -159,6 +159,15 @@ export const EDITOR_LABELS: Record<string, string> = {
     "custom": "Custom"
 };
 
+export const MCP_SUPPORTED_EXECUTORS: string[] = [
+    "claude",
+    "amp",
+    "gemini",
+    "sst-opencode",
+    "charm-opencode",
+    "claude-code-router"
+];
+
 export const SOUND_FILES: SoundFile[] = [
     "abstract-sound1",
     "abstract-sound2",


### PR DESCRIPTION
Now we define a set of executors that support MCP Server configuration (`MCP_SUPPORTED_EXECUTORS`).

This allows us to exclude `Claude Code Plan`, which shares the same configuration as `Claude Code`.