### PR TITLE
fix: display profile in the task attempt card

### DIFF
--- a/crates/db/.sqlx/query-15713b22bb39d3f0b49e5dd58f58f49ef5dc9393a3ed168b8bc59f6865a7121d.json
+++ b/crates/db/.sqlx/query-15713b22bb39d3f0b49e5dd58f58f49ef5dc9393a3ed168b8bc59f6865a7121d.json
@@ -1,6 +1,6 @@
 {
   "db_name": "SQLite",
-  "query": "SELECT  id                AS \"id!: Uuid\",\n                       task_id           AS \"task_id!: Uuid\",\n                       container_ref,\n                       branch,\n                       merge_commit,\n                       base_branch,\n                       base_coding_agent AS \"base_coding_agent!\",\n                       pr_url,\n                       pr_number,\n                       pr_status,\n                       pr_merged_at      AS \"pr_merged_at: DateTime<Utc>\",\n                       worktree_deleted  AS \"worktree_deleted!: bool\",\n                       setup_completed_at AS \"setup_completed_at: DateTime<Utc>\",\n                       created_at        AS \"created_at!: DateTime<Utc>\",\n                       updated_at        AS \"updated_at!: DateTime<Utc>\"\n               FROM    task_attempts\n               WHERE   rowid = $1",
+  "query": "SELECT id AS \"id!: Uuid\",\n                              task_id AS \"task_id!: Uuid\",\n                              container_ref,\n                              branch,\n                              base_branch,\n                              merge_commit,\n                              base_coding_agent AS \"base_coding_agent!\",\n                              profile_label AS \"profile_label!\",\n                              pr_url,\n                              pr_number,\n                              pr_status,\n                              pr_merged_at AS \"pr_merged_at: DateTime<Utc>\",\n                              worktree_deleted AS \"worktree_deleted!: bool\",\n                              setup_completed_at AS \"setup_completed_at: DateTime<Utc>\",\n                              created_at AS \"created_at!: DateTime<Utc>\",\n                              updated_at AS \"updated_at!: DateTime<Utc>\"\n                       FROM task_attempts\n                       WHERE task_id = $1\n                       ORDER BY created_at DESC",
   "describe": {
     "columns": [
       {
@@ -24,12 +24,12 @@
         "type_info": "Text"
       },
       {
-        "name": "merge_commit",
+        "name": "base_branch",
         "ordinal": 4,
         "type_info": "Text"
       },
       {
-        "name": "base_branch",
+        "name": "merge_commit",
         "ordinal": 5,
         "type_info": "Text"
       },
@@ -39,43 +39,48 @@
         "type_info": "Text"
       },
       {
-        "name": "pr_url",
+        "name": "profile_label!",
         "ordinal": 7,
         "type_info": "Text"
       },
       {
-        "name": "pr_number",
+        "name": "pr_url",
         "ordinal": 8,
+        "type_info": "Text"
+      },
+      {
+        "name": "pr_number",
+        "ordinal": 9,
         "type_info": "Integer"
       },
       {
         "name": "pr_status",
-        "ordinal": 9,
+        "ordinal": 10,
         "type_info": "Text"
       },
       {
         "name": "pr_merged_at: DateTime<Utc>",
-        "ordinal": 10,
+        "ordinal": 11,
         "type_info": "Datetime"
       },
       {
         "name": "worktree_deleted!: bool",
-        "ordinal": 11,
+        "ordinal": 12,
         "type_info": "Bool"
       },
       {
         "name": "setup_completed_at: DateTime<Utc>",
-        "ordinal": 12,
+        "ordinal": 13,
         "type_info": "Datetime"
       },
       {
         "name": "created_at!: DateTime<Utc>",
-        "ordinal": 13,
+        "ordinal": 14,
         "type_info": "Text"
       },
       {
         "name": "updated_at!: DateTime<Utc>",
-        "ordinal": 14,
+        "ordinal": 15,
         "type_info": "Text"
       }
     ],
@@ -87,9 +92,10 @@
       false,
       true,
       true,
-      true,
       false,
       true,
+      true,
+      false,
       true,
       true,
       true,
@@ -100,5 +106,5 @@
       false
     ]
   },
-  "hash": "1f1850b240af8edf2a05ad4a250c78331f69f3637f4b8a554898b9e6ba5bba37"
+  "hash": "15713b22bb39d3f0b49e5dd58f58f49ef5dc9393a3ed168b8bc59f6865a7121d"
 }

--- a/crates/db/.sqlx/query-17b44fd4d20ea668d218af3780e99cf929e1d26efba09481b7e0ab2ce2d3423e.json
+++ b/crates/db/.sqlx/query-17b44fd4d20ea668d218af3780e99cf929e1d26efba09481b7e0ab2ce2d3423e.json
@@ -1,6 +1,6 @@
 {
   "db_name": "SQLite",
-  "query": "SELECT  id                AS \"id!: Uuid\",\n                       task_id           AS \"task_id!: Uuid\",\n                       container_ref,\n                       branch,\n                       merge_commit,\n                       base_branch,\n                       base_coding_agent AS \"base_coding_agent!\",\n                       pr_url,\n                       pr_number,\n                       pr_status,\n                       pr_merged_at      AS \"pr_merged_at: DateTime<Utc>\",\n                       worktree_deleted  AS \"worktree_deleted!: bool\",\n                       setup_completed_at AS \"setup_completed_at: DateTime<Utc>\",\n                       created_at        AS \"created_at!: DateTime<Utc>\",\n                       updated_at        AS \"updated_at!: DateTime<Utc>\"\n               FROM    task_attempts\n               WHERE   id = $1",
+  "query": "SELECT  id                AS \"id!: Uuid\",\n                       task_id           AS \"task_id!: Uuid\",\n                       container_ref,\n                       branch,\n                       merge_commit,\n                       base_branch,\n                       base_coding_agent AS \"base_coding_agent!\",\n                       profile_label     AS \"profile_label!\",\n                       pr_url,\n                       pr_number,\n                       pr_status,\n                       pr_merged_at      AS \"pr_merged_at: DateTime<Utc>\",\n                       worktree_deleted  AS \"worktree_deleted!: bool\",\n                       setup_completed_at AS \"setup_completed_at: DateTime<Utc>\",\n                       created_at        AS \"created_at!: DateTime<Utc>\",\n                       updated_at        AS \"updated_at!: DateTime<Utc>\"\n               FROM    task_attempts\n               WHERE   rowid = $1",
   "describe": {
     "columns": [
       {
@@ -39,43 +39,48 @@
         "type_info": "Text"
       },
       {
-        "name": "pr_url",
+        "name": "profile_label!",
         "ordinal": 7,
         "type_info": "Text"
       },
       {
-        "name": "pr_number",
+        "name": "pr_url",
         "ordinal": 8,
+        "type_info": "Text"
+      },
+      {
+        "name": "pr_number",
+        "ordinal": 9,
         "type_info": "Integer"
       },
       {
         "name": "pr_status",
-        "ordinal": 9,
+        "ordinal": 10,
         "type_info": "Text"
       },
       {
         "name": "pr_merged_at: DateTime<Utc>",
-        "ordinal": 10,
+        "ordinal": 11,
         "type_info": "Datetime"
       },
       {
         "name": "worktree_deleted!: bool",
-        "ordinal": 11,
+        "ordinal": 12,
         "type_info": "Bool"
       },
       {
         "name": "setup_completed_at: DateTime<Utc>",
-        "ordinal": 12,
+        "ordinal": 13,
         "type_info": "Datetime"
       },
       {
         "name": "created_at!: DateTime<Utc>",
-        "ordinal": 13,
+        "ordinal": 14,
         "type_info": "Text"
       },
       {
         "name": "updated_at!: DateTime<Utc>",
-        "ordinal": 14,
+        "ordinal": 15,
         "type_info": "Text"
       }
     ],
@@ -90,6 +95,7 @@
       true,
       false,
       true,
+      false,
       true,
       true,
       true,
@@ -100,5 +106,5 @@
       false
     ]
   },
-  "hash": "acdb8488d9d698e8522a1a1a062f560857e70cf8c1dee1eaecd75b096911cb17"
+  "hash": "17b44fd4d20ea668d218af3780e99cf929e1d26efba09481b7e0ab2ce2d3423e"
 }

--- a/crates/db/.sqlx/query-3ad90fa61dcd97787589d5223b49164eebacd16f26d87be170c4f75540cd9c73.json
+++ b/crates/db/.sqlx/query-3ad90fa61dcd97787589d5223b49164eebacd16f26d87be170c4f75540cd9c73.json
@@ -1,6 +1,6 @@
 {
   "db_name": "SQLite",
-  "query": "SELECT  ta.id                AS \"id!: Uuid\",\n                       ta.task_id           AS \"task_id!: Uuid\",\n                       ta.container_ref,\n                       ta.branch,\n                       ta.base_branch,\n                       ta.merge_commit,\n                       ta.base_coding_agent AS \"base_coding_agent!\",\n                       ta.pr_url,\n                       ta.pr_number,\n                       ta.pr_status,\n                       ta.pr_merged_at      AS \"pr_merged_at: DateTime<Utc>\",\n                       ta.worktree_deleted  AS \"worktree_deleted!: bool\",\n                       ta.setup_completed_at AS \"setup_completed_at: DateTime<Utc>\",\n                       ta.created_at        AS \"created_at!: DateTime<Utc>\",\n                       ta.updated_at        AS \"updated_at!: DateTime<Utc>\"\n               FROM    task_attempts ta\n               JOIN    tasks t ON ta.task_id = t.id\n               JOIN    projects p ON t.project_id = p.id\n               WHERE   ta.id = $1 AND t.id = $2 AND p.id = $3",
+  "query": "INSERT INTO task_attempts (id, task_id, container_ref, branch, base_branch, merge_commit, base_coding_agent, profile_label, pr_url, pr_number, pr_status, pr_merged_at, worktree_deleted, setup_completed_at)\n               VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)\n               RETURNING id as \"id!: Uuid\", task_id as \"task_id!: Uuid\", container_ref, branch, base_branch, merge_commit, base_coding_agent as \"base_coding_agent!\", profile_label as \"profile_label!\", pr_url, pr_number, pr_status, pr_merged_at as \"pr_merged_at: DateTime<Utc>\", worktree_deleted as \"worktree_deleted!: bool\", setup_completed_at as \"setup_completed_at: DateTime<Utc>\", created_at as \"created_at!: DateTime<Utc>\", updated_at as \"updated_at!: DateTime<Utc>\"",
   "describe": {
     "columns": [
       {
@@ -39,48 +39,53 @@
         "type_info": "Text"
       },
       {
-        "name": "pr_url",
+        "name": "profile_label!",
         "ordinal": 7,
         "type_info": "Text"
       },
       {
-        "name": "pr_number",
+        "name": "pr_url",
         "ordinal": 8,
+        "type_info": "Text"
+      },
+      {
+        "name": "pr_number",
+        "ordinal": 9,
         "type_info": "Integer"
       },
       {
         "name": "pr_status",
-        "ordinal": 9,
+        "ordinal": 10,
         "type_info": "Text"
       },
       {
         "name": "pr_merged_at: DateTime<Utc>",
-        "ordinal": 10,
+        "ordinal": 11,
         "type_info": "Datetime"
       },
       {
         "name": "worktree_deleted!: bool",
-        "ordinal": 11,
+        "ordinal": 12,
         "type_info": "Bool"
       },
       {
         "name": "setup_completed_at: DateTime<Utc>",
-        "ordinal": 12,
+        "ordinal": 13,
         "type_info": "Datetime"
       },
       {
         "name": "created_at!: DateTime<Utc>",
-        "ordinal": 13,
+        "ordinal": 14,
         "type_info": "Text"
       },
       {
         "name": "updated_at!: DateTime<Utc>",
-        "ordinal": 14,
+        "ordinal": 15,
         "type_info": "Text"
       }
     ],
     "parameters": {
-      "Right": 3
+      "Right": 14
     },
     "nullable": [
       true,
@@ -90,6 +95,7 @@
       false,
       true,
       true,
+      false,
       true,
       true,
       true,
@@ -100,5 +106,5 @@
       false
     ]
   },
-  "hash": "a500d5054ba09e64a4f98500a5c600ba66b9c919af26ae6ca79b1cc82d138158"
+  "hash": "3ad90fa61dcd97787589d5223b49164eebacd16f26d87be170c4f75540cd9c73"
 }

--- a/crates/db/.sqlx/query-7016a75b7f2c35a3e71bf3c67700555a7034bc5c08f67e5f909c9be505305831.json
+++ b/crates/db/.sqlx/query-7016a75b7f2c35a3e71bf3c67700555a7034bc5c08f67e5f909c9be505305831.json
@@ -1,6 +1,6 @@
 {
   "db_name": "SQLite",
-  "query": "INSERT INTO task_attempts (id, task_id, container_ref, branch, base_branch, merge_commit, base_coding_agent, pr_url, pr_number, pr_status, pr_merged_at, worktree_deleted, setup_completed_at)\n               VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)\n               RETURNING id as \"id!: Uuid\", task_id as \"task_id!: Uuid\", container_ref, branch, base_branch, merge_commit, base_coding_agent as \"base_coding_agent!\",  pr_url, pr_number, pr_status, pr_merged_at as \"pr_merged_at: DateTime<Utc>\", worktree_deleted as \"worktree_deleted!: bool\", setup_completed_at as \"setup_completed_at: DateTime<Utc>\", created_at as \"created_at!: DateTime<Utc>\", updated_at as \"updated_at!: DateTime<Utc>\"",
+  "query": "SELECT id AS \"id!: Uuid\",\n                              task_id AS \"task_id!: Uuid\",\n                              container_ref,\n                              branch,\n                              base_branch,\n                              merge_commit,\n                              base_coding_agent AS \"base_coding_agent!\",\n                              profile_label AS \"profile_label!\",\n                              pr_url,\n                              pr_number,\n                              pr_status,\n                              pr_merged_at AS \"pr_merged_at: DateTime<Utc>\",\n                              worktree_deleted AS \"worktree_deleted!: bool\",\n                              setup_completed_at AS \"setup_completed_at: DateTime<Utc>\",\n                              created_at AS \"created_at!: DateTime<Utc>\",\n                              updated_at AS \"updated_at!: DateTime<Utc>\"\n                       FROM task_attempts\n                       ORDER BY created_at DESC",
   "describe": {
     "columns": [
       {
@@ -39,48 +39,53 @@
         "type_info": "Text"
       },
       {
-        "name": "pr_url",
+        "name": "profile_label!",
         "ordinal": 7,
         "type_info": "Text"
       },
       {
-        "name": "pr_number",
+        "name": "pr_url",
         "ordinal": 8,
+        "type_info": "Text"
+      },
+      {
+        "name": "pr_number",
+        "ordinal": 9,
         "type_info": "Integer"
       },
       {
         "name": "pr_status",
-        "ordinal": 9,
+        "ordinal": 10,
         "type_info": "Text"
       },
       {
         "name": "pr_merged_at: DateTime<Utc>",
-        "ordinal": 10,
+        "ordinal": 11,
         "type_info": "Datetime"
       },
       {
         "name": "worktree_deleted!: bool",
-        "ordinal": 11,
+        "ordinal": 12,
         "type_info": "Bool"
       },
       {
         "name": "setup_completed_at: DateTime<Utc>",
-        "ordinal": 12,
+        "ordinal": 13,
         "type_info": "Datetime"
       },
       {
         "name": "created_at!: DateTime<Utc>",
-        "ordinal": 13,
+        "ordinal": 14,
         "type_info": "Text"
       },
       {
         "name": "updated_at!: DateTime<Utc>",
-        "ordinal": 14,
+        "ordinal": 15,
         "type_info": "Text"
       }
     ],
     "parameters": {
-      "Right": 13
+      "Right": 0
     },
     "nullable": [
       true,
@@ -90,6 +95,7 @@
       false,
       true,
       true,
+      false,
       true,
       true,
       true,
@@ -100,5 +106,5 @@
       false
     ]
   },
-  "hash": "1174eecd9f26565a4f4e1e367b5d7c90b4d19b793e496c2e01593f32c5101f24"
+  "hash": "7016a75b7f2c35a3e71bf3c67700555a7034bc5c08f67e5f909c9be505305831"
 }

--- a/crates/db/.sqlx/query-bcda594c2f685e05a11662736ab870d96dcfa8b7a97bcc57831d166a0b544811.json
+++ b/crates/db/.sqlx/query-bcda594c2f685e05a11662736ab870d96dcfa8b7a97bcc57831d166a0b544811.json
@@ -1,6 +1,6 @@
 {
   "db_name": "SQLite",
-  "query": "SELECT id AS \"id!: Uuid\",\n                              task_id AS \"task_id!: Uuid\",\n                              container_ref,\n                              branch,\n                              base_branch,\n                              merge_commit,\n                              base_coding_agent AS \"base_coding_agent!\",\n                              pr_url,\n                              pr_number,\n                              pr_status,\n                              pr_merged_at AS \"pr_merged_at: DateTime<Utc>\",\n                              worktree_deleted AS \"worktree_deleted!: bool\",\n                              setup_completed_at AS \"setup_completed_at: DateTime<Utc>\",\n                              created_at AS \"created_at!: DateTime<Utc>\",\n                              updated_at AS \"updated_at!: DateTime<Utc>\"\n                       FROM task_attempts\n                       ORDER BY created_at DESC",
+  "query": "SELECT  ta.id                AS \"id!: Uuid\",\n                       ta.task_id           AS \"task_id!: Uuid\",\n                       ta.container_ref,\n                       ta.branch,\n                       ta.base_branch,\n                       ta.merge_commit,\n                       ta.base_coding_agent AS \"base_coding_agent!\",\n                       ta.profile_label     AS \"profile_label!\",\n                       ta.pr_url,\n                       ta.pr_number,\n                       ta.pr_status,\n                       ta.pr_merged_at      AS \"pr_merged_at: DateTime<Utc>\",\n                       ta.worktree_deleted  AS \"worktree_deleted!: bool\",\n                       ta.setup_completed_at AS \"setup_completed_at: DateTime<Utc>\",\n                       ta.created_at        AS \"created_at!: DateTime<Utc>\",\n                       ta.updated_at        AS \"updated_at!: DateTime<Utc>\"\n               FROM    task_attempts ta\n               JOIN    tasks t ON ta.task_id = t.id\n               JOIN    projects p ON t.project_id = p.id\n               WHERE   ta.id = $1 AND t.id = $2 AND p.id = $3",
   "describe": {
     "columns": [
       {
@@ -39,48 +39,53 @@
         "type_info": "Text"
       },
       {
-        "name": "pr_url",
+        "name": "profile_label!",
         "ordinal": 7,
         "type_info": "Text"
       },
       {
-        "name": "pr_number",
+        "name": "pr_url",
         "ordinal": 8,
+        "type_info": "Text"
+      },
+      {
+        "name": "pr_number",
+        "ordinal": 9,
         "type_info": "Integer"
       },
       {
         "name": "pr_status",
-        "ordinal": 9,
+        "ordinal": 10,
         "type_info": "Text"
       },
       {
         "name": "pr_merged_at: DateTime<Utc>",
-        "ordinal": 10,
+        "ordinal": 11,
         "type_info": "Datetime"
       },
       {
         "name": "worktree_deleted!: bool",
-        "ordinal": 11,
+        "ordinal": 12,
         "type_info": "Bool"
       },
       {
         "name": "setup_completed_at: DateTime<Utc>",
-        "ordinal": 12,
+        "ordinal": 13,
         "type_info": "Datetime"
       },
       {
         "name": "created_at!: DateTime<Utc>",
-        "ordinal": 13,
+        "ordinal": 14,
         "type_info": "Text"
       },
       {
         "name": "updated_at!: DateTime<Utc>",
-        "ordinal": 14,
+        "ordinal": 15,
         "type_info": "Text"
       }
     ],
     "parameters": {
-      "Right": 0
+      "Right": 3
     },
     "nullable": [
       true,
@@ -90,6 +95,7 @@
       false,
       true,
       true,
+      false,
       true,
       true,
       true,
@@ -100,5 +106,5 @@
       false
     ]
   },
-  "hash": "8f5d9d112659d04406c20c885f72c075b355e54836930226fc84390c5a4516f7"
+  "hash": "bcda594c2f685e05a11662736ab870d96dcfa8b7a97bcc57831d166a0b544811"
 }

--- a/crates/db/.sqlx/query-ce02a68ec268d26b931d7850eb8f285da33d32aab9c6b887fcfbe6b043b3b026.json
+++ b/crates/db/.sqlx/query-ce02a68ec268d26b931d7850eb8f285da33d32aab9c6b887fcfbe6b043b3b026.json
@@ -1,6 +1,6 @@
 {
   "db_name": "SQLite",
-  "query": "SELECT id AS \"id!: Uuid\",\n                              task_id AS \"task_id!: Uuid\",\n                              container_ref,\n                              branch,\n                              base_branch,\n                              merge_commit,\n                              base_coding_agent AS \"base_coding_agent!\",\n                              pr_url,\n                              pr_number,\n                              pr_status,\n                              pr_merged_at AS \"pr_merged_at: DateTime<Utc>\",\n                              worktree_deleted AS \"worktree_deleted!: bool\",\n                              setup_completed_at AS \"setup_completed_at: DateTime<Utc>\",\n                              created_at AS \"created_at!: DateTime<Utc>\",\n                              updated_at AS \"updated_at!: DateTime<Utc>\"\n                       FROM task_attempts\n                       WHERE task_id = $1\n                       ORDER BY created_at DESC",
+  "query": "SELECT  id                AS \"id!: Uuid\",\n                       task_id           AS \"task_id!: Uuid\",\n                       container_ref,\n                       branch,\n                       merge_commit,\n                       base_branch,\n                       base_coding_agent AS \"base_coding_agent!\",\n                       profile_label     AS \"profile_label!\",\n                       pr_url,\n                       pr_number,\n                       pr_status,\n                       pr_merged_at      AS \"pr_merged_at: DateTime<Utc>\",\n                       worktree_deleted  AS \"worktree_deleted!: bool\",\n                       setup_completed_at AS \"setup_completed_at: DateTime<Utc>\",\n                       created_at        AS \"created_at!: DateTime<Utc>\",\n                       updated_at        AS \"updated_at!: DateTime<Utc>\"\n               FROM    task_attempts\n               WHERE   id = $1",
   "describe": {
     "columns": [
       {
@@ -24,12 +24,12 @@
         "type_info": "Text"
       },
       {
-        "name": "base_branch",
+        "name": "merge_commit",
         "ordinal": 4,
         "type_info": "Text"
       },
       {
-        "name": "merge_commit",
+        "name": "base_branch",
         "ordinal": 5,
         "type_info": "Text"
       },
@@ -39,43 +39,48 @@
         "type_info": "Text"
       },
       {
-        "name": "pr_url",
+        "name": "profile_label!",
         "ordinal": 7,
         "type_info": "Text"
       },
       {
-        "name": "pr_number",
+        "name": "pr_url",
         "ordinal": 8,
+        "type_info": "Text"
+      },
+      {
+        "name": "pr_number",
+        "ordinal": 9,
         "type_info": "Integer"
       },
       {
         "name": "pr_status",
-        "ordinal": 9,
+        "ordinal": 10,
         "type_info": "Text"
       },
       {
         "name": "pr_merged_at: DateTime<Utc>",
-        "ordinal": 10,
+        "ordinal": 11,
         "type_info": "Datetime"
       },
       {
         "name": "worktree_deleted!: bool",
-        "ordinal": 11,
+        "ordinal": 12,
         "type_info": "Bool"
       },
       {
         "name": "setup_completed_at: DateTime<Utc>",
-        "ordinal": 12,
+        "ordinal": 13,
         "type_info": "Datetime"
       },
       {
         "name": "created_at!: DateTime<Utc>",
-        "ordinal": 13,
+        "ordinal": 14,
         "type_info": "Text"
       },
       {
         "name": "updated_at!: DateTime<Utc>",
-        "ordinal": 14,
+        "ordinal": 15,
         "type_info": "Text"
       }
     ],
@@ -87,9 +92,10 @@
       false,
       true,
       true,
+      true,
       false,
       true,
-      true,
+      false,
       true,
       true,
       true,
@@ -100,5 +106,5 @@
       false
     ]
   },
-  "hash": "8c691c79539b34f91f09e6dce51eb684840804f9279f9990cfdcb9015453d9d8"
+  "hash": "ce02a68ec268d26b931d7850eb8f285da33d32aab9c6b887fcfbe6b043b3b026"
 }

--- a/crates/db/migrations/20250808144413_add_profile_label_to_task_attempts.sql
+++ b/crates/db/migrations/20250808144413_add_profile_label_to_task_attempts.sql
@@ -1,0 +1,3 @@
+-- Add profile_label column to task_attempts table to track which profile was used
+-- Default to empty string for existing records
+ALTER TABLE task_attempts ADD COLUMN profile_label TEXT NOT NULL DEFAULT '';

--- a/crates/db/src/models/task_attempt.rs
+++ b/crates/db/src/models/task_attempt.rs
@@ -77,11 +77,12 @@ pub struct TaskAttempt {
     pub merge_commit: Option<String>,
     pub base_coding_agent: String, // Name of the base coding agent to use ("AMP", "CLAUDE_CODE",
     // "GEMINI", etc.)
-    pub pr_url: Option<String>,                    // GitHub PR URL
-    pub pr_number: Option<i64>,                    // GitHub PR number
-    pub pr_status: Option<String>,                 // open, closed, merged
-    pub pr_merged_at: Option<DateTime<Utc>>,       // When PR was merged
-    pub worktree_deleted: bool, // Flag indicating if worktree has been cleaned up
+    pub profile_label: String,     // Profile label used for this attempt
+    pub pr_url: Option<String>,    // GitHub PR URL
+    pub pr_number: Option<i64>,    // GitHub PR number
+    pub pr_status: Option<String>, // open, closed, merged
+    pub pr_merged_at: Option<DateTime<Utc>>, // When PR was merged
+    pub worktree_deleted: bool,    // Flag indicating if worktree has been cleaned up
     pub setup_completed_at: Option<DateTime<Utc>>, // When setup script was last completed
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
@@ -120,6 +121,7 @@ pub struct TaskAttemptContext {
 #[derive(Debug, Deserialize, TS)]
 pub struct CreateTaskAttempt {
     pub base_coding_agent: String,
+    pub profile_label: String,
     pub base_branch: String,
 }
 
@@ -143,6 +145,7 @@ impl TaskAttempt {
                               base_branch,
                               merge_commit,
                               base_coding_agent AS "base_coding_agent!",
+                              profile_label AS "profile_label!",
                               pr_url,
                               pr_number,
                               pr_status,
@@ -168,6 +171,7 @@ impl TaskAttempt {
                               base_branch,
                               merge_commit,
                               base_coding_agent AS "base_coding_agent!",
+                              profile_label AS "profile_label!",
                               pr_url,
                               pr_number,
                               pr_status,
@@ -204,6 +208,7 @@ impl TaskAttempt {
                        ta.base_branch,
                        ta.merge_commit,
                        ta.base_coding_agent AS "base_coding_agent!",
+                       ta.profile_label     AS "profile_label!",
                        ta.pr_url,
                        ta.pr_number,
                        ta.pr_status,
@@ -299,6 +304,7 @@ impl TaskAttempt {
                        merge_commit,
                        base_branch,
                        base_coding_agent AS "base_coding_agent!",
+                       profile_label     AS "profile_label!",
                        pr_url,
                        pr_number,
                        pr_status,
@@ -325,6 +331,7 @@ impl TaskAttempt {
                        merge_commit,
                        base_branch,
                        base_coding_agent AS "base_coding_agent!",
+                       profile_label     AS "profile_label!",
                        pr_url,
                        pr_number,
                        pr_status,
@@ -481,9 +488,9 @@ impl TaskAttempt {
         // Insert the record into the database
         Ok(sqlx::query_as!(
             TaskAttempt,
-            r#"INSERT INTO task_attempts (id, task_id, container_ref, branch, base_branch, merge_commit, base_coding_agent, pr_url, pr_number, pr_status, pr_merged_at, worktree_deleted, setup_completed_at)
-               VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
-               RETURNING id as "id!: Uuid", task_id as "task_id!: Uuid", container_ref, branch, base_branch, merge_commit, base_coding_agent as "base_coding_agent!",  pr_url, pr_number, pr_status, pr_merged_at as "pr_merged_at: DateTime<Utc>", worktree_deleted as "worktree_deleted!: bool", setup_completed_at as "setup_completed_at: DateTime<Utc>", created_at as "created_at!: DateTime<Utc>", updated_at as "updated_at!: DateTime<Utc>""#,
+            r#"INSERT INTO task_attempts (id, task_id, container_ref, branch, base_branch, merge_commit, base_coding_agent, profile_label, pr_url, pr_number, pr_status, pr_merged_at, worktree_deleted, setup_completed_at)
+               VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+               RETURNING id as "id!: Uuid", task_id as "task_id!: Uuid", container_ref, branch, base_branch, merge_commit, base_coding_agent as "base_coding_agent!", profile_label as "profile_label!", pr_url, pr_number, pr_status, pr_merged_at as "pr_merged_at: DateTime<Utc>", worktree_deleted as "worktree_deleted!: bool", setup_completed_at as "setup_completed_at: DateTime<Utc>", created_at as "created_at!: DateTime<Utc>", updated_at as "updated_at!: DateTime<Utc>""#,
             attempt_id,
             task_id,
             Option::<String>::None, // Container isn't known yet
@@ -491,6 +498,7 @@ impl TaskAttempt {
             data.base_branch,
             Option::<String>::None, // merge_commit is always None during creation
             data.base_coding_agent,
+            data.profile_label,
             Option::<String>::None, // pr_url is None during creation
             Option::<i64>::None, // pr_number is None during creation
             Option::<String>::None, // pr_status is None during creation

--- a/crates/server/src/routes/task_attempts.rs
+++ b/crates/server/src/routes/task_attempts.rs
@@ -267,6 +267,7 @@ pub async fn create_task_attempt(
         &deployment.db().pool,
         &CreateTaskAttempt {
             base_coding_agent: profile.agent.to_string(),
+            profile_label: profile_label.clone(),
             base_branch: payload.base_branch,
         },
         payload.task_id,

--- a/crates/server/src/routes/tasks.rs
+++ b/crates/server/src/routes/tasks.rs
@@ -109,6 +109,7 @@ pub async fn create_task_and_start(
         &deployment.db().pool,
         &CreateTaskAttempt {
             base_coding_agent: base_coding_agent.clone(),
+            profile_label: default_profile_label.clone(),
             base_branch: branch,
         },
         task.id,

--- a/frontend/src/components/tasks/Toolbar/CurrentAttempt.tsx
+++ b/frontend/src/components/tasks/Toolbar/CurrentAttempt.tsx
@@ -379,10 +379,10 @@ function CurrentAttempt({
 
         <div>
           <div className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-1">
-            Base Agent
+            Profile
           </div>
           <div className="text-sm font-medium">
-            {selectedAttempt.base_coding_agent}
+            {selectedAttempt.profile_label || selectedAttempt.base_coding_agent}
           </div>
         </div>
 
@@ -573,7 +573,7 @@ function CurrentAttempt({
                         {new Date(attempt.created_at).toLocaleTimeString()}
                       </span>
                       <span className="text-xs text-muted-foreground">
-                        {attempt.base_coding_agent || 'Base Agent'}
+                        {attempt.profile_label || attempt.base_coding_agent || 'Base Agent'}
                       </span>
                     </div>
                   </DropdownMenuItem>

--- a/frontend/src/components/tasks/Toolbar/CurrentAttempt.tsx
+++ b/frontend/src/components/tasks/Toolbar/CurrentAttempt.tsx
@@ -573,7 +573,9 @@ function CurrentAttempt({
                         {new Date(attempt.created_at).toLocaleTimeString()}
                       </span>
                       <span className="text-xs text-muted-foreground">
-                        {attempt.profile_label || attempt.base_coding_agent || 'Base Agent'}
+                        {attempt.profile_label ||
+                          attempt.base_coding_agent ||
+                          'Base Agent'}
                       </span>
                     </div>
                   </DropdownMenuItem>

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -118,7 +118,7 @@ export type CreateTaskAttemptBody = { task_id: string, profile: string | null, b
 
 export type RebaseTaskAttemptRequest = { new_base_branch: string | null, };
 
-export type TaskAttempt = { id: string, task_id: string, container_ref: string | null, branch: string | null, base_branch: string, merge_commit: string | null, base_coding_agent: string, pr_url: string | null, pr_number: bigint | null, pr_status: string | null, pr_merged_at: string | null, worktree_deleted: boolean, setup_completed_at: string | null, created_at: string, updated_at: string, };
+export type TaskAttempt = { id: string, task_id: string, container_ref: string | null, branch: string | null, base_branch: string, merge_commit: string | null, base_coding_agent: string, profile_label: string, pr_url: string | null, pr_number: bigint | null, pr_status: string | null, pr_merged_at: string | null, worktree_deleted: boolean, setup_completed_at: string | null, created_at: string, updated_at: string, };
 
 export type ExecutionProcess = { id: string, task_attempt_id: string, run_reason: ExecutionProcessRunReason, status: ExecutionProcessStatus, exit_code: bigint | null, started_at: string, completed_at: string | null, created_at: string, updated_at: string, };
 


### PR DESCRIPTION
- Display `profile_label` in the task attempt view rather than base coding agent
- Store `profile_label` as an additional column on `TaskAttempt` in the DB