### PR TITLE
Debug duplicate log entries (vibe-kanban)

### DIFF
--- a/frontend/src/components/tasks/TaskDetails/LogsTab.tsx
+++ b/frontend/src/components/tasks/TaskDetails/LogsTab.tsx
@@ -132,7 +132,7 @@ function LogsTab() {
       (attemptData.processes || []).filter((process) =>
         shouldShowInLogs(process.run_reason)
       ),
-    [attemptData.processes]
+    [attemptData.processes?.map(p => p.id).join(',')]
   );
 
   const { entries } = useProcessesLogs(filteredProcesses, true);

--- a/frontend/src/components/tasks/TaskDetails/LogsTab.tsx
+++ b/frontend/src/components/tasks/TaskDetails/LogsTab.tsx
@@ -132,7 +132,7 @@ function LogsTab() {
       (attemptData.processes || []).filter((process) =>
         shouldShowInLogs(process.run_reason)
       ),
-    [attemptData.processes?.map(p => p.id).join(',')]
+    [attemptData.processes?.map((p) => p.id).join(',')]
   );
 
   const { entries } = useProcessesLogs(filteredProcesses, true);


### PR DESCRIPTION
frontend/src/components/tasks/TaskDetails/LogsTab.tsx

Every time the LogsTab component re-renders, the logs duplicate, debug why using the oracle. Confirm with me before making changes