### PR TITLE
chore: re-enable local mcp builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,7 +71,7 @@ build-npm-package-codesign.sh
 
 npx-cli/dist
 npx-cli/vibe-kanban-*
-backend/db.sqlite
+vibe-kanban-*.tgz
 
 # Development ports file
 .dev-ports.json

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -30,7 +30,7 @@ async-trait = "0.1"
 command-group = { version = "5.0", features = ["with-tokio"] }
 nix = { version = "0.29", features = ["signal", "process"] }
 openssl-sys = { workspace = true }
-rmcp = { version = "0.2.1", features = ["server", "transport-io"] }
+rmcp = { version = "0.5.0", features = ["server", "transport-io"] }
 schemars = "0.8"
 regex = "1.11.1"
 toml = "0.8"

--- a/crates/server/src/bin/mcp_task_server.rs
+++ b/crates/server/src/bin/mcp_task_server.rs
@@ -34,7 +34,8 @@ fn main() -> anyhow::Result<()> {
                 .with(sentry_layer())
                 .init();
 
-            tracing::debug!("[MCP] Starting MCP task server...");
+            let version = env!("CARGO_PKG_VERSION");
+            tracing::debug!("[MCP] Starting MCP task server version {version}...");
 
             // Database connection
             let database_url = format!(

--- a/crates/server/src/mcp/task_server.rs
+++ b/crates/server/src/mcp/task_server.rs
@@ -9,7 +9,7 @@ use rmcp::{
     model::{
         CallToolResult, Content, Implementation, ProtocolVersion, ServerCapabilities, ServerInfo,
     },
-    schemars, tool, tool_handler, tool_router, Error as RmcpError, ServerHandler,
+    schemars, tool, tool_handler, tool_router, ErrorData, ServerHandler,
 };
 use serde::{Deserialize, Serialize};
 use serde_json;
@@ -218,7 +218,7 @@ impl TaskServer {
             title,
             description,
         }): Parameters<CreateTaskRequest>,
-    ) -> Result<CallToolResult, RmcpError> {
+    ) -> Result<CallToolResult, ErrorData> {
         // Parse project_id from string to UUID
         let project_uuid = match Uuid::parse_str(&project_id) {
             Ok(uuid) => uuid,
@@ -300,7 +300,7 @@ impl TaskServer {
     }
 
     #[tool(description = "List all the available projects")]
-    async fn list_projects(&self) -> Result<CallToolResult, RmcpError> {
+    async fn list_projects(&self) -> Result<CallToolResult, ErrorData> {
         match Project::find_all(&self.pool).await {
             Ok(projects) => {
                 let count = projects.len();
@@ -353,7 +353,7 @@ impl TaskServer {
             status,
             limit,
         }): Parameters<ListTasksRequest>,
-    ) -> Result<CallToolResult, RmcpError> {
+    ) -> Result<CallToolResult, ErrorData> {
         let project_uuid = match Uuid::parse_str(&project_id) {
             Ok(uuid) => uuid,
             Err(_) => {
@@ -494,7 +494,7 @@ impl TaskServer {
             description,
             status,
         }): Parameters<UpdateTaskRequest>,
-    ) -> Result<CallToolResult, RmcpError> {
+    ) -> Result<CallToolResult, ErrorData> {
         let project_uuid = match Uuid::parse_str(&project_id) {
             Ok(uuid) => uuid,
             Err(_) => {
@@ -628,7 +628,7 @@ impl TaskServer {
             project_id,
             task_id,
         }): Parameters<DeleteTaskRequest>,
-    ) -> Result<CallToolResult, RmcpError> {
+    ) -> Result<CallToolResult, ErrorData> {
         let project_uuid = match Uuid::parse_str(&project_id) {
             Ok(uuid) => uuid,
             Err(_) => {
@@ -722,7 +722,7 @@ impl TaskServer {
             project_id,
             task_id,
         }): Parameters<GetTaskRequest>,
-    ) -> Result<CallToolResult, RmcpError> {
+    ) -> Result<CallToolResult, ErrorData> {
         let project_uuid = match Uuid::parse_str(&project_id) {
             Ok(uuid) => uuid,
             Err(_) => {

--- a/local-build.sh
+++ b/local-build.sh
@@ -11,23 +11,23 @@ echo "🔨 Building frontend..."
 
 echo "🔨 Building Rust binaries..."
 cargo build --release --manifest-path Cargo.toml
-# cargo build --release --bin mcp_task_server --manifest-path Cargo.toml
+cargo build --release --bin mcp_task_server --manifest-path Cargo.toml
 
 echo "📦 Creating distribution package..."
 
 # Copy the main binary
 cp target/release/server vibe-kanban
-# cp target/release/mcp_task_server vibe-kanban-mcp
-
-zip vibe-kanban.zip vibe-kanban
-# zip vibe-kanban-mcp.zip vibe-kanban-mcp
-
-rm vibe-kanban #vibe-kanban-mcp
-
+zip -q vibe-kanban.zip vibe-kanban
+rm -f vibe-kanban 
 mv vibe-kanban.zip npx-cli/dist/macos-arm64/vibe-kanban.zip
-# mv vibe-kanban-mcp.zip npx-cli/dist/macos-arm64/vibe-kanban-mcp.zip
+
+# Copy the MCP binary
+cp target/release/mcp_task_server vibe-kanban-mcp
+zip -q vibe-kanban-mcp.zip vibe-kanban-mcp
+rm -f vibe-kanban-mcp
+mv vibe-kanban-mcp.zip npx-cli/dist/macos-arm64/vibe-kanban-mcp.zip
 
 echo "✅ NPM package ready!"
 echo "📁 Files created:"
 echo "   - npx-cli/dist/macos-arm64/vibe-kanban.zip"
-# echo "   - npx-cli/dist/macos-arm64/vibe-kanban-mcp.zip"
+echo "   - npx-cli/dist/macos-arm64/vibe-kanban-mcp.zip"

--- a/package.json
+++ b/package.json
@@ -2,6 +2,13 @@
   "name": "vibe-kanban",
   "version": "0.0.60",
   "private": true,
+  "bin": {
+    "vibe-kanban": "npx-cli/bin/cli.js"
+  },
+  "files": [
+    "npx-cli/bin/cli.js",
+    "npx-cli/dist/**"
+  ],
   "scripts": {
     "check": "npm run frontend:check && npm run backend:check",
     "dev": "export FRONTEND_PORT=$(node scripts/setup-dev-environment.js frontend) && export BACKEND_PORT=$(node scripts/setup-dev-environment.js backend) && concurrently \"npm run backend:dev:watch\" \"npm run frontend:dev\"",
@@ -13,7 +20,9 @@
     "backend:dev:watch": "DISABLE_WORKTREE_ORPHAN_CLEANUP=1 RUST_LOG=debug cargo watch -w crates -x 'run --bin server'",
     "generate-types": "cargo run --bin generate_types",
     "generate-types:check": "cargo run --bin generate_types -- --check",
-    "prepare-db": "node scripts/prepare-db.js"
+    "prepare-db": "node scripts/prepare-db.js",
+    "build:npx": "bash ./local-build.sh",
+    "prepack": "npm run build:npx"
   },
   "devDependencies": {
     "concurrently": "^8.2.2",


### PR DESCRIPTION
- Display crate version number in MCP logs
- Uncomment MCP from build script
- Can now run a local build of vibe-kanban from scratch by running `npm pack` from the root