### PR TITLE
Reset correctly if rebase fails

### DIFF
--- a/crates/services/src/services/git.rs
+++ b/crates/services/src/services/git.rs
@@ -1182,7 +1182,7 @@ impl GitService {
             let mut index = repo.index()?;
             if index.has_conflicts() {
                 return Err(GitServiceError::MergeConflicts(format!(
-                    "Cherry-pick failed due to conflicts on commit {commit_id}"
+                    "Cherry-pick failed due to conflicts on commit {commit_id}, please resolve conflicts manually"
                 )));
             }
 


### PR DESCRIPTION
We're currently leaving the worktree in limbo if rebase fails, now we reset if there is a failure