### PR TITLE
Skip running cleanup script if no changes (vibe-kanban)

### DIFF
--- a/crates/executors/src/logs/utils/entry_index.rs
+++ b/crates/executors/src/logs/utils/entry_index.rs
@@ -70,6 +70,14 @@ impl Default for EntryIndexProvider {
 }
 
 #[cfg(test)]
+impl EntryIndexProvider {
+    /// Test-only constructor for a fresh provider starting at 0
+    pub fn test_new() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
 
@@ -101,13 +109,5 @@ mod tests {
 
         provider.next();
         assert_eq!(provider.current(), 2);
-    }
-}
-
-#[cfg(test)]
-impl EntryIndexProvider {
-    /// Test-only constructor for a fresh provider starting at 0
-    pub fn test_new() -> Self {
-        Self::new()
     }
 }

--- a/crates/local-deployment/src/container.rs
+++ b/crates/local-deployment/src/container.rs
@@ -115,11 +115,7 @@ impl LocalContainerService {
     }
 
     /// Finalize task execution by updating status to InReview and sending notifications
-    async fn finalize_task(
-        db: &DBService,
-        config: &Arc<RwLock<Config>>,
-        ctx: &ExecutionContext,
-    ) {
+    async fn finalize_task(db: &DBService, config: &Arc<RwLock<Config>>, ctx: &ExecutionContext) {
         if let Err(e) = Task::update_status(&db.pool, ctx.task.id, TaskStatus::InReview).await {
             tracing::error!("Failed to update task status to InReview: {e}");
         }
@@ -386,7 +382,7 @@ impl LocalContainerService {
                                     "Skipping cleanup script for task attempt {} - no changes made by coding agent",
                                     ctx.task_attempt.id
                                 );
-                                
+
                                 // Manually finalize task since we're bypassing normal execution flow
                                 Self::finalize_task(&db, &config, &ctx).await;
                             }

--- a/crates/local-deployment/src/container.rs
+++ b/crates/local-deployment/src/container.rs
@@ -339,7 +339,10 @@ impl LocalContainerService {
                             let changes_committed = match container.try_commit_changes(&ctx).await {
                                 Ok(committed) => committed,
                                 Err(e) => {
-                                    tracing::error!("Failed to commit changes after execution: {}", e);
+                                    tracing::error!(
+                                        "Failed to commit changes after execution: {}",
+                                        e
+                                    );
                                     // Treat commit failures as if changes were made to be safe
                                     true
                                 }

--- a/crates/services/src/services/container.rs
+++ b/crates/services/src/services/container.rs
@@ -122,7 +122,7 @@ pub trait ContainerService {
         execution_process: &ExecutionProcess,
     ) -> Result<(), ContainerError>;
 
-    async fn try_commit_changes(&self, ctx: &ExecutionContext) -> Result<(), ContainerError>;
+    async fn try_commit_changes(&self, ctx: &ExecutionContext) -> Result<bool, ContainerError>;
 
     async fn copy_project_files(
         &self,

--- a/crates/services/src/services/git.rs
+++ b/crates/services/src/services/git.rs
@@ -171,7 +171,7 @@ impl GitService {
         Ok(())
     }
 
-    pub fn commit(&self, path: &Path, message: &str) -> Result<(), GitServiceError> {
+    pub fn commit(&self, path: &Path, message: &str) -> Result<bool, GitServiceError> {
         let repo = Repository::open(path)?;
 
         // Check if there are any changes to commit
@@ -189,7 +189,7 @@ impl GitService {
 
         if !has_changes {
             tracing::debug!("No changes to commit!");
-            return Ok(());
+            return Ok(false);
         }
 
         // Get the current HEAD commit
@@ -214,7 +214,7 @@ impl GitService {
             &[&parent_commit],
         )?;
 
-        Ok(())
+        Ok(true)
     }
 
     /// Get diffs between branches or worktree changes

--- a/frontend/src/components/projects/project-form-fields.tsx
+++ b/frontend/src/components/projects/project-form-fields.tsx
@@ -247,9 +247,9 @@ export function ProjectFormFields({
           className="w-full px-3 py-2 border border-input bg-background text-foreground rounded-md resize-vertical focus:outline-none focus:ring-2 focus:ring-ring"
         />
         <p className="text-sm text-muted-foreground">
-          This script will run after coding agent execution is complete. Use it
-          for quality assurance tasks like running linters, formatters, tests,
-          or other validation steps.
+          This script runs after coding agent execution <strong>only if changes were made</strong>. 
+          Use it for quality assurance tasks like running linters, formatters, tests, 
+          or other validation steps. If no changes are made, this script is skipped.
         </p>
       </div>
 

--- a/frontend/src/components/projects/project-form-fields.tsx
+++ b/frontend/src/components/projects/project-form-fields.tsx
@@ -247,9 +247,10 @@ export function ProjectFormFields({
           className="w-full px-3 py-2 border border-input bg-background text-foreground rounded-md resize-vertical focus:outline-none focus:ring-2 focus:ring-ring"
         />
         <p className="text-sm text-muted-foreground">
-          This script runs after coding agent execution <strong>only if changes were made</strong>. 
-          Use it for quality assurance tasks like running linters, formatters, tests, 
-          or other validation steps. If no changes are made, this script is skipped.
+          This script runs after coding agent execution{' '}
+          <strong>only if changes were made</strong>. Use it for quality
+          assurance tasks like running linters, formatters, tests, or other
+          validation steps. If no changes are made, this script is skipped.
         </p>
       </div>
 

--- a/frontend/src/utils/script-placeholders.ts
+++ b/frontend/src/utils/script-placeholders.ts
@@ -19,7 +19,7 @@ npm run dev
 REM Add dev server start command here...`,
       cleanup: `@echo off
 REM Add cleanup commands here...
-REM This runs after coding agent execution`,
+REM This runs after coding agent execution - only if changes were made`,
     };
   }
 }
@@ -35,7 +35,7 @@ npm run dev
 # Add dev server start command here...`,
       cleanup: `#!/bin/bash
 # Add cleanup commands here...
-# This runs after coding agent execution`,
+# This runs after coding agent execution - only if changes were made`,
     };
   }
 }


### PR DESCRIPTION
Please plan how to skip running the cleanup script if there are no changes made during coding agent execution.