### PR TITLE
Summary error (vibe-kanban)

### DIFF
--- a/crates/local-deployment/src/container.rs
+++ b/crates/local-deployment/src/container.rs
@@ -1103,19 +1103,6 @@ impl LocalContainerService {
             // Only update if summary is not already set
             if session.summary.is_none() {
                 if let Some(summary) = self.extract_last_assistant_message(exec_id) {
-                    let preview = {
-                        let end = summary
-                            .char_indices()
-                            .nth(100)
-                            .map(|(idx, _)| idx)
-                            .unwrap_or(summary.len());
-                        &summary[..end]
-                    };
-                    tracing::debug!(
-                        "Updating executor session summary for execution {}: {}",
-                        exec_id,
-                        preview
-                    );
                     ExecutorSession::update_summary(&self.db.pool, *exec_id, &summary).await?;
                 } else {
                     tracing::debug!("No assistant message found for execution {}", exec_id);

--- a/crates/local-deployment/src/container.rs
+++ b/crates/local-deployment/src/container.rs
@@ -1103,10 +1103,18 @@ impl LocalContainerService {
             // Only update if summary is not already set
             if session.summary.is_none() {
                 if let Some(summary) = self.extract_last_assistant_message(exec_id) {
+                    let preview = {
+                        let end = summary
+                            .char_indices()
+                            .nth(100)
+                            .map(|(idx, _)| idx)
+                            .unwrap_or(summary.len());
+                        &summary[..end]
+                    };
                     tracing::debug!(
                         "Updating executor session summary for execution {}: {}",
                         exec_id,
-                        &summary[..summary.len().min(100)]
+                        preview
                     );
                     ExecutorSession::update_summary(&self.db.pool, *exec_id, &summary).await?;
                 } else {


### PR DESCRIPTION
I get the error:

```
thread 'tokio-runtime-worker' panicked at crates/local-deployment/src/container.rs:
byte index 100 is not a char boundary; it is inside '✨' (bytes 98..101) of `## ✅ **Project Complete!**
```

For the code:
```
/// Update the executor session summary with the final assistant message
    async fn update_executor_session_summary(&self, exec_id: &Uuid) -> Result<(), anyhow::Error> {
        // Check if there's an executor session for this execution process
        let session =
            ExecutorSession::find_by_execution_process_id(&self.db.pool, *exec_id).await?;

        if let Some(session) = session {
            // Only update if summary is not already set
            if session.summary.is_none() {
                if let Some(summary) = self.extract_last_assistant_message(exec_id) {
                    tracing::debug!(
                        "Updating executor session summary for execution {}: {}",
                        exec_id,
                        &summary[..summary.len().min(100)]
                    );
                    ExecutorSession::update_summary(&self.db.pool, *exec_id, &summary).await?;
                } else {
                    tracing::debug!("No assistant message found for execution {}", exec_id);
                }
            }
        }

        Ok(())
    }
```