### PR TITLE
fix: spinning wheel on empty diff tab (vibe-kanban)

### DIFF
--- a/frontend/src/components/tasks/TaskDetails/DiffTab.tsx
+++ b/frontend/src/components/tasks/TaskDetails/DiffTab.tsx
@@ -1,9 +1,9 @@
 import { generateDiffFile } from '@git-diff-view/file';
 import { useDiffEntries } from '@/hooks/useDiffEntries';
 import { useMemo, useContext, useCallback, useState, useEffect } from 'react';
-import { 
+import {
   TaskSelectedAttemptContext,
-  TaskAttemptDataContext 
+  TaskAttemptDataContext,
 } from '@/components/context/taskDetailsContext.ts';
 import { Diff } from 'shared/types';
 import { getHighLightLanguageFromPath } from '@/utils/extToLanguage';

--- a/frontend/src/components/tasks/TaskDetails/DiffTab.tsx
+++ b/frontend/src/components/tasks/TaskDetails/DiffTab.tsx
@@ -81,7 +81,6 @@ function DiffTab() {
         <div className="text-center text-muted-foreground">
           <FileText className="w-12 h-12 mx-auto mb-3 opacity-50" />
           <p className="text-sm font-medium">No file changes</p>
-          <p className="text-xs mt-1">This attempt didn't modify any files</p>
         </div>
       </div>
     );


### PR DESCRIPTION
When the Diffs tab is empty it displays a spinning wheel. Even when an execution process is not currently in process. When an execution method stops we should not display a spinning wheel in this tab.