### PR TITLE
feat: `vk/xxxx-xxxx-xxxx` branch naming convention

### DIFF
--- a/frontend/src/pages/project-tasks.tsx
+++ b/frontend/src/pages/project-tasks.tsx
@@ -68,6 +68,7 @@ export function ProjectTasks() {
     queryKey: ['taskAttempts', selectedTask?.id],
     queryFn: () => attemptsApi.getAll(selectedTask!.id),
     enabled: !!selectedTask?.id,
+    refetchInterval: 5000,
   });
 
   // Selected attempt logic


### PR DESCRIPTION
Aligns VK branch names with common branch naming convention `author/branch-name`.

Quick fix for https://github.com/BloopAI/vibe-kanban/issues/632