### PR TITLE
Display notes after the version has changed (vibe-kanban)

### DIFF
--- a/crates/local-deployment/src/lib.rs
+++ b/crates/local-deployment/src/lib.rs
@@ -42,9 +42,29 @@ pub struct LocalDeployment {
 #[async_trait]
 impl Deployment for LocalDeployment {
     async fn new() -> Result<Self, DeploymentError> {
-        let raw_config = load_config_from_file(&config_path()).await;
-        // Immediately save config, as it may have just been migrated
-        save_config_to_file(&raw_config, &config_path()).await?;
+        let mut raw_config = load_config_from_file(&config_path()).await;
+        let mut config_changed = false;
+
+        // Check if app version has changed and set release notes flag
+        {
+            let current_version = utils::version::APP_VERSION;
+            let stored_version = raw_config.last_app_version.as_deref();
+
+            if stored_version != Some(current_version) {
+                // Show release notes only if this is an upgrade (not first install)
+                raw_config.show_release_notes = stored_version.is_some();
+                raw_config.last_app_version = Some(current_version.to_string());
+                config_changed = true;
+            }
+        }
+
+        // Save config if migrated or version changed
+        if config_changed {
+            save_config_to_file(&raw_config, &config_path()).await?;
+        } else {
+            // Save immediately as it may have just been migrated
+            save_config_to_file(&raw_config, &config_path()).await?;
+        }
 
         let config = Arc::new(RwLock::new(raw_config));
         let sentry = SentryService::new();

--- a/crates/services/src/services/config/mod.rs
+++ b/crates/services/src/services/config/mod.rs
@@ -14,13 +14,13 @@ pub enum ConfigError {
     ValidationError(String),
 }
 
-pub type Config = versions::v4::Config;
-pub type NotificationConfig = versions::v4::NotificationConfig;
-pub type EditorConfig = versions::v4::EditorConfig;
-pub type ThemeMode = versions::v4::ThemeMode;
-pub type SoundFile = versions::v4::SoundFile;
-pub type EditorType = versions::v4::EditorType;
-pub type GitHubConfig = versions::v4::GitHubConfig;
+pub type Config = versions::v5::Config;
+pub type NotificationConfig = versions::v5::NotificationConfig;
+pub type EditorConfig = versions::v5::EditorConfig;
+pub type ThemeMode = versions::v5::ThemeMode;
+pub type SoundFile = versions::v5::SoundFile;
+pub type EditorType = versions::v5::EditorType;
+pub type GitHubConfig = versions::v5::GitHubConfig;
 
 /// Will always return config, trying old schemas or eventually returning default
 pub async fn load_config_from_file(config_path: &PathBuf) -> Config {

--- a/crates/services/src/services/config/versions/mod.rs
+++ b/crates/services/src/services/config/versions/mod.rs
@@ -2,3 +2,4 @@ pub(super) mod v1;
 pub(super) mod v2;
 pub(super) mod v3;
 pub(super) mod v4;
+pub(super) mod v5;

--- a/crates/services/src/services/config/versions/v5.rs
+++ b/crates/services/src/services/config/versions/v5.rs
@@ -1,0 +1,97 @@
+use anyhow::Error;
+use executors::profile::ProfileVariantLabel;
+use serde::{Deserialize, Serialize};
+use ts_rs::TS;
+pub use v4::{EditorConfig, EditorType, GitHubConfig, NotificationConfig, SoundFile, ThemeMode};
+
+use crate::services::config::versions::v4;
+
+#[derive(Clone, Debug, Serialize, Deserialize, TS)]
+pub struct Config {
+    pub config_version: String,
+    pub theme: ThemeMode,
+    pub profile: ProfileVariantLabel,
+    pub disclaimer_acknowledged: bool,
+    pub onboarding_acknowledged: bool,
+    pub github_login_acknowledged: bool,
+    pub telemetry_acknowledged: bool,
+    pub notifications: NotificationConfig,
+    pub editor: EditorConfig,
+    pub github: GitHubConfig,
+    pub analytics_enabled: Option<bool>,
+    pub workspace_dir: Option<String>,
+    pub last_app_version: Option<String>,
+    pub show_release_notes: bool,
+}
+
+impl Config {
+    pub fn from_previous_version(raw_config: &str) -> Result<Self, Error> {
+        let old_config = match serde_json::from_str::<v4::Config>(raw_config) {
+            Ok(cfg) => cfg,
+            Err(e) => {
+                tracing::error!("❌ Failed to parse config: {}", e);
+                tracing::error!("   at line {}, column {}", e.line(), e.column());
+                return Err(e.into());
+            }
+        };
+
+        Ok(Self {
+            config_version: "v5".to_string(),
+            theme: old_config.theme,
+            profile: old_config.profile,
+            disclaimer_acknowledged: old_config.disclaimer_acknowledged,
+            onboarding_acknowledged: old_config.onboarding_acknowledged,
+            github_login_acknowledged: old_config.github_login_acknowledged,
+            telemetry_acknowledged: old_config.telemetry_acknowledged,
+            notifications: old_config.notifications,
+            editor: old_config.editor,
+            github: old_config.github,
+            analytics_enabled: old_config.analytics_enabled,
+            workspace_dir: old_config.workspace_dir,
+            last_app_version: None,
+            show_release_notes: false,
+        })
+    }
+}
+
+impl From<String> for Config {
+    fn from(raw_config: String) -> Self {
+        if let Ok(config) = serde_json::from_str::<Config>(&raw_config)
+            && config.config_version == "v5"
+        {
+            return config;
+        }
+
+        match Self::from_previous_version(&raw_config) {
+            Ok(config) => {
+                tracing::info!("Config upgraded to v5");
+                config
+            }
+            Err(e) => {
+                tracing::warn!("Config migration failed: {}, using default", e);
+                Self::default()
+            }
+        }
+    }
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            config_version: "v5".to_string(),
+            theme: ThemeMode::System,
+            profile: ProfileVariantLabel::default("claude-code".to_string()),
+            disclaimer_acknowledged: false,
+            onboarding_acknowledged: false,
+            github_login_acknowledged: false,
+            telemetry_acknowledged: false,
+            notifications: NotificationConfig::default(),
+            editor: EditorConfig::default(),
+            github: GitHubConfig::default(),
+            analytics_enabled: None,
+            workspace_dir: None,
+            last_app_version: None,
+            show_release_notes: false,
+        }
+    }
+}

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -14,6 +14,7 @@ pub mod sentry;
 pub mod shell;
 pub mod stream_lines;
 pub mod text;
+pub mod version;
 
 /// Cache for WSL2 detection result
 static WSL2_CACHE: OnceLock<bool> = OnceLock::new();

--- a/crates/utils/src/version.rs
+++ b/crates/utils/src/version.rs
@@ -1,0 +1,2 @@
+/// The current application version from Cargo.toml
+pub const APP_VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/frontend/src/components/ReleaseNotesDialog.tsx
+++ b/frontend/src/components/ReleaseNotesDialog.tsx
@@ -30,8 +30,8 @@ export function ReleaseNotesDialog({ open, onClose }: ReleaseNotesDialogProps) {
 
   return (
     <Dialog open={open} onOpenChange={() => {}}>
-      <DialogContent className="w-full h-full max-w-none max-h-none p-0 gap-0 grid grid-rows-[auto_1fr_auto] max-h-[calc(100dvh-2rem)]">
-        <DialogHeader className="p-6 pb-0 flex-shrink-0">
+      <DialogContent className="w-[95vw] max-w-7xl max-h-[calc(100dvh-1rem)] p-0 gap-0 grid grid-rows-[auto_1fr_auto] sm:rounded-lg">
+        <DialogHeader className="p-4 border-b flex-shrink-0">
           <div className="flex items-center justify-between">
             <DialogTitle className="text-xl font-semibold">
               What's New in Vibe Kanban
@@ -41,13 +41,14 @@ export function ReleaseNotesDialog({ open, onClose }: ReleaseNotesDialogProps) {
               size="icon"
               onClick={onClose}
               className="h-6 w-6"
+              aria-label="Close"
             >
               <X className="h-4 w-4" />
             </Button>
           </div>
         </DialogHeader>
 
-        <div className="flex-1 min-h-0 px-6">
+        <div className="flex-1 overflow-hidden p-4">
           {iframeError ? (
             <div className="flex flex-col items-center justify-center h-full text-center space-y-4">
               <AlertCircle className="h-12 w-12 text-muted-foreground" />
@@ -86,16 +87,11 @@ export function ReleaseNotesDialog({ open, onClose }: ReleaseNotesDialogProps) {
           )}
         </div>
 
-        <DialogFooter className="p-6 pt-0 flex-shrink-0">
-          <div className="flex w-full gap-2">
-            <Button variant="outline" onClick={handleOpenInBrowser} className="flex-1">
-              <ExternalLink className="h-4 w-4 mr-2" />
-              Open in Browser
-            </Button>
-            <Button onClick={onClose} className="flex-1">
-              Continue to Vibe Kanban
-            </Button>
-          </div>
+        <DialogFooter className="p-4 border-t flex-shrink-0">
+          <Button variant="outline" onClick={handleOpenInBrowser}>
+            <ExternalLink className="h-4 w-4 mr-2" />
+            Open in Browser
+          </Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/frontend/src/components/ReleaseNotesDialog.tsx
+++ b/frontend/src/components/ReleaseNotesDialog.tsx
@@ -7,7 +7,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
-import { X, ExternalLink, AlertCircle } from 'lucide-react';
+import { ExternalLink, AlertCircle } from 'lucide-react';
 
 interface ReleaseNotesDialogProps {
   open: boolean;
@@ -29,23 +29,12 @@ export function ReleaseNotesDialog({ open, onClose }: ReleaseNotesDialogProps) {
   };
 
   return (
-    <Dialog open={open} onOpenChange={() => {}}>
+    <Dialog open={open} onOpenChange={(open) => !open && onClose()}>
       <DialogContent className="flex flex-col w-full h-full max-w-7xl max-h-[calc(100dvh-1rem)] p-0">
         <DialogHeader className="p-4 border-b flex-shrink-0">
-          <div className="flex items-center justify-between">
-            <DialogTitle className="text-xl font-semibold">
-              What's New in Vibe Kanban
-            </DialogTitle>
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={onClose}
-              className="h-6 w-6"
-              aria-label="Close"
-            >
-              <X className="h-4 w-4" />
-            </Button>
-          </div>
+          <DialogTitle className="text-xl font-semibold">
+            What's New in Vibe Kanban
+          </DialogTitle>
         </DialogHeader>
 
         {iframeError ? (

--- a/frontend/src/components/ReleaseNotesDialog.tsx
+++ b/frontend/src/components/ReleaseNotesDialog.tsx
@@ -33,7 +33,7 @@ export function ReleaseNotesDialog({ open, onClose }: ReleaseNotesDialogProps) {
       <DialogContent className="flex flex-col w-full h-full max-w-7xl max-h-[calc(100dvh-1rem)] p-0">
         <DialogHeader className="p-4 border-b flex-shrink-0">
           <DialogTitle className="text-xl font-semibold">
-            What's New in Vibe Kanban
+            We've updated Vibe Kanban! Check out what's new...
           </DialogTitle>
         </DialogHeader>
 
@@ -54,7 +54,7 @@ export function ReleaseNotesDialog({ open, onClose }: ReleaseNotesDialogProps) {
         ) : (
           <iframe
             src={RELEASE_NOTES_URL}
-            className="flex-1 w-full border-0"
+            className="flex-1 w-full border-0 min-h-[600px]"
             sandbox="allow-scripts allow-same-origin allow-popups"
             referrerPolicy="no-referrer"
             title="Release Notes"

--- a/frontend/src/components/ReleaseNotesDialog.tsx
+++ b/frontend/src/components/ReleaseNotesDialog.tsx
@@ -66,7 +66,7 @@ export function ReleaseNotesDialog({ open, onClose }: ReleaseNotesDialogProps) {
             <iframe
               src={RELEASE_NOTES_URL}
               className="w-full h-full border-0 rounded"
-              sandbox="allow-scripts allow-popups"
+              sandbox="allow-scripts allow-same-origin allow-popups"
               referrerPolicy="no-referrer"
               title="Release Notes"
               onError={handleIframeError}

--- a/frontend/src/components/ReleaseNotesDialog.tsx
+++ b/frontend/src/components/ReleaseNotesDialog.tsx
@@ -41,9 +41,12 @@ export function ReleaseNotesDialog({ open, onClose }: ReleaseNotesDialogProps) {
           <div className="flex flex-col items-center justify-center flex-1 text-center space-y-4 p-4">
             <AlertCircle className="h-12 w-12 text-muted-foreground" />
             <div className="space-y-2">
-              <h3 className="text-lg font-medium">Unable to load release notes</h3>
+              <h3 className="text-lg font-medium">
+                Unable to load release notes
+              </h3>
               <p className="text-sm text-muted-foreground max-w-md">
-                We couldn't display the release notes in this window. Click below to view them in your browser.
+                We couldn't display the release notes in this window. Click
+                below to view them in your browser.
               </p>
             </div>
             <Button onClick={handleOpenInBrowser} className="mt-4">

--- a/frontend/src/components/ReleaseNotesDialog.tsx
+++ b/frontend/src/components/ReleaseNotesDialog.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import {
   Dialog,
   DialogContent,
@@ -6,14 +7,27 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
-import { X } from 'lucide-react';
+import { X, ExternalLink, AlertCircle } from 'lucide-react';
 
 interface ReleaseNotesDialogProps {
   open: boolean;
   onClose: () => void;
 }
 
+const RELEASE_NOTES_URL = 'https://vibekanban.com/release-notes';
+
 export function ReleaseNotesDialog({ open, onClose }: ReleaseNotesDialogProps) {
+  const [iframeError, setIframeError] = useState(false);
+
+  const handleOpenInBrowser = () => {
+    window.open(RELEASE_NOTES_URL, '_blank');
+    onClose();
+  };
+
+  const handleIframeError = () => {
+    setIframeError(true);
+  };
+
   return (
     <Dialog open={open} onOpenChange={() => {}}>
       <DialogContent className="w-full h-full max-w-none max-h-none p-0 gap-0 grid grid-rows-[auto_1fr_auto] max-h-[calc(100dvh-2rem)]">
@@ -34,19 +48,54 @@ export function ReleaseNotesDialog({ open, onClose }: ReleaseNotesDialogProps) {
         </DialogHeader>
 
         <div className="flex-1 min-h-0 px-6">
-          <iframe
-            src="https://vibekanban.com/release-notes"
-            className="w-full h-full border-0 rounded"
-            sandbox="allow-same-origin allow-popups"
-            referrerPolicy="no-referrer"
-            title="Release Notes"
-          />
+          {iframeError ? (
+            <div className="flex flex-col items-center justify-center h-full text-center space-y-4">
+              <AlertCircle className="h-12 w-12 text-muted-foreground" />
+              <div className="space-y-2">
+                <h3 className="text-lg font-medium">Unable to load release notes</h3>
+                <p className="text-sm text-muted-foreground max-w-md">
+                  We couldn't display the release notes in this window. Click below to view them in your browser.
+                </p>
+              </div>
+              <Button onClick={handleOpenInBrowser} className="mt-4">
+                <ExternalLink className="h-4 w-4 mr-2" />
+                Open Release Notes in Browser
+              </Button>
+            </div>
+          ) : (
+            <iframe
+              src={RELEASE_NOTES_URL}
+              className="w-full h-full border-0 rounded"
+              sandbox="allow-scripts allow-popups"
+              referrerPolicy="no-referrer"
+              title="Release Notes"
+              onError={handleIframeError}
+              onLoad={(e) => {
+                // Check if iframe content loaded successfully
+                try {
+                  const iframe = e.target as HTMLIFrameElement;
+                  // If iframe is accessible but empty, it might indicate loading issues
+                  if (iframe.contentDocument?.body?.children.length === 0) {
+                    setTimeout(() => setIframeError(true), 5000); // Wait 5s then show fallback
+                  }
+                } catch {
+                  // Cross-origin access blocked (expected), iframe loaded successfully
+                }
+              }}
+            />
+          )}
         </div>
 
         <DialogFooter className="p-6 pt-0 flex-shrink-0">
-          <Button onClick={onClose} className="w-full">
-            Continue to Vibe Kanban
-          </Button>
+          <div className="flex w-full gap-2">
+            <Button variant="outline" onClick={handleOpenInBrowser} className="flex-1">
+              <ExternalLink className="h-4 w-4 mr-2" />
+              Open in Browser
+            </Button>
+            <Button onClick={onClose} className="flex-1">
+              Continue to Vibe Kanban
+            </Button>
+          </div>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/frontend/src/components/ReleaseNotesDialog.tsx
+++ b/frontend/src/components/ReleaseNotesDialog.tsx
@@ -1,0 +1,54 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { X } from 'lucide-react';
+
+interface ReleaseNotesDialogProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export function ReleaseNotesDialog({ open, onClose }: ReleaseNotesDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={() => {}}>
+      <DialogContent className="w-full h-full max-w-none max-h-none p-0 gap-0 grid grid-rows-[auto_1fr_auto] max-h-[calc(100dvh-2rem)]">
+        <DialogHeader className="p-6 pb-0 flex-shrink-0">
+          <div className="flex items-center justify-between">
+            <DialogTitle className="text-xl font-semibold">
+              What's New in Vibe Kanban
+            </DialogTitle>
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={onClose}
+              className="h-6 w-6"
+            >
+              <X className="h-4 w-4" />
+            </Button>
+          </div>
+        </DialogHeader>
+
+        <div className="flex-1 min-h-0 px-6">
+          <iframe
+            src="https://vibekanban.com/release-notes"
+            className="w-full h-full border-0 rounded"
+            sandbox="allow-same-origin allow-popups"
+            referrerPolicy="no-referrer"
+            title="Release Notes"
+          />
+        </div>
+
+        <DialogFooter className="p-6 pt-0 flex-shrink-0">
+          <Button onClick={onClose} className="w-full">
+            Continue to Vibe Kanban
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/ReleaseNotesDialog.tsx
+++ b/frontend/src/components/ReleaseNotesDialog.tsx
@@ -30,7 +30,7 @@ export function ReleaseNotesDialog({ open, onClose }: ReleaseNotesDialogProps) {
 
   return (
     <Dialog open={open} onOpenChange={() => {}}>
-      <DialogContent className="w-[95vw] max-w-7xl max-h-[calc(100dvh-1rem)] p-0 gap-0 grid grid-rows-[auto_1fr_auto] sm:rounded-lg">
+      <DialogContent className="flex flex-col w-full h-full max-w-7xl max-h-[calc(100dvh-1rem)] p-0">
         <DialogHeader className="p-4 border-b flex-shrink-0">
           <div className="flex items-center justify-between">
             <DialogTitle className="text-xl font-semibold">
@@ -48,44 +48,42 @@ export function ReleaseNotesDialog({ open, onClose }: ReleaseNotesDialogProps) {
           </div>
         </DialogHeader>
 
-        <div className="flex-1 overflow-hidden p-4">
-          {iframeError ? (
-            <div className="flex flex-col items-center justify-center h-full text-center space-y-4">
-              <AlertCircle className="h-12 w-12 text-muted-foreground" />
-              <div className="space-y-2">
-                <h3 className="text-lg font-medium">Unable to load release notes</h3>
-                <p className="text-sm text-muted-foreground max-w-md">
-                  We couldn't display the release notes in this window. Click below to view them in your browser.
-                </p>
-              </div>
-              <Button onClick={handleOpenInBrowser} className="mt-4">
-                <ExternalLink className="h-4 w-4 mr-2" />
-                Open Release Notes in Browser
-              </Button>
+        {iframeError ? (
+          <div className="flex flex-col items-center justify-center flex-1 text-center space-y-4 p-4">
+            <AlertCircle className="h-12 w-12 text-muted-foreground" />
+            <div className="space-y-2">
+              <h3 className="text-lg font-medium">Unable to load release notes</h3>
+              <p className="text-sm text-muted-foreground max-w-md">
+                We couldn't display the release notes in this window. Click below to view them in your browser.
+              </p>
             </div>
-          ) : (
-            <iframe
-              src={RELEASE_NOTES_URL}
-              className="w-full h-full border-0 rounded"
-              sandbox="allow-scripts allow-same-origin allow-popups"
-              referrerPolicy="no-referrer"
-              title="Release Notes"
-              onError={handleIframeError}
-              onLoad={(e) => {
-                // Check if iframe content loaded successfully
-                try {
-                  const iframe = e.target as HTMLIFrameElement;
-                  // If iframe is accessible but empty, it might indicate loading issues
-                  if (iframe.contentDocument?.body?.children.length === 0) {
-                    setTimeout(() => setIframeError(true), 5000); // Wait 5s then show fallback
-                  }
-                } catch {
-                  // Cross-origin access blocked (expected), iframe loaded successfully
+            <Button onClick={handleOpenInBrowser} className="mt-4">
+              <ExternalLink className="h-4 w-4 mr-2" />
+              Open Release Notes in Browser
+            </Button>
+          </div>
+        ) : (
+          <iframe
+            src={RELEASE_NOTES_URL}
+            className="flex-1 w-full border-0"
+            sandbox="allow-scripts allow-same-origin allow-popups"
+            referrerPolicy="no-referrer"
+            title="Release Notes"
+            onError={handleIframeError}
+            onLoad={(e) => {
+              // Check if iframe content loaded successfully
+              try {
+                const iframe = e.target as HTMLIFrameElement;
+                // If iframe is accessible but empty, it might indicate loading issues
+                if (iframe.contentDocument?.body?.children.length === 0) {
+                  setTimeout(() => setIframeError(true), 5000); // Wait 5s then show fallback
                 }
-              }}
-            />
-          )}
-        </div>
+              } catch {
+                // Cross-origin access blocked (expected), iframe loaded successfully
+              }
+            }}
+          />
+        )}
 
         <DialogFooter className="p-4 border-t flex-shrink-0">
           <Button variant="outline" onClick={handleOpenInBrowser}>

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -72,7 +72,7 @@ export type ImageResponse = { id: string, file_path: string, original_name: stri
 
 export enum GitHubServiceError { TOKEN_INVALID = "TOKEN_INVALID", INSUFFICIENT_PERMISSIONS = "INSUFFICIENT_PERMISSIONS", REPO_NOT_FOUND_OR_NO_ACCESS = "REPO_NOT_FOUND_OR_NO_ACCESS" }
 
-export type Config = { config_version: string, theme: ThemeMode, profile: ProfileVariantLabel, disclaimer_acknowledged: boolean, onboarding_acknowledged: boolean, github_login_acknowledged: boolean, telemetry_acknowledged: boolean, notifications: NotificationConfig, editor: EditorConfig, github: GitHubConfig, analytics_enabled: boolean | null, workspace_dir: string | null, };
+export type Config = { config_version: string, theme: ThemeMode, profile: ProfileVariantLabel, disclaimer_acknowledged: boolean, onboarding_acknowledged: boolean, github_login_acknowledged: boolean, telemetry_acknowledged: boolean, notifications: NotificationConfig, editor: EditorConfig, github: GitHubConfig, analytics_enabled: boolean | null, workspace_dir: string | null, last_app_version: string | null, show_release_notes: boolean, };
 
 export type NotificationConfig = { sound_enabled: boolean, push_enabled: boolean, sound_file: SoundFile, };
 


### PR DESCRIPTION
Implement automatic NPX version upgrade detection by embedding the app version into Rust binaries via build.rs files, then adding last_app_version and show_release_notes fields to the config schema. On deployment startup, compare the embedded version with the stored version and set the release notes flag if they differ. Create a maximized release notes dialog component that displays https://vibekanban.com/release-notes in a sandboxed iframe with script execution allowed, using a grid layout with grid-rows-[auto_1fr_auto] and max-h-[calc(100dvh-2rem)] to perfectly fit the viewport while keeping the CTA button always visible. Integrate this dialog into the existing App.tsx onboarding flow after privacy opt-in and GitHub login, with a dismiss handler that saves show_release_notes: false to prevent re-display. The feature shows release notes exactly once per version upgrade and persists state through the existing config system.