### PR TITLE
Open file in IDE (vibe-kanban)

### DIFF
--- a/frontend/src/components/DiffCard.tsx
+++ b/frontend/src/components/DiffCard.tsx
@@ -16,14 +16,13 @@ import {
   Key,
 } from 'lucide-react';
 import '@/styles/diff-style-overrides.css';
-import { attemptsApi } from '@/lib/api';
-import type { TaskAttempt } from 'shared/types';
+import { ClickableFilePath } from '@/components/ui/ClickableFilePath';
 
 type Props = {
   diff: Diff;
   expanded: boolean;
   onToggle: () => void;
-  selectedAttempt: TaskAttempt | null;
+  onOpenFile: (path: string, line?: number) => void;
 };
 
 function labelAndIcon(diff: Diff) {
@@ -42,7 +41,7 @@ export default function DiffCard({
   diff,
   expanded,
   onToggle,
-  selectedAttempt,
+  onOpenFile,
 }: Props) {
   const { config } = useConfig();
   const theme = config?.theme === ThemeMode.DARK ? 'dark' : 'light';
@@ -102,12 +101,25 @@ export default function DiffCard({
       {label && <span className="mr-2">{label}</span>}
       {diff.change === 'renamed' && oldName ? (
         <span className="inline-flex items-center gap-2">
-          <span>{oldName}</span>
+          <ClickableFilePath 
+            path={oldName} 
+            onClick={onOpenFile}
+            className="text-xs font-mono"
+          />
           <span aria-hidden>→</span>
-          <span>{newName}</span>
+          <ClickableFilePath 
+            path={newName} 
+            onClick={onOpenFile}
+            className="text-xs font-mono"
+          />
         </span>
       ) : (
-        <span>{newName}</span>
+        <ClickableFilePath 
+          path={newName} 
+          onClick={onOpenFile}
+          disabled={diff.change === 'deleted'}
+          className="text-xs font-mono"
+        />
       )}
       <span className="ml-3" style={{ color: 'hsl(var(--console-success))' }}>
         +{add}
@@ -119,16 +131,9 @@ export default function DiffCard({
   );
 
   const handleOpenInIDE = async () => {
-    if (!selectedAttempt?.id) return;
-    try {
-      const openPath = newName || oldName;
-      await attemptsApi.openEditor(
-        selectedAttempt.id,
-        undefined,
-        openPath || undefined
-      );
-    } catch (err) {
-      console.error('Failed to open file in IDE:', err);
+    const openPath = newName || oldName;
+    if (openPath) {
+      onOpenFile(openPath);
     }
   };
 

--- a/frontend/src/components/NormalizedConversation/EditDiffRenderer.tsx
+++ b/frontend/src/components/NormalizedConversation/EditDiffRenderer.tsx
@@ -12,12 +12,14 @@ import { useConfig } from '@/components/config-provider';
 import { getHighLightLanguageFromPath } from '@/utils/extToLanguage';
 import '@/styles/diff-style-overrides.css';
 import '@/styles/edit-diff-overrides.css';
+import { ClickableFilePath } from '@/components/ui/ClickableFilePath';
 
 type Props = {
   path: string;
   unifiedDiff: string;
   hasLineNumbers: boolean;
   expansionKey: string;
+  onOpenFile?: (path: string, line?: number) => void;
 };
 
 /**
@@ -63,6 +65,7 @@ function EditDiffRenderer({
   unifiedDiff,
   hasLineNumbers,
   expansionKey,
+  onOpenFile,
 }: Props) {
   const { config } = useConfig();
   const [expanded, setExpanded] = useExpandable(expansionKey, false);
@@ -109,7 +112,11 @@ function EditDiffRenderer({
           className="text-xs font-mono overflow-x-auto flex-1"
           style={{ color: 'hsl(var(--muted-foreground) / 0.7)' }}
         >
-          {path}{' '}
+          {onOpenFile ? (
+            <ClickableFilePath path={path} onClick={onOpenFile} className="text-xs font-mono" />
+          ) : (
+            path
+          )}{' '}
           <span style={{ color: 'hsl(var(--console-success))' }}>
             +{additions}
           </span>{' '}

--- a/frontend/src/components/NormalizedConversation/FileChangeRenderer.tsx
+++ b/frontend/src/components/NormalizedConversation/FileChangeRenderer.tsx
@@ -13,11 +13,13 @@ import EditDiffRenderer from './EditDiffRenderer';
 import FileContentView from './FileContentView';
 import '@/styles/diff-style-overrides.css';
 import { useExpandable } from '@/stores/useExpandableStore';
+import { ClickableFilePath } from '@/components/ui/ClickableFilePath';
 
 type Props = {
   path: string;
   change: FileChange;
   expansionKey: string;
+  onOpenFile?: (path: string, line?: number) => void;
 };
 
 function isWrite(
@@ -41,7 +43,7 @@ function isEdit(
   return change?.action === 'edit';
 }
 
-const FileChangeRenderer = ({ path, change, expansionKey }: Props) => {
+const FileChangeRenderer = ({ path, change, expansionKey, onOpenFile }: Props) => {
   const { config } = useConfig();
   const [expanded, setExpanded] = useExpandable(expansionKey, false);
 
@@ -56,6 +58,7 @@ const FileChangeRenderer = ({ path, change, expansionKey }: Props) => {
         unifiedDiff={change.unified_diff}
         hasLineNumbers={change.has_line_numbers}
         expansionKey={expansionKey}
+        onOpenFile={onOpenFile}
       />
     );
   }
@@ -72,7 +75,11 @@ const FileChangeRenderer = ({ path, change, expansionKey }: Props) => {
         titleNode: (
           <p className={commonTitleClass} style={commonTitleStyle}>
             <Trash2 className="h-3 w-3 inline mr-1.5" aria-hidden />
-            Delete <span className="ml-1">{path}</span>
+            Delete {onOpenFile ? (
+              <ClickableFilePath path={path} onClick={onOpenFile} className="ml-1" />
+            ) : (
+              <span className="ml-1">{path}</span>
+            )}
           </p>
         ),
         expandable: false,
@@ -84,9 +91,17 @@ const FileChangeRenderer = ({ path, change, expansionKey }: Props) => {
         titleNode: (
           <p className={commonTitleClass} style={commonTitleStyle}>
             <ArrowLeftRight className="h-3 w-3 inline mr-1.5" aria-hidden />
-            Rename <span className="ml-1">{path}</span>{' '}
+            Rename {onOpenFile ? (
+              <ClickableFilePath path={path} onClick={onOpenFile} className="ml-1" />
+            ) : (
+              <span className="ml-1">{path}</span>
+            )}{' '}
             <ArrowRight className="h-3 w-3 inline mx-1" aria-hidden />{' '}
-            <span>{change.new_path}</span>
+            {onOpenFile ? (
+              <ClickableFilePath path={change.new_path} onClick={onOpenFile} />
+            ) : (
+              <span>{change.new_path}</span>
+            )}
           </p>
         ),
         expandable: false,
@@ -97,7 +112,11 @@ const FileChangeRenderer = ({ path, change, expansionKey }: Props) => {
       return {
         titleNode: (
           <p className={commonTitleClass} style={commonTitleStyle}>
-            Write to <span className="ml-1">{path}</span>
+            Write to {onOpenFile ? (
+              <ClickableFilePath path={path} onClick={onOpenFile} className="ml-1" />
+            ) : (
+              <span className="ml-1">{path}</span>
+            )}
           </p>
         ),
         expandable: true,

--- a/frontend/src/components/tasks/TaskDetails/DiffTab.tsx
+++ b/frontend/src/components/tasks/TaskDetails/DiffTab.tsx
@@ -8,9 +8,10 @@ import type { TaskAttempt } from 'shared/types';
 
 interface DiffTabProps {
   selectedAttempt: TaskAttempt | null;
+  onOpenFile: (path: string, line?: number) => void;
 }
 
-function DiffTab({ selectedAttempt }: DiffTabProps) {
+function DiffTab({ selectedAttempt, onOpenFile }: DiffTabProps) {
   const [loading, setLoading] = useState(true);
   const [collapsedIds, setCollapsedIds] = useState<Set<string>>(new Set());
   const { diffs, error } = useDiffEntries(selectedAttempt?.id ?? null, true);
@@ -113,7 +114,7 @@ function DiffTab({ selectedAttempt }: DiffTabProps) {
               diff={diff}
               expanded={!collapsedIds.has(id)}
               onToggle={() => toggle(id)}
-              selectedAttempt={selectedAttempt}
+              onOpenFile={onOpenFile}
             />
           );
         })}

--- a/frontend/src/components/tasks/TaskDetails/ProcessesTab.tsx
+++ b/frontend/src/components/tasks/TaskDetails/ProcessesTab.tsx
@@ -17,9 +17,12 @@ import { useProcessSelection } from '@/contexts/ProcessSelectionContext';
 
 interface ProcessesTabProps {
   attemptId?: string;
+  onOpenFile: (path: string, line?: number) => void;
 }
 
-function ProcessesTab({ attemptId }: ProcessesTabProps) {
+function ProcessesTab({ attemptId, onOpenFile }: ProcessesTabProps) {
+  // Note: onOpenFile is currently unused but kept for future enhancements
+  void onOpenFile; // Suppress unused parameter warning
   const { attemptData } = useAttemptExecution(attemptId);
   const { selectedProcessId, setSelectedProcessId } = useProcessSelection();
   const [loadingProcessId, setLoadingProcessId] = useState<string | null>(null);

--- a/frontend/src/components/ui/ClickableFilePath.tsx
+++ b/frontend/src/components/ui/ClickableFilePath.tsx
@@ -1,0 +1,71 @@
+import { useState } from 'react';
+import { cn } from '@/lib/utils';
+
+interface ClickableFilePathProps {
+  path: string;
+  line?: number;
+  onClick: (path: string, line?: number) => void;
+  disabled?: boolean;
+  className?: string;
+  children?: React.ReactNode;
+}
+
+export function ClickableFilePath({
+  path,
+  line,
+  onClick,
+  disabled = false,
+  className,
+  children,
+}: ClickableFilePathProps) {
+  const [loading, setLoading] = useState(false);
+
+  const handleClick = async (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    
+    if (disabled || loading) return;
+    
+    try {
+      setLoading(true);
+      await onClick(path, line);
+    } catch (error) {
+      console.error('Failed to open file:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const content = children ?? <code className="text-sm">{path}</code>;
+
+  return (
+    <button
+      onClick={handleClick}
+      disabled={disabled || loading}
+      className={cn(
+        'inline-flex items-center text-primary hover:text-primary/80',
+        'underline decoration-dotted hover:decoration-solid',
+        'transition-colors duration-150',
+        disabled && 'opacity-50 cursor-not-allowed',
+        loading && 'opacity-75',
+        className
+      )}
+      title={
+        disabled 
+          ? 'File no longer exists' 
+          : loading 
+          ? 'Opening...' 
+          : 'Click to open in IDE'
+      }
+    >
+      {loading ? (
+        <>
+          <span className="animate-spin mr-1 text-xs">⟳</span>
+          {content}
+        </>
+      ) : (
+        content
+      )}
+    </button>
+  );
+}


### PR DESCRIPTION
It should be possible to open a specific file in IDE. Currently you can open a project or task attempt.

Open file should be triggered:
- Diff view in conversation history
- Diff view in diffs tab
- Any conversation history tool that involves displaying a file path

The path itself should be clickable