### PR TITLE
Refactor docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,61 @@
+# Node modules
+**/node_modules
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+lerna-debug.log*
+
+# Build artifacts
+target/
+dist/
+build/
+*.tgz
+*.tar.gz
+
+# IDE and editor files
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS generated files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# Git
+.git/
+.gitignore
+
+# Docker
+Dockerfile*
+.dockerignore
+
+# Environment files
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# Logs
+logs/
+*.log
+
+# Runtime data
+pids/
+*.pid
+*.seed
+*.pid.lock
+
+# Coverage directory used by tools like istanbul
+coverage/
+
+# Temporary folders
+tmp/
+temp/

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,7 @@ WORKDIR /repos
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-    CMD wget --quiet --tries=1 --spider http://localhost:3000 || exit 1
+    CMD wget --quiet --tries=1 --spider "http://${HOST:-localhost}:${PORT:-3000}" || exit 1
 
 # Run the application
 ENTRYPOINT ["/sbin/tini", "--"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,37 +1,71 @@
-FROM node:18-alpine
+# Build stage
+FROM node:24-alpine AS builder
 
-# Install Rust and dependencies
-RUN apk add --no-cache curl build-base perl tini
+# Install build dependencies
+RUN apk add --no-cache \
+    curl \
+    build-base \
+    perl
+
+# Install Rust
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
 
 # Set working directory
 WORKDIR /app
 
-# Copy package files first for dependency caching
+# Copy package files for dependency caching
 COPY package*.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY frontend/package*.json ./frontend/
 COPY npx-cli/package*.json ./npx-cli/
 
-# Install pnpm and dependencies (cached if package files unchanged)
-RUN npm install -g pnpm
-RUN pnpm install
+# Install pnpm and dependencies
+RUN npm install -g pnpm && pnpm install
 
-COPY frontend/ ./frontend/
-COPY shared/ ./shared/
-RUN cd frontend && npm run build
+# Copy source code
+COPY . .
 
-# Copy Rust dependencies for cargo cache
-COPY backend/ ./backend/
-COPY Cargo.toml ./
-RUN cargo build --release --manifest-path backend/Cargo.toml
+# Build application
+RUN npm run generate-types
+RUN cd frontend && npm install && npm run build
+RUN cargo build --release --bin server
 
-# Expose port
+# Runtime stage
+FROM alpine:latest AS runtime
+
+# Install runtime dependencies
+RUN apk add --no-cache \
+    ca-certificates \
+    tini \
+    libgcc \
+    wget
+
+# Create app user for security
+RUN addgroup -g 1001 -S appgroup && \
+    adduser -u 1001 -S appuser -G appgroup
+
+# Copy binary from builder
+COPY --from=builder /app/target/release/server /usr/local/bin/server
+
+# Create repos directory and set permissions
+RUN mkdir -p /repos && \
+    chown -R appuser:appgroup /repos
+
+# Switch to non-root user
+USER appuser
+
+# Set runtime environment
 ENV HOST=0.0.0.0
 ENV PORT=3000
 EXPOSE 3000
 
-# Run the application
+# Set working directory
 WORKDIR /repos
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+    CMD wget --quiet --tries=1 --spider http://localhost:3000 || exit 1
+
+# Run the application
 ENTRYPOINT ["/sbin/tini", "--"]
-CMD ["/app/target/release/vibe-kanban"]
+CMD ["server"]


### PR DESCRIPTION
This pull request improves the container builds.

- Refactored the Dockerfile
	- Build the application as part of the Docker build, rather than depending on the external host having to build the frontend/backend, then copying those into an image which does not contain the build environment
	- Use a multi-stage build for smaller and more secure images
	- Fix the broken entrypoint cmd
	- Updated NodeJS base image from the old, unmaintained version v18 to the current stable v24
	- Run as a non-privileged user
- Added `.dockerignore`