### PR TITLE
chore: make agent terminology more consistent

### DIFF
--- a/frontend/src/components/OnboardingDialog.tsx
+++ b/frontend/src/components/OnboardingDialog.tsx
@@ -84,7 +84,7 @@ export function OnboardingDialog({ open, onComplete }: OnboardingDialogProps) {
             Choose Your Coding Agent
           </h2>
           <div className="space-y-2">
-            <Label htmlFor="profile">Default Profile</Label>
+            <Label htmlFor="profile">Default Agent</Label>
             <div className="flex gap-2">
               <Select
                 value={profile.executor}

--- a/frontend/src/components/projects/project-form-fields.tsx
+++ b/frontend/src/components/projects/project-form-fields.tsx
@@ -413,7 +413,7 @@ export function ProjectFormFields({
             />
             <p className="text-sm text-muted-foreground">
               This script will run after creating the worktree and before the
-              executor starts. Use it for setup tasks like installing
+              coding agent starts. Use it for setup tasks like installing
               dependencies or preparing the environment.
             </p>
           </div>

--- a/frontend/src/components/tasks/AttemptHeaderCard.tsx
+++ b/frontend/src/components/tasks/AttemptHeaderCard.tsx
@@ -65,7 +65,7 @@ export function AttemptHeaderCard({
           {attemptNumber}/{totalAttempts}
         </p>
         <p>
-          <span className="text-secondary-foreground">Profile &middot; </span>
+          <span className="text-secondary-foreground">Agent &middot; </span>
           {selectedAttempt?.executor}
         </p>
         {selectedAttempt?.branch && (

--- a/frontend/src/components/tasks/TaskDetails/ProcessesTab.tsx
+++ b/frontend/src/components/tasks/TaskDetails/ProcessesTab.tsx
@@ -159,7 +159,7 @@ function ProcessesTab({ attemptId }: ProcessesTabProps) {
                       )}
                       {
                         <p className="text-sm text-muted-foreground mt-1">
-                          Profile:{' '}
+                          Agent:{' '}
                           {process.executor_action.typ.type ===
                             'CodingAgentInitialRequest' ||
                           process.executor_action.typ.type ===

--- a/frontend/src/components/tasks/Toolbar/CurrentAttempt.tsx
+++ b/frontend/src/components/tasks/Toolbar/CurrentAttempt.tsx
@@ -388,7 +388,7 @@ function CurrentAttempt({
       <div className="grid grid-cols-2 gap-3 items-start @md:flex @md:items-start">
         <div className="min-w-0">
           <div className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-1">
-            Profile
+            Agent
           </div>
           <div className="text-sm font-medium">{selectedAttempt.executor}</div>
         </div>

--- a/frontend/src/pages/settings/AgentSettings.tsx
+++ b/frontend/src/pages/settings/AgentSettings.tsx
@@ -515,7 +515,7 @@ export function AgentSettings() {
             <div className="space-y-4">
               <div className="space-y-2">
                 <Label htmlFor="profiles-editor">
-                  Profiles Configuration (JSON)
+                  Agent Configuration (JSON)
                 </Label>
                 <JSONEditor
                   id="profiles-editor"
@@ -547,7 +547,7 @@ export function AgentSettings() {
                   {profilesSaving && (
                     <Loader2 className="mr-2 h-4 w-4 animate-spin" />
                   )}
-                  Save Executor Configurations
+                  Save Agent Configurations
                 </Button>
               </div>
             </div>

--- a/frontend/src/pages/settings/GeneralSettings.tsx
+++ b/frontend/src/pages/settings/GeneralSettings.tsx
@@ -191,7 +191,7 @@ export function GeneralSettings() {
         </CardHeader>
         <CardContent className="space-y-4">
           <div className="space-y-2">
-            <Label htmlFor="executor">Default Executor Profile</Label>
+            <Label htmlFor="executor">Default Agent Configuration</Label>
             <div className="grid grid-cols-2 gap-2">
               <Select
                 value={config.executor_profile?.executor ?? ''}
@@ -296,7 +296,7 @@ export function GeneralSettings() {
               })()}
             </div>
             <p className="text-sm text-muted-foreground">
-              Choose the default executor profile to use when creating a task
+              Choose the default agent configuration to use when creating a task
               attempt.
             </p>
           </div>


### PR DESCRIPTION
- `agent` over `executor`
- `configuration` over `profile`