### PR TITLE
Small fix: improve Release notes dialog

### DIFF
--- a/frontend/src/components/dialogs/global/ReleaseNotesDialog.tsx
+++ b/frontend/src/components/dialogs/global/ReleaseNotesDialog.tsx
@@ -7,7 +7,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
-import { ExternalLink, AlertCircle } from 'lucide-react';
+import { AlertCircle, ExternalLink } from 'lucide-react';
 import NiceModal, { useModal } from '@ebay/nice-modal-react';
 
 const RELEASE_NOTES_URL = 'https://vibekanban.com/release-notes';
@@ -29,6 +29,7 @@ export const ReleaseNotesDialog = NiceModal.create(() => {
     <Dialog
       open={modal.visible}
       onOpenChange={(open) => !open && modal.resolve()}
+      className="h-[calc(100%-4rem)]"
     >
       <DialogContent className="flex flex-col w-full h-full max-w-7xl max-h-[calc(100dvh-1rem)] p-0">
         <DialogHeader className="p-4 border-b flex-shrink-0">
@@ -57,7 +58,7 @@ export const ReleaseNotesDialog = NiceModal.create(() => {
         ) : (
           <iframe
             src={RELEASE_NOTES_URL}
-            className="flex-1 w-full border-0 min-h-[600px]"
+            className="flex-1 w-full border-0"
             sandbox="allow-scripts allow-same-origin allow-popups"
             referrerPolicy="no-referrer"
             title="Release Notes"


### PR DESCRIPTION
Currently, the dialogue overflows the page size and requires scrolling to get to the bottom button. This UI fix makes it fit nicely into the page window.

Before:
<img width="1507" height="832" alt="Screenshot 2025-09-09 at 13 02 15" src="https://github.com/user-attachments/assets/884c7eab-6810-4371-8e4a-75e19465b455" />
<img width="1511" height="838" alt="Screenshot 2025-09-09 at 13 02 28" src="https://github.com/user-attachments/assets/60ba4fd3-9fc8-41a0-bfa1-688b3569696a" />

After:
<img width="1511" height="836" alt="Screenshot 2025-09-09 at 13 05 58" src="https://github.com/user-attachments/assets/9f205b7b-dea0-42fb-9c5b-ab4db2c6b381" />
