### PR TITLE
Minor UI fixes for settings page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,20 +1,20 @@
 import { useEffect } from 'react';
 import {
   BrowserRouter,
+  Navigate,
   Route,
   Routes,
   useLocation,
-  Navigate,
 } from 'react-router-dom';
 import { Navbar } from '@/components/layout/navbar';
 import { Projects } from '@/pages/projects';
 import { ProjectTasks } from '@/pages/project-tasks';
 
 import {
-  SettingsLayout,
-  GeneralSettings,
   AgentSettings,
+  GeneralSettings,
   McpSettings,
+  SettingsLayout,
 } from '@/pages/settings/';
 import {
   UserSystemProvider,
@@ -132,7 +132,7 @@ function AppContent() {
 
             {showNavbar && <DevBanner />}
             {showNavbar && <Navbar />}
-            <div className="flex-1 h-full overflow-y-scroll">
+            <div className="flex-1 h-full overflow-y-scroll flex">
               <SentryRoutes>
                 <Route path="/" element={<Projects />} />
                 <Route path="/projects" element={<Projects />} />

--- a/frontend/src/components/ui/dropdown-menu.tsx
+++ b/frontend/src/components/ui/dropdown-menu.tsx
@@ -160,7 +160,7 @@ const DropdownMenuSeparator = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DropdownMenuPrimitive.Separator
     ref={ref}
-    className={cn('-mx-1 my-1 h-px bg-muted', className)}
+    className={cn('-mx-1 my-1 h-px bg-border', className)}
     {...props}
   />
 ));

--- a/frontend/src/pages/settings/AgentSettings.tsx
+++ b/frontend/src/pages/settings/AgentSettings.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import {
   Card,
   CardContent,
@@ -513,23 +513,25 @@ export function AgentSettings() {
                   </p>
                 </div>
               )}
-
-              {/* Save button for JSON editor mode */}
-              <div className="flex justify-end pt-4">
-                <Button
-                  onClick={handleSaveProfiles}
-                  disabled={!isDirty || profilesSaving || !!profilesError}
-                >
-                  {profilesSaving && (
-                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                  )}
-                  Save Agent Configurations
-                </Button>
-              </div>
             </div>
           )}
         </CardContent>
       </Card>
+
+      {/* Save button for JSON editor mode */}
+      <div className="sticky bottom-0 z-10 bg-background/80 backdrop-blur-sm border-t py-4">
+        <div className="flex justify-end">
+          <Button
+            onClick={handleSaveProfiles}
+            disabled={!isDirty || profilesSaving || !!profilesError}
+          >
+            {profilesSaving && (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            )}
+            Save Agent Configurations
+          </Button>
+        </div>
+      </div>
     </div>
   );
 }

--- a/frontend/src/pages/settings/GeneralSettings.tsx
+++ b/frontend/src/pages/settings/GeneralSettings.tsx
@@ -25,11 +25,11 @@ import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Checkbox } from '@/components/ui/checkbox';
 import { ChevronDown, Key, Loader2, Volume2 } from 'lucide-react';
 import {
-  ThemeMode,
-  EditorType,
-  SoundFile,
-  ExecutorProfileId,
   BaseCodingAgent,
+  EditorType,
+  ExecutorProfileId,
+  SoundFile,
+  ThemeMode,
 } from 'shared/types';
 
 import { toPrettyCase } from '@/utils/string';
@@ -564,7 +564,7 @@ export function GeneralSettings() {
       </Card>
 
       {/* Sticky Save Button */}
-      <div className="sticky bottom-0 z-10 bg-background/80 backdrop-blur-sm border-t pt-4">
+      <div className="sticky bottom-0 z-10 bg-background/80 backdrop-blur-sm border-t py-4">
         <div className="flex justify-end">
           <Button onClick={handleSave} disabled={saving}>
             {saving && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}

--- a/frontend/src/pages/settings/McpSettings.tsx
+++ b/frontend/src/pages/settings/McpSettings.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import {
   Card,
   CardContent,
@@ -18,8 +18,8 @@ import { Label } from '@/components/ui/label';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { JSONEditor } from '@/components/ui/json-editor';
 import { Loader2 } from 'lucide-react';
-import { McpConfig } from 'shared/types';
 import type { BaseCodingAgent, ExecutorConfig } from 'shared/types';
+import { McpConfig } from 'shared/types';
 import { useUserSystem } from '@/components/config-provider';
 import { mcpServersApi } from '@/lib/api';
 import { McpConfigStrategyGeneral } from '@/lib/mcp-strategies';
@@ -342,7 +342,7 @@ export function McpSettings() {
       </Card>
 
       {/* Sticky Save Button */}
-      <div className="sticky bottom-0 z-10 bg-background/80 backdrop-blur-sm border-t pt-4">
+      <div className="sticky bottom-0 z-10 bg-background/80 backdrop-blur-sm border-t py-4">
         <div className="flex justify-end">
           <Button
             onClick={handleApplyMcpServers}


### PR DESCRIPTION
- Made the Save button look the same on all settings pages
- Fixed double scroll on settings pages by making general app container flex (checked on projects and tasks pages and seems to be fine, but possibly needs another check)
- Fixed separator in navbar menu not showing up due to same colour as background