### PR TITLE
Fix frontend variant cycle (vibe-kanban)

### DIFF
--- a/frontend/src/lib/keyboard-shortcuts.ts
+++ b/frontend/src/lib/keyboard-shortcuts.ts
@@ -293,7 +293,9 @@ export function useVariantCyclingShortcut({
         const variantLabels = Object.keys(variants);
 
         // Find current index and cycle to next
-        const currentIndex = variantLabels.findIndex((v) => v === selectedVariant);
+        const currentIndex = variantLabels.findIndex(
+          (v) => v === selectedVariant
+        );
         const nextIndex = (currentIndex + 1) % variantLabels.length;
         const nextVariant = variantLabels[nextIndex];
 


### PR DESCRIPTION
When cycling through variants in the frontend, the default variant is twice in the cycle. Previously, default didn't exist and this logic hasn't yet been updated.