### PR TITLE
Navigate to fullscreen task (vibe-kanban)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,14 +1,9 @@
 import { useEffect } from 'react';
-import {
-  BrowserRouter,
-  Navigate,
-  Route,
-  Routes,
-  useLocation,
-} from 'react-router-dom';
+import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
 import { Navbar } from '@/components/layout/navbar';
 import { Projects } from '@/pages/projects';
 import { ProjectTasks } from '@/pages/project-tasks';
+import { useTaskViewManager } from '@/hooks/useTaskViewManager';
 
 import {
   AgentSettings,
@@ -38,9 +33,9 @@ const SentryRoutes = Sentry.withSentryReactRouterV6Routing(Routes);
 
 function AppContent() {
   const { config, updateAndSaveConfig, loading } = useUserSystem();
-  const location = useLocation();
+  const { isFullscreen } = useTaskViewManager();
 
-  const showNavbar = !location.pathname.endsWith('/full');
+  const showNavbar = !isFullscreen;
 
   useEffect(() => {
     let cancelled = false;
@@ -163,6 +158,10 @@ function AppContent() {
                 />
                 <Route
                   path="/projects/:projectId/tasks/:taskId/attempts/:attemptId/full"
+                  element={<ProjectTasks />}
+                />
+                <Route
+                  path="/projects/:projectId/tasks/:taskId/full"
                   element={<ProjectTasks />}
                 />
                 <Route

--- a/frontend/src/components/tasks/TaskDetailsHeader.tsx
+++ b/frontend/src/components/tasks/TaskDetailsHeader.tsx
@@ -11,6 +11,7 @@ import type { TaskWithAttemptStatus } from 'shared/types';
 import { TaskTitleDescription } from './TaskDetails/TaskTitleDescription';
 import { Card } from '../ui/card';
 import { statusBoardColors, statusLabels } from '@/utils/status-labels';
+import { useTaskViewManager } from '@/hooks/useTaskViewManager';
 
 interface TaskDetailsHeaderProps {
   task: TaskWithAttemptStatus;
@@ -19,7 +20,6 @@ interface TaskDetailsHeaderProps {
   onDeleteTask?: (taskId: string) => void;
   hideCloseButton?: boolean;
   isFullScreen?: boolean;
-  setFullScreen?: (isFullScreen: boolean) => void;
 }
 
 // backgroundColor: `hsl(var(${statusBoardColors[task.status]}) / 0.03)`,
@@ -31,8 +31,8 @@ function TaskDetailsHeader({
   onDeleteTask,
   hideCloseButton = false,
   isFullScreen,
-  setFullScreen,
 }: TaskDetailsHeaderProps) {
+  const { toggleFullscreen } = useTaskViewManager();
   return (
     <div>
       <Card
@@ -49,37 +49,35 @@ function TaskDetailsHeader({
           <p className="ml-2 text-sm">{statusLabels[task.status]}</p>
         </div>
         <div className="mr-3">
-          {setFullScreen && (
-            <TooltipProvider>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    onClick={() => setFullScreen(!isFullScreen)}
-                    aria-label={
-                      isFullScreen
-                        ? 'Collapse to sidebar'
-                        : 'Expand to fullscreen'
-                    }
-                  >
-                    {isFullScreen ? (
-                      <Minimize2 className="h-4 w-4" />
-                    ) : (
-                      <Maximize2 className="h-4 w-4" />
-                    )}
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>
-                  <p>
-                    {isFullScreen
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={() => toggleFullscreen(!isFullScreen)}
+                  aria-label={
+                    isFullScreen
                       ? 'Collapse to sidebar'
-                      : 'Expand to fullscreen'}
-                  </p>
-                </TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
-          )}
+                      : 'Expand to fullscreen'
+                  }
+                >
+                  {isFullScreen ? (
+                    <Minimize2 className="h-4 w-4" />
+                  ) : (
+                    <Maximize2 className="h-4 w-4" />
+                  )}
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>
+                <p>
+                  {isFullScreen
+                    ? 'Collapse to sidebar'
+                    : 'Expand to fullscreen'}
+                </p>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
           {onEditTask && (
             <TooltipProvider>
               <Tooltip>

--- a/frontend/src/components/tasks/TaskDetailsPanel.tsx
+++ b/frontend/src/components/tasks/TaskDetailsPanel.tsx
@@ -22,6 +22,7 @@ import { ReviewProvider } from '@/contexts/ReviewProvider';
 import { AttemptHeaderCard } from './AttemptHeaderCard';
 import { inIframe } from '@/vscode/bridge';
 import { TaskRelationshipViewer } from './TaskRelationshipViewer';
+import { useTaskViewManager } from '@/hooks/useTaskViewManager.ts';
 
 interface TaskDetailsPanelProps {
   task: TaskWithAttemptStatus | null;
@@ -36,13 +37,13 @@ interface TaskDetailsPanelProps {
   className?: string;
   hideHeader?: boolean;
   isFullScreen?: boolean;
-  setFullScreen?: (value: boolean) => void;
   forceCreateAttempt?: boolean;
   onLeaveForceCreateAttempt?: () => void;
   onNewAttempt?: () => void;
   selectedAttempt: TaskAttempt | null;
   attempts: TaskAttempt[];
   setSelectedAttempt: (attempt: TaskAttempt | null) => void;
+  tasksById?: Record<string, TaskWithAttemptStatus>;
 }
 
 export function TaskDetailsPanel({
@@ -57,12 +58,12 @@ export function TaskDetailsPanel({
   hideBackdrop = false,
   className,
   isFullScreen,
-  setFullScreen,
   forceCreateAttempt,
   onLeaveForceCreateAttempt,
   selectedAttempt,
   attempts,
   setSelectedAttempt,
+  tasksById,
 }: TaskDetailsPanelProps) {
   // Attempt number, find the current attempt number
   const attemptNumber =
@@ -73,8 +74,10 @@ export function TaskDetailsPanel({
   const [activeTab, setActiveTab] = useState<TabType>('logs');
 
   // Handler for jumping to diff tab in full screen
+  const { toggleFullscreen } = useTaskViewManager();
+
   const jumpToDiffFullScreen = () => {
-    setFullScreen?.(true);
+    toggleFullscreen(true);
     setActiveTab('diffs');
   };
 
@@ -137,7 +140,6 @@ export function TaskDetailsPanel({
                       onDeleteTask={onDeleteTask}
                       hideCloseButton={hideBackdrop}
                       isFullScreen={isFullScreen}
-                      setFullScreen={setFullScreen}
                     />
                   )}
 
@@ -172,6 +174,8 @@ export function TaskDetailsPanel({
                         <TaskRelationshipViewer
                           selectedAttempt={selectedAttempt}
                           onNavigateToTask={onNavigateToTask}
+                          task={task}
+                          tasksById={tasksById}
                         />
                       </aside>
 

--- a/frontend/src/hooks/useAttemptCreation.ts
+++ b/frontend/src/hooks/useAttemptCreation.ts
@@ -1,13 +1,14 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import { attemptsApi } from '@/lib/api';
+import { useTaskViewManager } from '@/hooks/useTaskViewManager';
 import type { TaskAttempt } from 'shared/types';
 import type { ExecutorProfileId } from 'shared/types';
 
 export function useAttemptCreation(taskId: string) {
   const queryClient = useQueryClient();
-  const navigate = useNavigate();
   const { projectId } = useParams<{ projectId: string }>();
+  const { navigateToAttempt } = useTaskViewManager();
 
   const mutation = useMutation({
     mutationFn: ({
@@ -31,10 +32,7 @@ export function useAttemptCreation(taskId: string) {
 
       // Navigate to new attempt (triggers polling switch)
       if (projectId) {
-        navigate(
-          `/projects/${projectId}/tasks/${taskId}/attempts/${newAttempt.id}`,
-          { replace: true }
-        );
+        navigateToAttempt(projectId, taskId, newAttempt.id);
       }
     },
   });

--- a/frontend/src/hooks/useTaskMutations.ts
+++ b/frontend/src/hooks/useTaskMutations.ts
@@ -1,6 +1,6 @@
-import { useNavigate } from 'react-router-dom';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { tasksApi } from '@/lib/api';
+import { useTaskViewManager } from '@/hooks/useTaskViewManager';
 import type {
   CreateTask,
   CreateAndStartTaskRequest,
@@ -10,8 +10,8 @@ import type {
 } from 'shared/types';
 
 export function useTaskMutations(projectId?: string) {
-  const navigate = useNavigate();
   const queryClient = useQueryClient();
+  const { navigateToTask } = useTaskViewManager();
 
   const invalidateQueries = (taskId?: string) => {
     queryClient.invalidateQueries({ queryKey: ['tasks', projectId] });
@@ -24,9 +24,9 @@ export function useTaskMutations(projectId?: string) {
     mutationFn: (data: CreateTask) => tasksApi.create(data),
     onSuccess: (createdTask: Task) => {
       invalidateQueries();
-      navigate(`/projects/${projectId}/tasks/${createdTask.id}`, {
-        replace: true,
-      });
+      if (projectId) {
+        navigateToTask(projectId, createdTask.id);
+      }
     },
     onError: (err) => {
       console.error('Failed to create task:', err);
@@ -38,9 +38,9 @@ export function useTaskMutations(projectId?: string) {
       tasksApi.createAndStart(data),
     onSuccess: (createdTask: TaskWithAttemptStatus) => {
       invalidateQueries();
-      navigate(`/projects/${projectId}/tasks/${createdTask.id}`, {
-        replace: true,
-      });
+      if (projectId) {
+        navigateToTask(projectId, createdTask.id);
+      }
     },
     onError: (err) => {
       console.error('Failed to create and start task:', err);

--- a/frontend/src/hooks/useTaskViewManager.ts
+++ b/frontend/src/hooks/useTaskViewManager.ts
@@ -1,0 +1,89 @@
+import { useCallback } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+
+interface NavigateOptions {
+  attemptId?: string;
+  fullscreen?: boolean;
+  replace?: boolean;
+  state?: unknown;
+}
+
+/**
+ * Centralised hook for task routing and fullscreen controls
+ * Exposes navigation helpers alongside fullscreen state/toggles
+ */
+export function useTaskViewManager() {
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const isFullscreen = location.pathname.endsWith('/full');
+
+  const toggleFullscreen = useCallback(
+    (fullscreen: boolean) => {
+      const currentPath = location.pathname;
+      let targetPath: string;
+
+      if (fullscreen) {
+        targetPath = currentPath.endsWith('/full')
+          ? currentPath
+          : `${currentPath}/full`;
+      } else {
+        targetPath = currentPath.endsWith('/full')
+          ? currentPath.slice(0, -5)
+          : currentPath;
+      }
+
+      navigate(targetPath, { replace: true });
+    },
+    [location.pathname, navigate]
+  );
+
+  const buildTaskUrl = useCallback(
+    (projectId: string, taskId: string, options?: NavigateOptions) => {
+      const baseUrl = `/projects/${projectId}/tasks/${taskId}`;
+      const attemptUrl = options?.attemptId
+        ? `/attempts/${options.attemptId}`
+        : '';
+      const fullscreenSuffix =
+        (options?.fullscreen ?? isFullscreen) ? '/full' : '';
+
+      return `${baseUrl}${attemptUrl}${fullscreenSuffix}`;
+    },
+    [isFullscreen]
+  );
+
+  const navigateToTask = useCallback(
+    (projectId: string, taskId: string, options?: NavigateOptions) => {
+      const targetUrl = buildTaskUrl(projectId, taskId, options);
+
+      navigate(targetUrl, {
+        replace: options?.replace ?? true,
+        state: options?.state,
+      });
+    },
+    [buildTaskUrl, navigate]
+  );
+
+  const navigateToAttempt = useCallback(
+    (
+      projectId: string,
+      taskId: string,
+      attemptId: string,
+      options?: Omit<NavigateOptions, 'attemptId'>
+    ) => {
+      navigateToTask(projectId, taskId, {
+        ...options,
+        attemptId,
+      });
+    },
+    [navigateToTask]
+  );
+
+  return {
+    isFullscreen,
+    toggleFullscreen,
+    buildTaskUrl,
+    navigateToTask,
+    navigateToAttempt,
+  };
+}


### PR DESCRIPTION
Fullscreen state is now preserved at:
- New Attempt
- Create Subtask
- Navigate to child/parent task

Before this any of the above actions would leave fullscreen mode.