### PR TITLE
Print warning if not using anthropic subscription

### DIFF
--- a/crates/executors/src/executors/claude.rs
+++ b/crates/executors/src/executors/claude.rs
@@ -615,6 +615,25 @@ impl ClaudeLogProcessor {
         }
     }
 
+    /// Generate warning entry if API key source is not managed
+    fn warn_if_unmanaged_key(src: &Option<String>) -> Option<NormalizedEntry> {
+        match src.as_deref() {
+            Some("/login managed key") | None => None,
+            Some(other) => {
+                tracing::warn!("apiKeySource '{}' is not managed – potential unexpected billing", other);
+                Some(NormalizedEntry {
+                    timestamp: None,
+                    entry_type: NormalizedEntryType::SystemMessage,
+                    content: format!(
+                        "⚠️  Using apiKeySource \"{}\" – calls will be billed to that key. Run `claude-code login` (or set `/login managed key`) if you want to route usage through the managed key.",
+                        other
+                    ),
+                    metadata: None,
+                })
+            }
+        }
+    }
+
     /// Convert Claude JSON to normalized entries
     fn normalize_entries(
         &mut self,
@@ -622,25 +641,46 @@ impl ClaudeLogProcessor {
         worktree_path: &str,
     ) -> Vec<NormalizedEntry> {
         match claude_json {
-            ClaudeJson::System { subtype, .. } => {
-                let content = match subtype.as_deref() {
+            ClaudeJson::System { subtype, api_key_source, .. } => {
+                let mut entries = Vec::new();
+
+                // 1) emit billing warning if required
+                if let Some(warning) = Self::warn_if_unmanaged_key(api_key_source) {
+                    entries.push(warning);
+                }
+
+                // 2) keep the existing behaviour for the normal system message
+                match subtype.as_deref() {
                     Some("init") => {
                         // Skip system init messages because it doesn't contain the actual model that will be used in assistant messages in case of claude-code-router.
                         // We'll send system initialized message with first assistant message that has a model field.
-                        return vec![];
+                        return entries; // only the warning (if any)
                     }
-                    Some(subtype) => format!("System: {subtype}"),
-                    None => "System message".to_string(),
-                };
+                    Some(subtype) => {
+                        let content = format!("System: {subtype}");
+                        entries.push(NormalizedEntry {
+                            timestamp: None,
+                            entry_type: NormalizedEntryType::SystemMessage,
+                            content,
+                            metadata: Some(
+                                serde_json::to_value(claude_json).unwrap_or(serde_json::Value::Null),
+                            ),
+                        });
+                    }
+                    None => {
+                        let content = "System message".to_string();
+                        entries.push(NormalizedEntry {
+                            timestamp: None,
+                            entry_type: NormalizedEntryType::SystemMessage,
+                            content,
+                            metadata: Some(
+                                serde_json::to_value(claude_json).unwrap_or(serde_json::Value::Null),
+                            ),
+                        });
+                    }
+                }
 
-                vec![NormalizedEntry {
-                    timestamp: None,
-                    entry_type: NormalizedEntryType::SystemMessage,
-                    content,
-                    metadata: Some(
-                        serde_json::to_value(claude_json).unwrap_or(serde_json::Value::Null),
-                    ),
-                }]
+                entries
             }
             ClaudeJson::Assistant { message, .. } => {
                 let mut entries = Vec::new();
@@ -1061,6 +1101,8 @@ pub enum ClaudeJson {
         cwd: Option<String>,
         tools: Option<Vec<serde_json::Value>>,
         model: Option<String>,
+        #[serde(default, rename = "apiKeySource")]
+        api_key_source: Option<String>,
     },
     #[serde(rename = "assistant")]
     Assistant {
@@ -1769,6 +1811,37 @@ mod tests {
         // ToolResult content items should be ignored (produce no entries) until proper support is added
         let entries = ClaudeLogProcessor::new().normalize_entries(&parsed, "");
         assert_eq!(entries.len(), 0);
+    }
+
+    #[test]
+    fn test_api_key_source_warning() {
+        // Test with non-managed API key source - should generate warning
+        let system_with_non_managed_key = r#"{"type":"system","subtype":"init","apiKeySource":"ANTHROPIC_API_KEY","session_id":"test123"}"#;
+        let parsed: ClaudeJson = serde_json::from_str(system_with_non_managed_key).unwrap();
+        let entries = ClaudeLogProcessor::new().normalize_entries(&parsed, "");
+        
+        assert_eq!(entries.len(), 1);
+        assert!(matches!(
+            entries[0].entry_type,
+            NormalizedEntryType::SystemMessage
+        ));
+        assert!(entries[0].content.contains("⚠️"));
+        assert!(entries[0].content.contains("ANTHROPIC_API_KEY"));
+        assert!(entries[0].content.contains("claude-code login"));
+
+        // Test with managed API key source - should not generate warning
+        let system_with_managed_key = r#"{"type":"system","subtype":"init","apiKeySource":"/login managed key","session_id":"test123"}"#;
+        let parsed_managed: ClaudeJson = serde_json::from_str(system_with_managed_key).unwrap();
+        let entries_managed = ClaudeLogProcessor::new().normalize_entries(&parsed_managed, "");
+        
+        assert_eq!(entries_managed.len(), 0); // No warning for managed key
+
+        // Test with missing apiKeySource - should not generate warning  
+        let system_no_key = r#"{"type":"system","subtype":"init","session_id":"test123"}"#;
+        let parsed_no_key: ClaudeJson = serde_json::from_str(system_no_key).unwrap();
+        let entries_no_key = ClaudeLogProcessor::new().normalize_entries(&parsed_no_key, "");
+        
+        assert_eq!(entries_no_key.len(), 0); // No warning when field is missing
     }
 
     #[test]

--- a/crates/executors/src/executors/claude.rs
+++ b/crates/executors/src/executors/claude.rs
@@ -625,7 +625,7 @@ impl ClaudeLogProcessor {
                 Some(NormalizedEntry {
                     timestamp: None,
                     entry_type: NormalizedEntryType::SystemMessage,
-                    content: "ANTHROPIC_API_KEY env variable detected, your Anthropic subscription is not being used".to_string(),
+                    content: "⚠️ ANTHROPIC_API_KEY env variable detected, your Anthropic subscription is not being used".to_string(),
                     metadata: None,
                 })
             }
@@ -1832,7 +1832,7 @@ mod tests {
         ));
         assert_eq!(
             entries[0].content,
-            "ANTHROPIC_API_KEY env variable detected, your Anthropic subscription is not being used"
+            "⚠️ ANTHROPIC_API_KEY env variable detected, your Anthropic subscription is not being used"
         );
 
         // Test with managed API key source - should not generate warning

--- a/crates/executors/src/executors/claude.rs
+++ b/crates/executors/src/executors/claude.rs
@@ -619,7 +619,9 @@ impl ClaudeLogProcessor {
     fn warn_if_unmanaged_key(src: &Option<String>) -> Option<NormalizedEntry> {
         match src.as_deref() {
             Some("ANTHROPIC_API_KEY") => {
-                tracing::warn!("ANTHROPIC_API_KEY env variable detected, your Anthropic subscription is not being used");
+                tracing::warn!(
+                    "ANTHROPIC_API_KEY env variable detected, your Anthropic subscription is not being used"
+                );
                 Some(NormalizedEntry {
                     timestamp: None,
                     entry_type: NormalizedEntryType::SystemMessage,
@@ -1818,38 +1820,41 @@ mod tests {
 
     #[test]
     fn test_api_key_source_warning() {
-    // Test with ANTHROPIC_API_KEY - should generate warning
+        // Test with ANTHROPIC_API_KEY - should generate warning
         let system_with_env_key = r#"{"type":"system","subtype":"init","apiKeySource":"ANTHROPIC_API_KEY","session_id":"test123"}"#;
         let parsed: ClaudeJson = serde_json::from_str(system_with_env_key).unwrap();
         let entries = ClaudeLogProcessor::new().normalize_entries(&parsed, "");
-        
+
         assert_eq!(entries.len(), 1);
         assert!(matches!(
             entries[0].entry_type,
             NormalizedEntryType::SystemMessage
         ));
-        assert_eq!(entries[0].content, "ANTHROPIC_API_KEY env variable detected, your Anthropic subscription is not being used");
+        assert_eq!(
+            entries[0].content,
+            "ANTHROPIC_API_KEY env variable detected, your Anthropic subscription is not being used"
+        );
 
         // Test with managed API key source - should not generate warning
-    let system_with_managed_key = r#"{"type":"system","subtype":"init","apiKeySource":"/login managed key","session_id":"test123"}"#;
+        let system_with_managed_key = r#"{"type":"system","subtype":"init","apiKeySource":"/login managed key","session_id":"test123"}"#;
         let parsed_managed: ClaudeJson = serde_json::from_str(system_with_managed_key).unwrap();
         let entries_managed = ClaudeLogProcessor::new().normalize_entries(&parsed_managed, "");
-        
+
         assert_eq!(entries_managed.len(), 0); // No warning for managed key
 
-        // Test with other apiKeySource values - should not generate warning  
-    let system_other_key = r#"{"type":"system","subtype":"init","apiKeySource":"OTHER_KEY","session_id":"test123"}"#;
+        // Test with other apiKeySource values - should not generate warning
+        let system_other_key = r#"{"type":"system","subtype":"init","apiKeySource":"OTHER_KEY","session_id":"test123"}"#;
         let parsed_other: ClaudeJson = serde_json::from_str(system_other_key).unwrap();
         let entries_other = ClaudeLogProcessor::new().normalize_entries(&parsed_other, "");
-        
+
         assert_eq!(entries_other.len(), 0); // No warning for other keys
 
-        // Test with missing apiKeySource - should not generate warning  
-    let system_no_key = r#"{"type":"system","subtype":"init","session_id":"test123"}"#;
-    let parsed_no_key: ClaudeJson = serde_json::from_str(system_no_key).unwrap();
-    let entries_no_key = ClaudeLogProcessor::new().normalize_entries(&parsed_no_key, "");
-    
-    assert_eq!(entries_no_key.len(), 0); // No warning when field is missing
+        // Test with missing apiKeySource - should not generate warning
+        let system_no_key = r#"{"type":"system","subtype":"init","session_id":"test123"}"#;
+        let parsed_no_key: ClaudeJson = serde_json::from_str(system_no_key).unwrap();
+        let entries_no_key = ClaudeLogProcessor::new().normalize_entries(&parsed_no_key, "");
+
+        assert_eq!(entries_no_key.len(), 0); // No warning when field is missing
     }
 
     #[test]


### PR DESCRIPTION
User can sometimes end up using their anthropic key inadvertently, rather than their Anthropic subscription