### PR TITLE
fix: send keyboard shortcut should queue when attempt is running

### DIFF
--- a/frontend/src/components/tasks/TaskFollowUpSection.tsx
+++ b/frontend/src/components/tasks/TaskFollowUpSection.tsx
@@ -1012,7 +1012,6 @@ export function TaskFollowUpSection({
                         !canSendFollowUp ||
                         isDraftLocked ||
                         !isDraftReady ||
-                        !followUpMessage.trim() ||
                         isSendingFollowUp
                       }
                       size="sm"
@@ -1153,7 +1152,6 @@ export function TaskFollowUpSection({
                           ? isUnqueuing
                           : !canSendFollowUp ||
                             !isDraftReady ||
-                            !followUpMessage.trim() ||
                             isQueuing ||
                             isUnqueuing ||
                             isDraftSending

--- a/frontend/src/components/tasks/TaskFollowUpSection.tsx
+++ b/frontend/src/components/tasks/TaskFollowUpSection.tsx
@@ -794,7 +794,11 @@ export function TaskFollowUpSection({
                     if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
                       e.preventDefault();
                       if (canSendFollowUp && !isSendingFollowUp) {
-                        onSendFollowUp();
+                        if (isAttemptRunning) {
+                          onQueue(); // Use queue when something is running
+                        } else {
+                          onSendFollowUp(); // Direct send when nothing is running
+                        }
                       }
                     } else if (e.key === 'Escape') {
                       // Clear input and auto-cancel queue


### PR DESCRIPTION
Before: Send keyboard shortcut ALWAYS starts follow-up, even when an attempt is running.

Now: Send keyboard shortcut queues the follow-up if an attempt is running, same behaviour as the send button