### PR TITLE
Fix: Exclude dev server from running process check

### DIFF
--- a/frontend/src/hooks/useConversationHistory.ts
+++ b/frontend/src/hooks/useConversationHistory.ts
@@ -157,10 +157,11 @@ export const useConversationHistory = ({
   };
 
   const getRunningExecutionProcesses = (): ExecutionProcess | null => {
-    // If more than one, throw an error
+    // Filter for running processes, excluding dev server and other non-agent processes
     const runningProcesses = executionProcesses?.current.filter(
-      (p) => p.status === 'running'
+      (p) => p.status === 'running' && p.run_reason !== 'devserver'
     );
+    // Only throw error if there are multiple agent processes running
     if (runningProcesses.length > 1) {
       throw new Error('More than one running execution process found');
     }


### PR DESCRIPTION
## Summary
This PR fixes an error that occurs when sending a message in the chat while a dev server is running.

Fixes #723

## Problem
When users have a dev server running and try to send a message in the task chat, the application crashes with:
```
Error: More than one running execution process found
```

This happens because the `getRunningExecutionProcesses` function counts both the dev server process and the agent process as running processes, triggering the error when it finds more than one.

## Solution
Modified the `getRunningExecutionProcesses` function in `useConversationHistory.ts` to exclude dev server processes from the count by filtering out processes where `run_reason === 'devserver'`.

The function now only considers actual agent processes when checking for multiple running processes, allowing the dev server to run in parallel with agent executions without causing conflicts.

## Test Plan
1. Open a task in full view
2. Start the dev server by clicking the "Dev" button
3. While dev server is running, send a message in the chat
4. Verify that no error occurs and the message is processed correctly
5. Confirm both the dev server and agent process can run simultaneously