### PR TITLE
GitHub action pre-release shouldn't depend on package lock (vibe-kanban)

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -105,7 +105,7 @@ jobs:
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
-          git add package.json package-lock.json npx-cli/package.json 
+          git add package.json pnpm-lock.yaml npx-cli/package.json 
           git add $(find . -name Cargo.toml) 
           git commit -m "chore: bump version to ${{ steps.version.outputs.new_version }}"
           git tag -a ${{ steps.version.outputs.new_tag }} -m "Release ${{ steps.version.outputs.new_tag }}"


### PR DESCRIPTION
We use PNPM instead