### PR TITLE
Raise log truncation limit to 100kb

### DIFF
--- a/crates/utils/src/stream_ext.rs
+++ b/crates/utils/src/stream_ext.rs
@@ -6,7 +6,7 @@ use tokio::time::{Duration, Instant, sleep_until};
 use crate::log_msg::LogMsg;
 
 const WINDOW_MS: u64 = 10;
-const WINDOW_LIMIT: usize = 10 * 1024; // 10 KiB per window
+const WINDOW_LIMIT: usize = 100 * 1024; // 100 KiB per window
 
 // helper that flushes buf + optional [truncated] marker
 fn flush_buf(


### PR DESCRIPTION
Noticing some legit logs are being truncated