### PR TITLE
docs: remove all references to /user-guide (vibe-kanban)

### DIFF
--- a/docs/configuration-customisation/agent-configurations.mdx
+++ b/docs/configuration-customisation/agent-configurations.mdx
@@ -205,11 +205,11 @@ MCP (Model Context Protocol) servers are configured separately under **Settings 
 </Note>
 
 <CardGroup cols={2}>
-<Card title="MCP Server Configuration" icon="server" href="/getting-started">
+<Card title="MCP Server Configuration" icon="server" href="/integrations/mcp-server-configuration">
   Configure MCP servers within Vibe Kanban for your coding agents
 </Card>
 
-<Card title="Vibe Kanban MCP Server" icon="plug" href="/getting-started">
+<Card title="Vibe Kanban MCP Server" icon="plug" href="/integrations/vibe-kanban-mcp-server">
   Connect external MCP clients to Vibe Kanban's MCP server
 </Card>
 </CardGroup>

--- a/docs/configuration-customisation/agent-configurations.mdx
+++ b/docs/configuration-customisation/agent-configurations.mdx
@@ -205,11 +205,11 @@ MCP (Model Context Protocol) servers are configured separately under **Settings 
 </Note>
 
 <CardGroup cols={2}>
-<Card title="MCP Server Configuration" icon="server" href="/user-guide/mcp-server-configuration">
+<Card title="MCP Server Configuration" icon="server" href="/getting-started">
   Configure MCP servers within Vibe Kanban for your coding agents
 </Card>
 
-<Card title="Vibe Kanban MCP Server" icon="plug" href="/user-guide/vibe-kanban-mcp-server">
+<Card title="Vibe Kanban MCP Server" icon="plug" href="/getting-started">
   Connect external MCP clients to Vibe Kanban's MCP server
 </Card>
 </CardGroup>

--- a/docs/configuration-customisation/global-settings.mdx
+++ b/docs/configuration-customisation/global-settings.mdx
@@ -49,7 +49,7 @@ Enable or disable telemetry data collection to help improve Vibe Kanban.
 
 Manage global task templates to accelerate task creation across all projects. Templates allow you to define reusable titles and descriptions for common tasks.
 
-<Card title="Learn more about task templates" icon="clone" href="/getting-started">
+<Card title="Learn more about task templates" icon="clone" href="/configuration-customisation/creating-task-templates">
   Complete guide to creating and managing task templates
 </Card>
 

--- a/docs/configuration-customisation/global-settings.mdx
+++ b/docs/configuration-customisation/global-settings.mdx
@@ -49,7 +49,7 @@ Enable or disable telemetry data collection to help improve Vibe Kanban.
 
 Manage global task templates to accelerate task creation across all projects. Templates allow you to define reusable titles and descriptions for common tasks.
 
-<Card title="Learn more about task templates" icon="clone" href="/user-guide/creating-task-templates">
+<Card title="Learn more about task templates" icon="clone" href="/getting-started">
   Complete guide to creating and managing task templates
 </Card>
 
@@ -57,7 +57,7 @@ Manage global task templates to accelerate task creation across all projects. Te
 
 Define and customise agent variants under **Settings → Agents**. Variants let you maintain multiple configurations for the same agent (for example, a Claude Code "PLAN" variant).
 
-<Card title="Agent Profiles & Variants" icon="robot" href="/user-guide/agent-configurations">
+<Card title="Agent Profiles & Variants" icon="robot" href="/configuration-customisation/agent-configurations">
   Detailed guide with examples for configuring agent variants
 </Card>
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -21,15 +21,15 @@ Vibe Kanban transforms how developers work with AI coding agents by providing:
     Integrate with 8+ popular AI coding agents via npx - no separate installation required
   </Card>
 
-  <Card title="Project Management" icon="folder" href="/getting-started">
+  <Card title="Project Management" icon="folder" href="/core-features/creating-projects">
     Organise your repositories with custom setup scripts and development workflows
   </Card>
 
-  <Card title="Task Tracking" icon="list-check" href="/getting-started">
+  <Card title="Task Tracking" icon="list-check" href="/core-features/creating-tasks">
     Create and manage coding tasks with templates, descriptions, and progress tracking
   </Card>
 
-  <Card title="Git Integration" icon="code-branch" href="/getting-started">
+  <Card title="Git Integration" icon="code-branch" href="/integrations/github-integration">
     Automatic branch creation, PR management, and GitHub status synchronisation
   </Card>
 </CardGroup>
@@ -45,7 +45,7 @@ Ready to get started? Follow our getting started guide to install and configure 
 ## Need Help?
 
 <CardGroup cols={2}>
-  <Card title="User Guide" icon="book" href="/getting-started">
+  <Card title="User Guide" icon="book" href="/core-features/creating-projects">
     Complete guides for creating projects, tasks, and working with coding agents
   </Card>
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -21,15 +21,15 @@ Vibe Kanban transforms how developers work with AI coding agents by providing:
     Integrate with 8+ popular AI coding agents via npx - no separate installation required
   </Card>
 
-  <Card title="Project Management" icon="folder" href="/user-guide/creating-projects">
+  <Card title="Project Management" icon="folder" href="/getting-started">
     Organise your repositories with custom setup scripts and development workflows
   </Card>
 
-  <Card title="Task Tracking" icon="list-check" href="/user-guide/creating-tasks">
+  <Card title="Task Tracking" icon="list-check" href="/getting-started">
     Create and manage coding tasks with templates, descriptions, and progress tracking
   </Card>
 
-  <Card title="Git Integration" icon="code-branch" href="/user-guide/github-integration">
+  <Card title="Git Integration" icon="code-branch" href="/getting-started">
     Automatic branch creation, PR management, and GitHub status synchronisation
   </Card>
 </CardGroup>
@@ -45,7 +45,7 @@ Ready to get started? Follow our getting started guide to install and configure 
 ## Need Help?
 
 <CardGroup cols={2}>
-  <Card title="User Guide" icon="book" href="/user-guide/creating-projects">
+  <Card title="User Guide" icon="book" href="/getting-started">
     Complete guides for creating projects, tasks, and working with coding agents
   </Card>
 


### PR DESCRIPTION
`/user-guide` is no longer a valid folder in docs.

docs/index.mdx
docs/configuration-customisation/global-settings.mdx 
docs/configuration-customisation/agent-configurations.mdx