### PR TITLE
add posthog to docs (vibe-kanban)

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -85,6 +85,12 @@
       "vscode"
     ]
   },
+  "integrations": {
+    "posthog": {
+      "apiKey": "phc_tUHOX3YsGW4d9cEKyIvxjrFDHTRQ8nCfzG65McGZEuC",
+      "apiHost": "https://eu.i.posthog.com"
+    }
+  },
   "footer": {
     "socials": {
       "github": "https://github.com/BloopAI/vibe-kanban"


### PR DESCRIPTION
PostHog analytics has been successfully added to your docs.json with your provided API key and EU endpoint. This will enable analytics tracking on your documentation site and disable the default Mintlify dashboard analytics.