### PR TITLE
Refactor TaskWithAttemptStatus (vibe-kanban)

### DIFF
--- a/crates/server/src/mcp/task_server.rs
+++ b/crates/server/src/mcp/task_server.rs
@@ -440,8 +440,8 @@ impl TaskServer {
                     .into_iter()
                     .map(|task| TaskSummary {
                         id: task.id.to_string(),
-                        title: task.title,
-                        description: task.description,
+                        title: task.title.clone(),
+                        description: task.description.clone(),
                         status: task_status_to_string(&task.status),
                         created_at: task.created_at.to_rfc3339(),
                         updated_at: task.updated_at.to_rfc3339(),

--- a/crates/server/src/routes/tasks.rs
+++ b/crates/server/src/routes/tasks.rs
@@ -195,14 +195,7 @@ pub async fn create_task_and_start(
 
     tracing::info!("Started execution process {}", execution_process.id);
     Ok(ResponseJson(ApiResponse::success(TaskWithAttemptStatus {
-        id: task.id,
-        title: task.title,
-        description: task.description,
-        project_id: task.project_id,
-        status: task.status,
-        parent_task_attempt: task.parent_task_attempt,
-        created_at: task.created_at,
-        updated_at: task.updated_at,
+        task,
         has_in_progress_attempt: true,
         has_merged_attempt: false,
         last_attempt_failed: false,

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -44,7 +44,7 @@ export type TaskStatus = "todo" | "inprogress" | "inreview" | "done" | "cancelle
 
 export type Task = { id: string, project_id: string, title: string, description: string | null, status: TaskStatus, parent_task_attempt: string | null, created_at: string, updated_at: string, };
 
-export type TaskWithAttemptStatus = { id: string, project_id: string, title: string, description: string | null, status: TaskStatus, parent_task_attempt: string | null, created_at: string, updated_at: string, has_in_progress_attempt: boolean, has_merged_attempt: boolean, last_attempt_failed: boolean, executor: string, };
+export type TaskWithAttemptStatus = { has_in_progress_attempt: boolean, has_merged_attempt: boolean, last_attempt_failed: boolean, executor: string, id: string, project_id: string, title: string, description: string | null, status: TaskStatus, parent_task_attempt: string | null, created_at: string, updated_at: string, };
 
 export type TaskRelationships = { parent_task: Task | null, current_attempt: TaskAttempt, children: Array<Task>, };
 


### PR DESCRIPTION
TaskWithAttemptStatus non-Task fields do not update correctly.

This causes an issue where tasks do not correctly show running/error state on the kanban board.