### PR TITLE
Fix no branch for empty repo

### DIFF
--- a/crates/services/src/services/git.rs
+++ b/crates/services/src/services/git.rs
@@ -177,11 +177,19 @@ impl GitService {
     pub fn ensure_main_branch_exists(&self, repo_path: &Path) -> Result<(), GitServiceError> {
         let repo = self.open_repo(repo_path)?;
 
-        // Only create initial commit if repository is empty
-        if repo.is_empty()? {
-            self.create_initial_commit(&repo)?;
+        match repo.branches(None) {
+            Ok(branches) => {
+                if branches.count() == 0 {
+                    // No branches exist - create initial commit on main branch
+                    self.create_initial_commit(&repo)?;
+                }
+            }
+            Err(e) => {
+                return Err(GitServiceError::InvalidRepository(format!(
+                    "Failed to list branches: {e}"
+                )));
+            }
         }
-
         Ok(())
     }
 


### PR DESCRIPTION
- When starting from an empty repo task attempt creation fails
- Fixed `ensure_main_branch_exists` to correctly detect empty repos