### PR TITLE
feat: tune down diff wait time

### DIFF
--- a/frontend/src/components/tasks/TaskDetails/DiffTab.tsx
+++ b/frontend/src/components/tasks/TaskDetails/DiffTab.tsx
@@ -35,14 +35,14 @@ function DiffTab({ selectedAttempt }: DiffTabProps) {
     }
   }, [diffs, loading]);
 
-  // If no diffs arrive within 7 seconds, stop showing the spinner
+  // If no diffs arrive within 3 seconds, stop showing the spinner
   useEffect(() => {
     if (!loading) return;
     const timer = setTimeout(() => {
       if (diffs.length === 0) {
         setLoading(false);
       }
-    }, 7000);
+    }, 3000);
     return () => clearTimeout(timer);
   }, [loading, diffs.length]);
 


### PR DESCRIPTION
diffs are faster, so we shouldn't have to wait 7 seconds before deciding that there have been no diffs