### PR TITLE
Deduplicate repos in discovery

### DIFF
--- a/crates/services/src/services/filesystem.rs
+++ b/crates/services/src/services/filesystem.rs
@@ -215,10 +215,15 @@ impl FilesystemService {
         for p in path.iter().skip(1) {
             walker_builder.add(p);
         }
+        let mut seen_dirs = HashSet::new();
         let mut git_repos: Vec<DirectoryEntry> = walker_builder
             .build()
             .filter_map(|entry| {
                 let entry = entry.ok()?;
+                if seen_dirs.contains(entry.path()) {
+                    return None;
+                }
+                seen_dirs.insert(entry.path().to_owned());
                 let name = entry.file_name().to_str()?;
                 if !entry.path().join(".git").exists() {
                     return None;


### PR DESCRIPTION
Some search paths for repo discovery can overlap, causing duplicate repos in the list.
Fix by adding deduplication to repo discovery.