### PR TITLE
Increase character limit for git branch ID generation to 16

### DIFF
--- a/crates/local-deployment/src/container.rs
+++ b/crates/local-deployment/src/container.rs
@@ -533,7 +533,7 @@ impl LocalContainerService {
 
     pub fn dir_name_from_task_attempt(attempt_id: &Uuid, task_title: &str) -> String {
         let task_title_id = git_branch_id(task_title);
-        format!("vk-{}-{}", short_uuid(attempt_id), task_title_id)
+        format!("{}-{}", short_uuid(attempt_id), task_title_id)
     }
 
     pub fn git_branch_from_task_attempt(attempt_id: &Uuid, task_title: &str) -> String {

--- a/crates/utils/src/text.rs
+++ b/crates/utils/src/text.rs
@@ -12,8 +12,8 @@ pub fn git_branch_id(input: &str) -> String {
     // 3. trim extra hyphens
     let trimmed = slug.trim_matches('-');
 
-    // 4. take up to 10 chars, then trim trailing hyphens again
-    let cut: String = trimmed.chars().take(10).collect();
+    // 4. take up to 16 chars, then trim trailing hyphens again
+    let cut: String = trimmed.chars().take(16).collect();
     cut.trim_end_matches('-').to_string()
 }
 


### PR DESCRIPTION
- branch/worktree name char limit 10 -> 16
- Remove `vk-` from worktree path