### PR TITLE
Soften useConversationHistory error

### DIFF
--- a/frontend/src/hooks/useConversationHistory.ts
+++ b/frontend/src/hooks/useConversationHistory.ts
@@ -44,7 +44,7 @@ interface UseConversationHistoryParams {
   onEntriesUpdated: OnEntriesUpdated;
 }
 
-interface UseConversationHistoryResult { }
+interface UseConversationHistoryResult {}
 
 const MIN_INITIAL_ENTRIES = 10;
 const REMAINING_BATCH_SIZE = 50;
@@ -176,9 +176,9 @@ export const useConversationHistory = ({
       .filter(
         (p) =>
           p.executionProcess.executor_action.typ.type ===
-          'CodingAgentFollowUpRequest' ||
+            'CodingAgentFollowUpRequest' ||
           p.executionProcess.executor_action.typ.type ===
-          'CodingAgentInitialRequest'
+            'CodingAgentInitialRequest'
       )
       .sort(
         (a, b) =>
@@ -219,9 +219,9 @@ export const useConversationHistory = ({
         const entries: PatchTypeWithKey[] = [];
         if (
           p.executionProcess.executor_action.typ.type ===
-          'CodingAgentInitialRequest' ||
+            'CodingAgentInitialRequest' ||
           p.executionProcess.executor_action.typ.type ===
-          'CodingAgentFollowUpRequest'
+            'CodingAgentFollowUpRequest'
         ) {
           // New user message
           const userNormalizedEntry: NormalizedEntry = {
@@ -279,9 +279,9 @@ export const useConversationHistory = ({
             executionProcess?.status === 'running'
               ? null
               : {
-                type: 'exit_code',
-                code: exitCode,
-              };
+                  type: 'exit_code',
+                  code: exitCode,
+                };
 
           const toolStatus: ToolStatus =
             executionProcess?.status === 'running'


### PR DESCRIPTION
There are situations where we might run into `More than one running execution process found` error, I don't fully understand why, but it seems unnecessary to throw an error so let's change this to print the error and we can measure in sentry