### PR TITLE
feat: implement automatic PR discovery and attachment for task attempts

### DIFF
--- a/crates/db/src/models/merge.rs
+++ b/crates/db/src/models/merge.rs
@@ -124,6 +124,7 @@ impl Merge {
         target_branch_name: &str,
         pr_number: i64,
         pr_url: &str,
+        pr_status: MergeStatus,
     ) -> Result<PrMerge, sqlx::Error> {
         let id = Uuid::new_v4();
         let now = Utc::now();
@@ -132,8 +133,8 @@ impl Merge {
             MergeRow,
             r#"INSERT INTO merges (
                 id, task_attempt_id, merge_type, pr_number, pr_url, pr_status, created_at, target_branch_name
-            ) VALUES ($1, $2, 'pr', $3, $4, 'open', $5, $6)
-            RETURNING 
+            ) VALUES ($1, $2, 'pr', $3, $4, $5, $6, $7)
+            RETURNING
                 id as "id!: Uuid",
                 task_attempt_id as "task_attempt_id!: Uuid",
                 merge_type as "merge_type!: MergeType",
@@ -150,6 +151,7 @@ impl Merge {
             task_attempt_id,
             pr_number,
             pr_url,
+            pr_status,
             now,
             target_branch_name
         )

--- a/crates/server/src/routes/task_attempts.rs
+++ b/crates/server/src/routes/task_attempts.rs
@@ -1245,6 +1245,7 @@ pub async fn create_github_pr(
                 &norm_base_branch_name,
                 pr_info.number,
                 &pr_info.url,
+                MergeStatus::Open,
             )
             .await
             {
@@ -1715,6 +1716,132 @@ pub async fn stop_task_attempt_execution(
     Ok(ResponseJson(ApiResponse::success(())))
 }
 
+#[derive(Debug, Serialize, TS)]
+pub struct AttachPrResponse {
+    pub pr_attached: bool,
+    pub pr_url: Option<String>,
+    pub pr_number: Option<i64>,
+    pub pr_status: Option<MergeStatus>,
+}
+
+pub async fn attach_existing_pr(
+    Extension(task_attempt): Extension<TaskAttempt>,
+    State(deployment): State<DeploymentImpl>,
+) -> Result<ResponseJson<ApiResponse<AttachPrResponse>>, ApiError> {
+    let pool = &deployment.db().pool;
+
+    // Check if PR already attached
+    if let Some(existing_merge) = Merge::find_by_task_attempt_id(pool, task_attempt.id).await? {
+        return Ok(ResponseJson(ApiResponse::success(AttachPrResponse {
+            pr_attached: true,
+            pr_url: Some(existing_merge.pr_info.url.clone()),
+            pr_number: Some(existing_merge.pr_info.number),
+            pr_status: Some(existing_merge.pr_info.status.clone()),
+        })));
+    }
+
+    // Get branch name
+    let Some(branch_name) = &task_attempt.branch else {
+        return Ok(ResponseJson(ApiResponse::success(AttachPrResponse {
+            pr_attached: false,
+            pr_url: None,
+            pr_number: None,
+            pr_status: None,
+        })));
+    };
+
+    // Get GitHub token
+    let github_config = deployment.config().read().await.github.clone();
+    let Some(github_token) = github_config.token() else {
+        return Ok(ResponseJson(ApiResponse::error_with_data(
+            GitHubServiceError::TokenInvalid,
+        )));
+    };
+
+    // Get project and repo info
+    let Some(task) = task_attempt.parent_task(pool).await? else {
+        return Err(ApiError::TaskAttempt(TaskAttemptError::TaskNotFound));
+    };
+    let Some(project) = Project::find_by_id(pool, task.project_id).await? else {
+        return Err(ApiError::Project(ProjectError::NotFound));
+    };
+
+    let github_service = GitHubService::new(&github_token)?;
+    let repo_info = deployment
+        .git()
+        .get_github_repo_info(&project.git_repo_path)?;
+
+    // List PRs for branch (including closed/merged)
+    let prs = github_service
+        .list_prs_for_branch(&repo_info, branch_name)
+        .await?;
+
+    // Take the first PR (prefer open, but also accept merged/closed)
+    if let Some(pr_info) = prs.into_iter().next() {
+        // Save PR info to database
+        Merge::create_pr(
+            pool,
+            task_attempt.id,
+            &task_attempt.base_branch,
+            pr_info.number,
+            &pr_info.url,
+            pr_info.status.clone(),
+        )
+        .await?;
+
+        // If PR is merged, mark task as done
+        if matches!(pr_info.status, MergeStatus::Merged) {
+            Task::update_status(pool, task.id, TaskStatus::Done).await?;
+        }
+
+        Ok(ResponseJson(ApiResponse::success(AttachPrResponse {
+            pr_attached: true,
+            pr_url: Some(pr_info.url),
+            pr_number: Some(pr_info.number),
+            pr_status: Some(pr_info.status),
+        })))
+    } else {
+        // No PR found, but let's also check for closed/merged PRs
+        // by searching all PRs (not just open ones)
+        let all_prs = github_service
+            .list_all_prs_for_branch(&repo_info, branch_name)
+            .await
+            .unwrap_or_default();
+
+        if let Some(pr_info) = all_prs.into_iter().next() {
+            // Save PR info to database
+            Merge::create_pr(
+                pool,
+                task_attempt.id,
+                &task_attempt.base_branch,
+                pr_info.number,
+                &pr_info.url,
+                pr_info.status.clone(),
+            )
+            .await?;
+
+            // If PR is merged, mark task as done
+            if matches!(pr_info.status, MergeStatus::Merged) {
+                Task::update_status(pool, task.id, TaskStatus::Done).await?;
+            }
+
+            Ok(ResponseJson(ApiResponse::success(AttachPrResponse {
+                pr_attached: true,
+                pr_url: Some(pr_info.url),
+                pr_number: Some(pr_info.number),
+                pr_status: Some(pr_info.status),
+            })))
+        } else {
+            Ok(ResponseJson(ApiResponse::success(AttachPrResponse {
+                pr_attached: false,
+                pr_url: None,
+                pr_number: None,
+                pr_status: None,
+            })))
+        }
+    }
+}
+
 pub fn router(deployment: &DeploymentImpl) -> Router<DeploymentImpl> {
     let task_attempt_id_router = Router::new()
         .route("/", get(get_task_attempt))
@@ -1736,6 +1863,7 @@ pub fn router(deployment: &DeploymentImpl) -> Router<DeploymentImpl> {
         .route("/rebase", post(rebase_task_attempt))
         .route("/conflicts/abort", post(abort_conflicts_task_attempt))
         .route("/pr", post(create_github_pr))
+        .route("/pr/attach", post(attach_existing_pr))
         .route("/open-editor", post(open_task_attempt_in_editor))
         .route("/delete-file", post(delete_task_attempt_file))
         .route("/children", get(get_task_attempt_children))

--- a/crates/services/src/services/github_service.rs
+++ b/crates/services/src/services/github_service.rs
@@ -323,6 +323,118 @@ impl GitHubService {
         }
     }
 
+    /// List pull requests for a branch
+    pub async fn list_prs_for_branch(
+        &self,
+        repo_info: &GitHubRepoInfo,
+        branch_name: &str,
+    ) -> Result<Vec<PullRequestInfo>, GitHubServiceError> {
+        (|| async { self.list_prs_for_branch_internal(repo_info, branch_name).await })
+            .retry(
+                &ExponentialBuilder::default()
+                    .with_min_delay(Duration::from_secs(1))
+                    .with_max_delay(Duration::from_secs(30))
+                    .with_max_times(3)
+                    .with_jitter(),
+            )
+            .when(|e| e.should_retry())
+            .notify(|err: &GitHubServiceError, dur: Duration| {
+                tracing::warn!(
+                    "GitHub API call failed, retrying after {:.2}s: {}",
+                    dur.as_secs_f64(),
+                    err
+                );
+            })
+            .await
+    }
+
+    async fn list_prs_for_branch_internal(
+        &self,
+        repo_info: &GitHubRepoInfo,
+        branch_name: &str,
+    ) -> Result<Vec<PullRequestInfo>, GitHubServiceError> {
+        let prs = self
+            .client
+            .pulls(&repo_info.owner, &repo_info.repo_name)
+            .list()
+            .state(octocrab::params::State::Open)
+            .head(format!("{}:{}", repo_info.owner, branch_name))
+            .per_page(100)
+            .send()
+            .await
+            .map_err(|err| match GitHubServiceError::from(err) {
+                GitHubServiceError::Client(source) => GitHubServiceError::PullRequest(format!(
+                    "Failed to list PRs for branch '{}': {}",
+                    branch_name, source
+                )),
+                other => other,
+            })?;
+
+        let pr_infos = prs
+            .items
+            .into_iter()
+            .map(Self::map_pull_request)
+            .collect();
+
+        Ok(pr_infos)
+    }
+
+    /// List all pull requests for a branch (including closed/merged)
+    pub async fn list_all_prs_for_branch(
+        &self,
+        repo_info: &GitHubRepoInfo,
+        branch_name: &str,
+    ) -> Result<Vec<PullRequestInfo>, GitHubServiceError> {
+        (|| async { self.list_all_prs_for_branch_internal(repo_info, branch_name).await })
+            .retry(
+                &ExponentialBuilder::default()
+                    .with_min_delay(Duration::from_secs(1))
+                    .with_max_delay(Duration::from_secs(30))
+                    .with_max_times(3)
+                    .with_jitter(),
+            )
+            .when(|e| e.should_retry())
+            .notify(|err: &GitHubServiceError, dur: Duration| {
+                tracing::warn!(
+                    "GitHub API call failed, retrying after {:.2}s: {}",
+                    dur.as_secs_f64(),
+                    err
+                );
+            })
+            .await
+    }
+
+    async fn list_all_prs_for_branch_internal(
+        &self,
+        repo_info: &GitHubRepoInfo,
+        branch_name: &str,
+    ) -> Result<Vec<PullRequestInfo>, GitHubServiceError> {
+        let prs = self
+            .client
+            .pulls(&repo_info.owner, &repo_info.repo_name)
+            .list()
+            .state(octocrab::params::State::All)
+            .head(format!("{}:{}", repo_info.owner, branch_name))
+            .per_page(100)
+            .send()
+            .await
+            .map_err(|err| match GitHubServiceError::from(err) {
+                GitHubServiceError::Client(source) => GitHubServiceError::PullRequest(format!(
+                    "Failed to list all PRs for branch '{}': {}",
+                    branch_name, source
+                )),
+                other => other,
+            })?;
+
+        let pr_infos = prs
+            .items
+            .into_iter()
+            .map(Self::map_pull_request)
+            .collect();
+
+        Ok(pr_infos)
+    }
+
     /// List repositories for the authenticated user with pagination
     #[cfg(feature = "cloud")]
     pub async fn list_repositories(


### PR DESCRIPTION
## Summary
This PR enhances the functionality introduced in #837 by implementing automatic PR discovery and attachment for task attempts using the GitHub API.

## Changes
- **GitHub Service Enhancement**: Added methods to list PRs for a specific branch (both open and all states)
- **New API Endpoint**: `/task-attempts/{id}/pr/attach` that automatically discovers and attaches existing PRs
- **Automatic Task Completion**: Tasks are automatically marked as done when their attached PR is merged
- **Database Model Update**: Enhanced `Merge::create_pr()` to accept PR status parameter

## How It Works
1. When calling the `/pr/attach` endpoint for a task attempt:
   - Checks if a PR is already attached
   - Queries GitHub API for PRs associated with the branch
   - Attaches the first PR found (prioritizing open PRs)
   - Automatically marks the task as done if the PR is merged
   - Returns information about the attached PR

## Benefits
- Users can create PRs outside of Vibe Kanban (via CLI, VS Code, etc.) and still track them
- Tasks are automatically completed when their PRs are merged
- Navigate to PRs through Vibe Kanban even if created externally
- No need to manually input PR details - discovery happens automatically

## Improvements over #837
This implementation addresses the reviewer feedback from #837:
- ✅ Uses GitHub API to discover PRs automatically
- ✅ Checks PR status (open/closed/merged)
- ✅ Validates that the PR belongs to the task's branch
- ✅ Handles both open and closed/merged PRs appropriately

## Testing
The implementation has been tested with the API endpoint successfully discovering and attaching PRs. The code handles edge cases including:
- No PR exists for the branch
- PR already attached
- PR is merged (marks task as done)
- Multiple PRs exist (takes the first, preferring open ones)

Related to #837