### PR TITLE
Fix/kanban infinite horizontal dragging (2)

### DIFF
--- a/frontend/src/pages/project-tasks.tsx
+++ b/frontend/src/pages/project-tasks.tsx
@@ -521,7 +521,7 @@ export function ProjectTasks() {
               </Card>
             </div>
           ) : (
-            <div className="w-full h-full overflow-x-auto">
+            <div className="w-full h-full">
               <TaskKanbanBoard
                 groupedTasks={groupedFilteredTasks}
                 onDragEnd={handleDragEnd}

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "pnpm": ">=8"
   },
   "dependencies": {
-    "@ebay/nice-modal-react": "^1.2.13",
-    "lodash": "^4.17.21"
+    "lodash": "^4.17.21",
+    "@dnd-kit/utilities": "^3.2.2",
+    "@ebay/nice-modal-react": "^1.2.13"
   }
 }


### PR DESCRIPTION
Previously, if a card in the Kanban board was dragged to the far right edge of the screen, it would continue scrolling.
With this change, we introduce a variant of the `restrictToFirstScrollableAncestor` dnd-kit modifier (https://docs.dndkit.com/api-documentation/modifiers#restricttofirstscrollableancestor).
This modifier additionally limits the x delta of the dragged card by comparing the right edge of the card to the right edge of the scrollable ancestor and ensuring that it is at least 16 units.