### PR TITLE
Debug delete issue / refactor event deletion (vibe-kanban)

### DIFF
--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -14,7 +14,7 @@ serde_json = { workspace = true }
 anyhow = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
-sqlx = { version = "0.8.6", features = ["runtime-tokio-rustls", "sqlite", "chrono", "uuid"] }
+sqlx = { version = "0.8.6", features = ["runtime-tokio-rustls", "sqlite", "sqlite-preupdate-hook", "chrono", "uuid"] }
 chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1.0", features = ["v4", "serde"] }
 ts-rs = { workspace = true }

--- a/crates/local-deployment/Cargo.toml
+++ b/crates/local-deployment/Cargo.toml
@@ -17,7 +17,7 @@ serde_json = { workspace = true }
 anyhow = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
-sqlx = { version = "0.8.6", features = ["runtime-tokio-rustls", "sqlite", "chrono", "uuid"] }
+sqlx = { version = "0.8.6", features = ["runtime-tokio-rustls", "sqlite", "sqlite-preupdate-hook", "chrono", "uuid"] }
 chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1.0", features = ["v4", "serde"] }
 ts-rs = { workspace = true }

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -22,7 +22,7 @@ serde_json = { workspace = true }
 anyhow = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
-sqlx = { version = "0.8.6", features = ["runtime-tokio-rustls", "sqlite", "chrono", "uuid"] }
+sqlx = { version = "0.8.6", features = ["runtime-tokio-rustls", "sqlite", "sqlite-preupdate-hook", "chrono", "uuid"] }
 chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1.0", features = ["v4", "serde"] }
 ts-rs = { workspace = true }

--- a/crates/services/Cargo.toml
+++ b/crates/services/Cargo.toml
@@ -19,7 +19,7 @@ serde_json = { workspace = true }
 anyhow = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
-sqlx = { version = "0.8.6", features = ["runtime-tokio-rustls", "sqlite", "chrono", "uuid"] }
+sqlx = { version = "0.8.6", features = ["runtime-tokio-rustls", "sqlite", "sqlite-preupdate-hook", "chrono", "uuid"] }
 chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1.0", features = ["v4", "serde"] }
 ts-rs = { workspace = true }

--- a/crates/services/src/services/events.rs
+++ b/crates/services/src/services/events.rs
@@ -248,6 +248,40 @@ impl EventService {
             Box::pin(async move {
                 let mut handle = conn.lock_handle().await?;
                 let runtime_handle = tokio::runtime::Handle::current();
+                
+                // Set up preupdate hook to capture task data before deletion
+                handle.set_preupdate_hook({
+                    let msg_store_for_preupdate = msg_store_for_hook.clone();
+                    move |preupdate: sqlx::sqlite::PreUpdateHookResult<'_>| {
+                        if preupdate.table == "tasks" 
+                            && preupdate.operation == sqlx::sqlite::SqliteOperation::Delete {
+                            // Extract task ID and project ID from old row values before deletion
+                            if let (Ok(id_value), Ok(project_id_value)) = (
+                                preupdate.old(0), // id column 
+                                preupdate.old(1)  // project_id column
+                            ) {
+                                // Decode UUID from BLOB (16 bytes) or text format
+                                let decode_uuid = |value: sqlx::sqlite::SqliteValueRef| -> Option<uuid::Uuid> {
+                                    match value {
+                                        sqlx::sqlite::SqliteValueRef::Blob(bytes) if bytes.len() == 16 => {
+                                            uuid::Uuid::from_slice(bytes).ok()
+                                        },
+                                        sqlx::sqlite::SqliteValueRef::Text(text) => {
+                                            uuid::Uuid::parse_str(text).ok()
+                                        },
+                                        _ => None,
+                                    }
+                                };
+                                
+                                if let Some(task_id) = decode_uuid(id_value) {
+                                    let patch = task_patch::remove(task_id);
+                                    msg_store_for_preupdate.push_patch(patch);
+                                }
+                            }
+                        }
+                    }
+                });
+
                 handle.set_update_hook(move |hook: sqlx::sqlite::UpdateHookResult<'_>| {
                     let runtime_handle = runtime_handle.clone();
                     let entry_count_for_hook = entry_count_for_hook.clone();
@@ -412,12 +446,9 @@ impl EventService {
                                         return;
                                     }
                                 }
-                                RecordTypes::DeletedTask {
-                                    task_id: Some(task_id),
-                                    ..
-                                } => {
-                                    let patch = task_patch::remove(*task_id);
-                                    msg_store_for_hook.push_patch(patch);
+                                RecordTypes::DeletedTask { .. } => {
+                                    // Task deletion is now handled by preupdate hook to avoid None task_id issue
+                                    // Skip this case as patch was already sent from preupdate hook
                                     return;
                                 }
                                 RecordTypes::TaskAttempt(attempt) => {

--- a/crates/services/src/services/events.rs
+++ b/crates/services/src/services/events.rs
@@ -1,6 +1,7 @@
 use std::{str::FromStr, sync::Arc};
 
 use anyhow::Error as AnyhowError;
+use sqlx::ValueRef;
 use db::{
     DBService,
     models::{
@@ -252,34 +253,17 @@ impl EventService {
                 // Set up preupdate hook to capture task data before deletion
                 handle.set_preupdate_hook({
                     let msg_store_for_preupdate = msg_store_for_hook.clone();
-                    move |preupdate: sqlx::sqlite::PreUpdateHookResult<'_>| {
-                        if preupdate.table == "tasks"
-                            && preupdate.operation == sqlx::sqlite::SqliteOperation::Delete
-                        {
-                            // Extract task ID and project ID from old row values before deletion
-                            if let (Ok(id_value), Ok(project_id_value)) = (
-                                preupdate.old(0), // id column
-                                preupdate.old(1), // project_id column
-                            ) {
-                                // Decode UUID from BLOB (16 bytes) or text format
-                                let decode_uuid =
-                                    |value: sqlx::sqlite::SqliteValueRef| -> Option<uuid::Uuid> {
-                                        match value {
-                                            sqlx::sqlite::SqliteValueRef::Blob(bytes)
-                                                if bytes.len() == 16 =>
-                                            {
-                                                uuid::Uuid::from_slice(bytes).ok()
-                                            }
-                                            sqlx::sqlite::SqliteValueRef::Text(text) => {
-                                                uuid::Uuid::parse_str(text).ok()
-                                            }
-                                            _ => None,
-                                        }
-                                    };
-
-                                if let Some(task_id) = decode_uuid(id_value) {
-                                    let patch = task_patch::remove(task_id);
-                                    msg_store_for_preupdate.push_patch(patch);
+                    move |preupdate: sqlx::sqlite::PreupdateHookResult<'_>| {
+                        if preupdate.table == "tasks" 
+                            && preupdate.operation == sqlx::sqlite::SqliteOperation::Delete {
+                            // Extract task ID from old column values before deletion  
+                            if let Ok(id_value) = preupdate.get_old_column_value(0) {
+                                if !id_value.is_null() {
+                                    // Decode UUID from SQLite value
+                                    if let Ok(task_id) = <uuid::Uuid as sqlx::Decode<'_, sqlx::Sqlite>>::decode(id_value) {
+                                        let patch = task_patch::remove(task_id);
+                                        msg_store_for_preupdate.push_patch(patch);
+                                    }
                                 }
                             }
                         }

--- a/crates/services/src/services/events.rs
+++ b/crates/services/src/services/events.rs
@@ -412,7 +412,7 @@ impl EventService {
                                     }
                                 }
                                 _ => {
-                                    // Ignore other tables  
+                                    // Ignore other tables
                                 }
                             }
                         }
@@ -875,15 +875,16 @@ impl EventService {
                             else if let Ok(event_patch_value) = serde_json::to_value(patch_op)
                                 && let Ok(event_patch) =
                                     serde_json::from_value::<EventPatch>(event_patch_value)
-                                && let RecordTypes::ExecutionProcess(process) = &event_patch.value.record
-                                    && process.task_attempt_id == task_attempt_id {
-                                        if !show_soft_deleted && process.dropped {
-                                            let remove_patch =
-                                                execution_process_patch::remove(process.id);
-                                            return Some(Ok(LogMsg::JsonPatch(remove_patch)));
-                                        }
-                                        return Some(Ok(LogMsg::JsonPatch(patch)));
-                                    }
+                                && let RecordTypes::ExecutionProcess(process) =
+                                    &event_patch.value.record
+                                && process.task_attempt_id == task_attempt_id
+                            {
+                                if !show_soft_deleted && process.dropped {
+                                    let remove_patch = execution_process_patch::remove(process.id);
+                                    return Some(Ok(LogMsg::JsonPatch(remove_patch)));
+                                }
+                                return Some(Ok(LogMsg::JsonPatch(patch)));
+                            }
                         }
                         None
                     }

--- a/crates/services/src/services/events.rs
+++ b/crates/services/src/services/events.rs
@@ -741,21 +741,15 @@ impl EventService {
                             else if let Ok(event_patch_value) = serde_json::to_value(patch_op)
                                 && let Ok(event_patch) =
                                     serde_json::from_value::<EventPatch>(event_patch_value)
-                            {
-                                match &event_patch.value.record {
-                                    RecordTypes::ExecutionProcess(process) => {
-                                        if process.task_attempt_id == task_attempt_id {
-                                            if !show_soft_deleted && process.dropped {
-                                                let remove_patch =
-                                                    execution_process_patch::remove(process.id);
-                                                return Some(Ok(LogMsg::JsonPatch(remove_patch)));
-                                            }
-                                            return Some(Ok(LogMsg::JsonPatch(patch)));
+                                && let RecordTypes::ExecutionProcess(process) = &event_patch.value.record
+                                    && process.task_attempt_id == task_attempt_id {
+                                        if !show_soft_deleted && process.dropped {
+                                            let remove_patch =
+                                                execution_process_patch::remove(process.id);
+                                            return Some(Ok(LogMsg::JsonPatch(remove_patch)));
                                         }
+                                        return Some(Ok(LogMsg::JsonPatch(patch)));
                                     }
-                                    _ => {}
-                                }
-                            }
                         }
                         None
                     }

--- a/crates/services/src/services/events.rs
+++ b/crates/services/src/services/events.rs
@@ -891,18 +891,19 @@ impl EventService {
                             && let Ok(event_patch) =
                                 serde_json::from_value::<EventPatch>(event_patch_value)
                             && let RecordTypes::FollowUpDraft(draft) = &event_patch.value.record
-                                && draft.task_attempt_id == task_attempt_id {
-                                    // Build a direct patch to replace /follow_up_draft
-                                    let direct = json!([
-                                        {
-                                            "op": "replace",
-                                            "path": "/follow_up_draft",
-                                            "value": draft
-                                        }
-                                    ]);
-                                    let direct_patch = serde_json::from_value(direct).unwrap();
-                                    return Some(Ok(LogMsg::JsonPatch(direct_patch)));
+                            && draft.task_attempt_id == task_attempt_id
+                        {
+                            // Build a direct patch to replace /follow_up_draft
+                            let direct = json!([
+                                {
+                                    "op": "replace",
+                                    "path": "/follow_up_draft",
+                                    "value": draft
                                 }
+                            ]);
+                            let direct_patch = serde_json::from_value(direct).unwrap();
+                            return Some(Ok(LogMsg::JsonPatch(direct_patch)));
+                        }
                         None
                     }
                     Ok(other) => Some(Ok(other)),


### PR DESCRIPTION
Utilise the `sqlite-preupdate-hook` feature of SQLX to set a pre update hook for task deletion. This works around the fact that the post update hook only gets rowid, and if the task has been deleted then we can't lookup the ID to update the JSON meaning we'd fail to push delete patches for any entities in this file.

Original issue:

When a task is deleted, the DB hook runs this code: https://github.com/BloopAI/vibe-kanban/blob/3a68435f2a0c1eeebaa2ba729a8486e4d06473ea/crates/services/src/services/events.rs#L261-L270
But at this point, the task isn't in the DB so project_id and task_id  in the RecordTypes::DeletedTask struct are None and thus the pattern match responsible for generating the remove JSON patch doesn't fire.
https://github.com/BloopAI/vibe-kanban/blob/3a68435f2a0c1eeebaa2ba729a8486e4d06473ea/crates/services/src/services/events.rs#L415-L422
