### PR TITLE
pre fill token permissions using github token link format 

### DIFF
--- a/frontend/src/pages/settings/GeneralSettings.tsx
+++ b/frontend/src/pages/settings/GeneralSettings.tsx
@@ -527,7 +527,7 @@ export function GeneralSettings() {
             <p className="text-sm text-muted-foreground">
               {t('settings.general.github.pat.helper')}{' '}
               <a
-                href="https://github.com/settings/tokens"
+                href="https://github.com/settings/personal-access-tokens/new?name=Vibe+kanban+token&description=Token+for+creating+pull+requests+and+pushing+content&contents=write&actions=write&pull_requests=write"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="text-blue-600 hover:underline"


### PR DESCRIPTION
Github supports  [pre filling token permissions](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#pre-filling-fine-grained-personal-access-token-details-using-url-parameters) which is convenient to have when onboarding.  