### PR TITLE
Task template is missing a space (vibe-kanban)

### DIFF
--- a/crates/db/src/models/task.rs
+++ b/crates/db/src/models/task.rs
@@ -81,7 +81,7 @@ pub struct UpdateTask {
 impl Task {
     pub fn to_prompt(&self) -> String {
         if let Some(description) = self.description.as_ref().filter(|d| !d.trim().is_empty()) {
-            format!("Title: {}\n\nDescription:{}", &self.title, description)
+            format!("Title: {}\n\nDescription: {}", &self.title, description)
         } else {
             self.title.clone()
         }


### PR DESCRIPTION
Title:[SPACE][TITLE]
Description:[TITLE]

Should become
Title:[SPACE][TITLE]
Description:[SPACE][TITLE]
