### PR TITLE
Todos do not update when the user changes task attempt (vibe-kanban)

### DIFF
--- a/frontend/src/components/tasks/TaskDetailsPanel.tsx
+++ b/frontend/src/components/tasks/TaskDetailsPanel.tsx
@@ -97,7 +97,7 @@ export function TaskDetailsPanel({
         <TabNavContext.Provider value={{ activeTab, setActiveTab }}>
           <ProcessSelectionProvider>
             <ReviewProvider>
-              <EntriesProvider>
+              <EntriesProvider key={selectedAttempt?.id}>
                 {/* Backdrop - only on smaller screens (overlay mode) */}
                 {!hideBackdrop && (
                   <div


### PR DESCRIPTION
I have noticed that sometimes when I navigate from one task attempt to another, the todos from the previous attempt can still be displayed

frontend/src/components/tasks/TodoPanel.tsx