### PR TITLE
Use new sonnet models for the cursor agent profiles

### DIFF
--- a/crates/executors/default_profiles.json
+++ b/crates/executors/default_profiles.json
@@ -95,6 +95,12 @@
           "model": "sonnet-4.5"
         }
       },
+      "SONNET_4_5_THINKING": {
+        "CURSOR": {
+          "force": true,
+          "model": "sonnet-4.5-thinking"
+        }
+      },
       "OPUS_4_1": {
         "CURSOR": {
           "force": true,

--- a/crates/executors/default_profiles.json
+++ b/crates/executors/default_profiles.json
@@ -89,10 +89,10 @@
           "model": "auto"
         }
       },
-      "SONNET_4": {
+      "SONNET_4_5": {
         "CURSOR": {
           "force": true,
-          "model": "sonnet-4"
+          "model": "sonnet-4.5"
         }
       },
       "OPUS_4_1": {

--- a/crates/executors/src/executors/cursor.rs
+++ b/crates/executors/src/executors/cursor.rs
@@ -36,7 +36,7 @@ pub struct Cursor {
     #[schemars(description = "Force allow commands unless explicitly denied")]
     pub force: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[schemars(description = "auto, sonnet-4, gpt-5, opus-4.1, grok")]
+    #[schemars(description = "auto, sonnet-4.5, sonnet-4.5-thinking, gpt-5, opus-4.1, grok")]
     pub model: Option<String>,
     #[serde(flatten)]
     pub cmd: CmdOverrides,

--- a/shared/schemas/cursor.json
+++ b/shared/schemas/cursor.json
@@ -19,7 +19,7 @@
       ]
     },
     "model": {
-      "description": "auto, sonnet-4, gpt-5, opus-4.1, grok",
+      "description": "auto, sonnet-4.5, sonnet-4.5-thinking, gpt-5, opus-4.1, grok",
       "type": [
         "string",
         "null"


### PR DESCRIPTION
Error: `Cannot use this model: sonnet-4. Available models: auto, sonnet-4.5, sonnet-4.5-thinking, gpt-5, opus-4.1, grok`