### PR TITLE
fix claude code rotuer version

### DIFF
--- a/crates/executors/src/executors/claude.rs
+++ b/crates/executors/src/executors/claude.rs
@@ -41,7 +41,7 @@ const CONFIRM_HOOK_SCRIPT: &str = include_str!("./hooks/confirm.py");
 
 fn base_command(claude_code_router: bool) -> &'static str {
     if claude_code_router {
-        "npx -y @musistudio/claude-code-router@2.0.49 code"
+        "npx -y @musistudio/claude-code-router@1.0.49 code"
     } else {
         "npx -y @anthropic-ai/claude-code@2.0.1"
     }


### PR DESCRIPTION
2.0.49 is in not valid. 1.0.49 is. this is likely a minor typo