### PR TITLE
Add variant/config cycle keyboard shortcut (vibe-kanban)

### DIFF
--- a/frontend/src/components/tasks/follow-up/FollowUpEditorCard.tsx
+++ b/frontend/src/components/tasks/follow-up/FollowUpEditorCard.tsx
@@ -2,6 +2,7 @@ import { Loader2 } from 'lucide-react';
 import { FileSearchTextarea } from '@/components/ui/file-search-textarea';
 import { cn } from '@/lib/utils';
 import { useProject } from '@/contexts/project-context';
+import { useCallback } from 'react';
 
 type Props = {
   placeholder: string;
@@ -11,10 +12,9 @@ type Props = {
   disabled: boolean;
   // Loading overlay
   showLoadingOverlay: boolean;
-  onCommandEnter?: (e: React.KeyboardEvent<HTMLTextAreaElement>) => void;
-  onCommandShiftEnter?: (e: React.KeyboardEvent<HTMLTextAreaElement>) => void;
   onPasteFiles?: (files: File[]) => void;
   textareaClassName?: string;
+  onFocusChange?: (isFocused: boolean) => void;
 };
 
 export function FollowUpEditorCard({
@@ -24,12 +24,20 @@ export function FollowUpEditorCard({
   onKeyDown,
   disabled,
   showLoadingOverlay,
-  onCommandEnter,
-  onCommandShiftEnter,
   onPasteFiles,
   textareaClassName,
+  onFocusChange,
 }: Props) {
   const { projectId } = useProject();
+
+  const handleFocus = useCallback(() => {
+    onFocusChange?.(true);
+  }, [onFocusChange]);
+
+  const handleBlur = useCallback(() => {
+    onFocusChange?.(false);
+  }, [onFocusChange]);
+
   return (
     <div className="relative">
       <FileSearchTextarea
@@ -37,13 +45,13 @@ export function FollowUpEditorCard({
         value={value}
         onChange={onChange}
         onKeyDown={onKeyDown}
+        onFocus={handleFocus}
+        onBlur={handleBlur}
         className={cn('flex-1 min-h-[40px] resize-none', textareaClassName)}
         disabled={disabled}
         projectId={projectId}
         rows={1}
         maxRows={6}
-        onCommandEnter={onCommandEnter}
-        onCommandShiftEnter={onCommandShiftEnter}
         onPasteFiles={onPasteFiles}
       />
       {showLoadingOverlay && (

--- a/frontend/src/components/ui/auto-expanding-textarea.tsx
+++ b/frontend/src/components/ui/auto-expanding-textarea.tsx
@@ -3,90 +3,67 @@ import { cn } from '@/lib/utils';
 
 interface AutoExpandingTextareaProps extends React.ComponentProps<'textarea'> {
   maxRows?: number;
-  onCommandEnter?: (e: React.KeyboardEvent<HTMLTextAreaElement>) => void;
-  onCommandShiftEnter?: (e: React.KeyboardEvent<HTMLTextAreaElement>) => void;
 }
 
 const AutoExpandingTextarea = React.forwardRef<
   HTMLTextAreaElement,
   AutoExpandingTextareaProps
->(
-  (
-    { className, maxRows = 10, onCommandEnter, onCommandShiftEnter, ...props },
-    ref
-  ) => {
-    const internalRef = React.useRef<HTMLTextAreaElement>(null);
+>(({ className, maxRows = 10, ...props }, ref) => {
+  const internalRef = React.useRef<HTMLTextAreaElement>(null);
 
-    // Get the actual ref to use
-    const textareaRef = ref || internalRef;
+  // Get the actual ref to use
+  const textareaRef = ref || internalRef;
 
-    const adjustHeight = React.useCallback(() => {
-      const textarea = (textareaRef as React.RefObject<HTMLTextAreaElement>)
-        .current;
-      if (!textarea) return;
+  const adjustHeight = React.useCallback(() => {
+    const textarea = (textareaRef as React.RefObject<HTMLTextAreaElement>)
+      .current;
+    if (!textarea) return;
 
-      // Reset height to auto to get the natural height
-      textarea.style.height = 'auto';
+    // Reset height to auto to get the natural height
+    textarea.style.height = 'auto';
 
-      // Calculate line height
-      const style = window.getComputedStyle(textarea);
-      const lineHeight = parseInt(style.lineHeight) || 20;
-      const paddingTop = parseInt(style.paddingTop) || 0;
-      const paddingBottom = parseInt(style.paddingBottom) || 0;
+    // Calculate line height
+    const style = window.getComputedStyle(textarea);
+    const lineHeight = parseInt(style.lineHeight) || 20;
+    const paddingTop = parseInt(style.paddingTop) || 0;
+    const paddingBottom = parseInt(style.paddingBottom) || 0;
 
-      // Calculate max height based on maxRows
-      const maxHeight = lineHeight * maxRows + paddingTop + paddingBottom;
+    // Calculate max height based on maxRows
+    const maxHeight = lineHeight * maxRows + paddingTop + paddingBottom;
 
-      // Set the height to scrollHeight, but cap at maxHeight
-      const newHeight = Math.min(textarea.scrollHeight, maxHeight);
-      textarea.style.height = `${newHeight}px`;
-    }, [maxRows]);
+    // Set the height to scrollHeight, but cap at maxHeight
+    const newHeight = Math.min(textarea.scrollHeight, maxHeight);
+    textarea.style.height = `${newHeight}px`;
+  }, [maxRows]);
 
-    // Adjust height on mount and when content changes
-    React.useEffect(() => {
+  // Adjust height on mount and when content changes
+  React.useEffect(() => {
+    adjustHeight();
+  }, [adjustHeight, props.value]);
+
+  // Adjust height on input
+  const handleInput = React.useCallback(
+    (e: React.FormEvent<HTMLTextAreaElement>) => {
       adjustHeight();
-    }, [adjustHeight, props.value]);
+      if (props.onInput) {
+        props.onInput(e);
+      }
+    },
+    [adjustHeight, props.onInput]
+  );
 
-    // Handle keyboard shortcuts
-    const handleKeyDown = React.useCallback(
-      (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-        if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
-          if (e.metaKey && e.shiftKey) {
-            onCommandShiftEnter?.(e);
-          } else if (e.metaKey) {
-            onCommandEnter?.(e);
-          }
-        }
-        props.onKeyDown?.(e);
-      },
-      [onCommandEnter, onCommandShiftEnter, props.onKeyDown]
-    );
-
-    // Adjust height on input
-    const handleInput = React.useCallback(
-      (e: React.FormEvent<HTMLTextAreaElement>) => {
-        adjustHeight();
-        if (props.onInput) {
-          props.onInput(e);
-        }
-      },
-      [adjustHeight, props.onInput]
-    );
-
-    return (
-      <textarea
-        className={cn(
-          'bg-muted p-0 min-h-[80px] w-full text-sm outline-none disabled:cursor-not-allowed disabled:opacity-50 resize-none overflow-y-auto overflow-x-hidden whitespace-pre-wrap break-words',
-          className
-        )}
-        ref={textareaRef}
-        onInput={handleInput}
-        {...props}
-        onKeyDown={handleKeyDown}
-      />
-    );
-  }
-);
+  return (
+    <textarea
+      className={cn(
+        'bg-muted p-0 min-h-[80px] w-full text-sm outline-none disabled:cursor-not-allowed disabled:opacity-50 resize-none overflow-y-auto overflow-x-hidden whitespace-pre-wrap break-words',
+        className
+      )}
+      ref={textareaRef}
+      onInput={handleInput}
+      {...props}
+    />
+  );
+});
 
 AutoExpandingTextarea.displayName = 'AutoExpandingTextarea';
 

--- a/frontend/src/components/ui/file-search-textarea.tsx
+++ b/frontend/src/components/ui/file-search-textarea.tsx
@@ -19,9 +19,9 @@ interface FileSearchTextareaProps {
   projectId?: string;
   onKeyDown?: (e: React.KeyboardEvent) => void;
   maxRows?: number;
-  onCommandEnter?: (e: React.KeyboardEvent<HTMLTextAreaElement>) => void;
-  onCommandShiftEnter?: (e: React.KeyboardEvent<HTMLTextAreaElement>) => void;
   onPasteFiles?: (files: File[]) => void;
+  onFocus?: (e: React.FocusEvent<HTMLTextAreaElement>) => void;
+  onBlur?: (e: React.FocusEvent<HTMLTextAreaElement>) => void;
 }
 
 export function FileSearchTextarea({
@@ -32,10 +32,11 @@ export function FileSearchTextarea({
   disabled = false,
   className,
   projectId,
-  onCommandEnter,
-  onCommandShiftEnter,
+  onKeyDown,
   maxRows = 10,
   onPasteFiles,
+  onFocus,
+  onBlur,
 }: FileSearchTextareaProps) {
   const [searchQuery, setSearchQuery] = useState('');
   const [searchResults, setSearchResults] = useState<FileSearchResult[]>([]);
@@ -270,6 +271,9 @@ export function FileSearchTextarea({
           break;
       }
     }
+
+    // Propagate event to parent component for additional handling
+    onKeyDown?.(e);
   };
 
   return (
@@ -286,9 +290,9 @@ export function FileSearchTextarea({
         className={className}
         maxRows={maxRows}
         onKeyDown={handleKeyDown}
-        onCommandEnter={onCommandEnter}
-        onCommandShiftEnter={onCommandShiftEnter}
         onPaste={handlePaste}
+        onFocus={onFocus}
+        onBlur={onBlur}
       />
 
       {showDropdown &&

--- a/frontend/src/hooks/useKeyboardShortcut.ts
+++ b/frontend/src/hooks/useKeyboardShortcut.ts
@@ -63,6 +63,12 @@ export function useKeyboardShortcut(
   useHotkeys(
     keys,
     (event) => {
+      // Skip if IME composition is in progress (e.g., Japanese, Chinese, Korean input)
+      // This prevents shortcuts from firing when user is converting text with Enter
+      if (event.isComposing) {
+        return;
+      }
+
       const w = whenRef.current;
       const enabled = typeof w === 'function' ? !!w() : !!w;
       if (enabled) callbackRef.current?.(event as KeyboardEvent);

--- a/frontend/src/keyboard/hooks.ts
+++ b/frontend/src/keyboard/hooks.ts
@@ -108,3 +108,47 @@ export const useKeyApproveRequest = createSemanticHook(Action.APPROVE_REQUEST);
  * useKeyDenyApproval(() => denyPendingRequest(), { scope: Scope.GLOBAL });
  */
 export const useKeyDenyApproval = createSemanticHook(Action.DENY_APPROVAL);
+
+/**
+ * Cycle variant action - typically Shift+Tab
+ *
+ * @example
+ * useKeyCycleVariant(() => cycleToNextVariant(), { scope: Scope.FOLLOW_UP });
+ */
+export const useKeyCycleVariant = createSemanticHook(Action.CYCLE_VARIANT);
+
+/**
+ * Submit follow-up action - typically Cmd+Enter
+ * Intelligently sends or queues based on current state (running vs idle)
+ *
+ * @example
+ * useKeySubmitFollowUp(() => handleSubmit(), { scope: Scope.FOLLOW_UP_READY });
+ */
+export const useKeySubmitFollowUp = createSemanticHook(Action.SUBMIT_FOLLOW_UP);
+
+/**
+ * Submit task action - typically Cmd+Enter
+ * Primary submit action in task dialog (Create & Start or Update)
+ *
+ * @example
+ * useKeySubmitTask(() => handleSubmit(), { scope: Scope.DIALOG, when: canSubmit });
+ */
+export const useKeySubmitTask = createSemanticHook(Action.SUBMIT_TASK);
+
+/**
+ * Alternative task submit action - typically Cmd+Shift+Enter
+ * Secondary submit action in task dialog (Create Task without starting)
+ *
+ * @example
+ * useKeySubmitTaskAlt(() => handleCreateOnly(), { scope: Scope.DIALOG, when: canSubmit });
+ */
+export const useKeySubmitTaskAlt = createSemanticHook(Action.SUBMIT_TASK_ALT);
+
+/**
+ * Submit comment action - typically Cmd+Enter
+ * Submit review comment in diff view
+ *
+ * @example
+ * useKeySubmitComment(() => handleSave(), { scope: Scope.EDIT_COMMENT, when: hasContent });
+ */
+export const useKeySubmitComment = createSemanticHook(Action.SUBMIT_COMMENT);

--- a/frontend/src/keyboard/registry.ts
+++ b/frontend/src/keyboard/registry.ts
@@ -5,6 +5,8 @@ export enum Scope {
   PROJECTS = 'projects',
   EDIT_COMMENT = 'edit-comment',
   APPROVALS = 'approvals',
+  FOLLOW_UP = 'follow-up',
+  FOLLOW_UP_READY = 'follow-up-ready',
 }
 
 export enum Action {
@@ -22,6 +24,11 @@ export enum Action {
   DELETE_TASK = 'delete_task',
   APPROVE_REQUEST = 'approve_request',
   DENY_APPROVAL = 'deny_approval',
+  CYCLE_VARIANT = 'cycle_variant',
+  SUBMIT_FOLLOW_UP = 'submit_follow_up',
+  SUBMIT_TASK = 'submit_task',
+  SUBMIT_TASK_ALT = 'submit_task_alt',
+  SUBMIT_COMMENT = 'submit_comment',
 }
 
 export interface KeyBinding {
@@ -166,6 +173,43 @@ export const keyBindings: KeyBinding[] = [
     scopes: [Scope.APPROVALS],
     description: 'Deny pending approval request',
     group: 'Approvals',
+  },
+
+  // Follow-up actions
+  {
+    action: Action.CYCLE_VARIANT,
+    keys: 'shift+tab',
+    scopes: [Scope.FOLLOW_UP],
+    description: 'Cycle between agent configurations',
+    group: 'Follow-up',
+  },
+  {
+    action: Action.SUBMIT_FOLLOW_UP,
+    keys: 'meta+enter',
+    scopes: [Scope.FOLLOW_UP_READY],
+    description: 'Send or queue follow-up (depending on state)',
+    group: 'Follow-up',
+  },
+  {
+    action: Action.SUBMIT_TASK,
+    keys: ['meta+enter', 'ctrl+enter'],
+    scopes: [Scope.DIALOG],
+    description: 'Submit task form (Create & Start or Update)',
+    group: 'Dialog',
+  },
+  {
+    action: Action.SUBMIT_TASK_ALT,
+    keys: ['meta+shift+enter', 'ctrl+shift+enter'],
+    scopes: [Scope.DIALOG],
+    description: 'Submit task form (Create Task)',
+    group: 'Dialog',
+  },
+  {
+    action: Action.SUBMIT_COMMENT,
+    keys: ['meta+enter', 'ctrl+enter'],
+    scopes: [Scope.EDIT_COMMENT],
+    description: 'Submit review comment',
+    group: 'Comments',
   },
 ];
 


### PR DESCRIPTION
Add a shortcut to cycle between agent configurations (previously called profile variants) when typing a follow up. Should be active when the user is editing the follow-up text box.
User shift tab to trigger the shortcut.