### PR TITLE
No user deny messages in history (vibe-kanban)

### DIFF
--- a/crates/executors/src/executors/claude.rs
+++ b/crates/executors/src/executors/claude.rs
@@ -734,27 +734,24 @@ impl ClaudeLogProcessor {
                                             }
 
                                             // Check if this is a denial with user feedback (for both command and non-command tools)
-                                            if is_error.unwrap_or(false) {
-                                                if let Some(denial_reason) =
+                                            if is_error.unwrap_or(false)
+                                                && let Some(denial_reason) =
                                                     extract_denial_reason(content)
-                                                {
-                                                    let user_feedback = NormalizedEntry {
-                                                        timestamp: None,
-                                                        entry_type:
-                                                            NormalizedEntryType::UserFeedback {
-                                                                denied_tool: display_tool_name
-                                                                    .clone(),
-                                                            },
-                                                        content: denial_reason,
-                                                        metadata: None,
-                                                    };
-                                                    msg_store.push_patch(
-                                                        ConversationPatch::add_normalized_entry(
-                                                            entry_index_provider.next(),
-                                                            user_feedback,
-                                                        ),
-                                                    );
-                                                }
+                                            {
+                                                let user_feedback = NormalizedEntry {
+                                                    timestamp: None,
+                                                    entry_type: NormalizedEntryType::UserFeedback {
+                                                        denied_tool: display_tool_name.clone(),
+                                                    },
+                                                    content: denial_reason,
+                                                    metadata: None,
+                                                };
+                                                msg_store.push_patch(
+                                                    ConversationPatch::add_normalized_entry(
+                                                        entry_index_provider.next(),
+                                                        user_feedback,
+                                                    ),
+                                                );
                                             }
                                         }
                                     }

--- a/crates/executors/src/executors/claude.rs
+++ b/crates/executors/src/executors/claude.rs
@@ -233,12 +233,8 @@ async fn write_python_hook(current_dir: &Path) -> Result<(), ExecutorError> {
     tokio::fs::create_dir_all(&hooks_dir).await?;
     let hook_path = hooks_dir.join("confirm.py");
 
-    // Replace placeholder with actual marker value (single source of truth)
-    let script_content =
-        CONFIRM_HOOK_SCRIPT.replace("{{USER_FEEDBACK_MARKER}}", USER_FEEDBACK_MARKER);
-
     let mut file = tokio::fs::File::create(&hook_path).await?;
-    file.write_all(script_content.as_bytes()).await?;
+    file.write_all(CONFIRM_HOOK_SCRIPT.as_bytes()).await?;
     file.flush().await?;
 
     // TODO: Handle Windows permissioning
@@ -280,7 +276,7 @@ async fn settings_json(plan: bool) -> Result<String, std::io::Error> {
                     "hooks": [
                         {
                             "type": "command",
-                            "command": format!("$CLAUDE_PROJECT_DIR/.claude/hooks/confirm.py --timeout-seconds {backend_timeout} --poll-interval 5 --backend-port {backend_port}"),
+                            "command": format!("$CLAUDE_PROJECT_DIR/.claude/hooks/confirm.py --timeout-seconds {backend_timeout} --poll-interval 5 --backend-port {backend_port} --feedback-marker '{USER_FEEDBACK_MARKER}'"),
                             "timeout": backend_timeout + 10
                        }
                     ]

--- a/crates/executors/src/executors/claude.rs
+++ b/crates/executors/src/executors/claude.rs
@@ -334,16 +334,10 @@ fn extract_denial_reason(content: &serde_json::Value) -> Option<String> {
         content.to_string()
     };
 
-    // Look for our natural language marker and extract everything after it
-    if let Some(pos) = content_str.find(USER_FEEDBACK_MARKER) {
-        let after_marker = &content_str[pos + USER_FEEDBACK_MARKER.len()..];
-        let feedback = after_marker.trim();
-        if !feedback.is_empty() {
-            return Some(feedback.to_string());
-        }
-    }
-
-    None
+    content_str
+        .split_once(USER_FEEDBACK_MARKER)
+        .map(|(_, rest)| rest.trim().to_string())
+        .filter(|s| !s.is_empty())
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/executors/src/executors/hooks/confirm.py
+++ b/crates/executors/src/executors/hooks/confirm.py
@@ -10,11 +10,15 @@ from typing import Optional
 
 def json_error(reason: Optional[str]) -> None:
     """Emit a deny PreToolUse JSON to stdout and exit(0)."""
+    # Prefix user feedback with a natural language marker for extraction
+    # This marker is replaced at runtime by Rust code - do not modify directly
+    USER_FEEDBACK_MARKER = "{{USER_FEEDBACK_MARKER}}"
+    formatted_reason = f"{USER_FEEDBACK_MARKER}{reason}" if reason else None
     payload = {
         "hookSpecificOutput": {
             "hookEventName": "PreToolUse",
             "permissionDecision": "deny",
-            "permissionDecisionReason": reason,
+            "permissionDecisionReason": formatted_reason,
         }
     }
     print(json.dumps(payload, ensure_ascii=False))

--- a/crates/executors/src/executors/hooks/confirm.py
+++ b/crates/executors/src/executors/hooks/confirm.py
@@ -8,13 +8,18 @@ import urllib.request
 from typing import Optional
 
 
-def json_error(reason: Optional[str]) -> None:
+def json_error(reason: Optional[str], feedback_marker: Optional[str] = None) -> None:
     """Emit a deny PreToolUse JSON to stdout and exit(0)."""
+    # Prefix user feedback with marker for extraction if provided
+    formatted_reason = reason
+    if reason and feedback_marker:
+        formatted_reason = f"{feedback_marker}{reason}"
+
     payload = {
         "hookSpecificOutput": {
             "hookEventName": "PreToolUse",
             "permissionDecision": "deny",
-            "permissionDecisionReason": reason,
+            "permissionDecisionReason": formatted_reason,
         }
     }
     print(json.dumps(payload, ensure_ascii=False))
@@ -93,6 +98,13 @@ def parse_args() -> argparse.Namespace:
         required=True,
         help="Port of the approval backend running on 127.0.0.1.",
     )
+    parser.add_argument(
+        "-m",
+        "--feedback-marker",
+        type=str,
+        required=True,
+        help="Marker prefix for user feedback messages.",
+    )
     args = parser.parse_args()
 
     if args.timeout_seconds <= 0:
@@ -147,10 +159,7 @@ def main():
             json_success()
         elif status == "denied":
             reason = result.get("reason")
-            # Prefix user feedback with marker for extraction by Rust code
-            USER_FEEDBACK_MARKER = "{{USER_FEEDBACK_MARKER}}"
-            formatted_reason = f"{USER_FEEDBACK_MARKER}{reason}" if reason else None
-            json_error(formatted_reason)
+            json_error(reason, args.feedback_marker)
         elif status == "timed_out":
             # concat to avoid triggering the watchkill script
             json_error(

--- a/crates/executors/src/logs/mod.rs
+++ b/crates/executors/src/logs/mod.rs
@@ -52,6 +52,9 @@ pub struct NormalizedConversation {
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum NormalizedEntryType {
     UserMessage,
+    UserFeedback {
+        denied_tool: String,
+    },
     AssistantMessage,
     ToolUse {
         tool_name: String,

--- a/frontend/src/components/NormalizedConversation/DisplayConversationEntry.tsx
+++ b/frontend/src/components/NormalizedConversation/DisplayConversationEntry.tsx
@@ -600,6 +600,7 @@ function DisplayConversationEntry({
   executionProcessId,
   taskAttempt,
 }: Props) {
+  const { t } = useTranslation('common');
   const isNormalizedEntry = (
     entry: NormalizedEntry | ProcessStartPayload
   ): entry is NormalizedEntry => 'entry_type' in entry;
@@ -657,7 +658,9 @@ function DisplayConversationEntry({
             className="text-xs mb-1 opacity-70"
             style={{ color: 'hsl(var(--destructive))' }}
           >
-            {feedbackEntry.denied_tool} denied by user
+            {t('conversation.deniedByUser', {
+              toolName: feedbackEntry.denied_tool,
+            })}
           </div>
           <MarkdownRenderer
             content={entry.content}

--- a/frontend/src/components/NormalizedConversation/DisplayConversationEntry.tsx
+++ b/frontend/src/components/NormalizedConversation/DisplayConversationEntry.tsx
@@ -49,7 +49,7 @@ const renderJson = (v: JsonValue) => (
 
 const getEntryIcon = (entryType: NormalizedEntryType) => {
   const iconSize = 'h-3 w-3';
-  if (entryType.type === 'user_message') {
+  if (entryType.type === 'user_message' || entryType.type === 'user_feedback') {
     return <User className={iconSize} />;
   }
   if (entryType.type === 'assistant_message') {
@@ -630,6 +630,7 @@ function DisplayConversationEntry({
   const isError = entryType.type === 'error_message';
   const isToolUse = entryType.type === 'tool_use';
   const isUserMessage = entryType.type === 'user_message';
+  const isUserFeedback = entryType.type === 'user_feedback';
   const isLoading = entryType.type === 'loading';
   const isFileEdit = (a: ActionType): a is FileEditAction =>
     a.action === 'file_edit';
@@ -641,6 +642,29 @@ function DisplayConversationEntry({
         executionProcessId={executionProcessId}
         taskAttempt={taskAttempt}
       />
+    );
+  }
+
+  if (isUserFeedback) {
+    const feedbackEntry = entryType as Extract<
+      NormalizedEntryType,
+      { type: 'user_feedback' }
+    >;
+    return (
+      <div className="py-2">
+        <div className="bg-background px-4 py-2 text-sm border-y border-dashed">
+          <div
+            className="text-xs mb-1 opacity-70"
+            style={{ color: 'hsl(var(--destructive))' }}
+          >
+            {feedbackEntry.denied_tool} denied by user
+          </div>
+          <MarkdownRenderer
+            content={entry.content}
+            className="whitespace-pre-wrap break-words flex flex-col gap-1 font-light py-3"
+          />
+        </div>
+      </div>
     );
   }
   const renderToolUse = () => {

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -34,6 +34,7 @@
     },
     "args": "Args",
     "output": "Output",
-    "result": "Result"
+    "result": "Result",
+    "deniedByUser": "{{toolName}} denied by user"
   }
 }

--- a/frontend/src/i18n/locales/es/common.json
+++ b/frontend/src/i18n/locales/es/common.json
@@ -21,5 +21,8 @@
   },
   "language": {
     "browserDefault": "Predeterminado del navegador"
+  },
+  "conversation": {
+    "deniedByUser": "{{toolName}} denegado por el usuario"
   }
 }

--- a/frontend/src/i18n/locales/ja/common.json
+++ b/frontend/src/i18n/locales/ja/common.json
@@ -34,6 +34,7 @@
     },
     "args": "引数",
     "output": "出力",
-    "result": "結果"
+    "result": "結果",
+    "deniedByUser": "{{toolName}} がユーザーによって拒否されました"
   }
 }

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -284,7 +284,7 @@ export type CommandRunResult = { exit_status: CommandExitStatus | null, output: 
 
 export type NormalizedEntry = { timestamp: string | null, entry_type: NormalizedEntryType, content: string, };
 
-export type NormalizedEntryType = { "type": "user_message" } | { "type": "assistant_message" } | { "type": "tool_use", tool_name: string, action_type: ActionType, status: ToolStatus, } | { "type": "system_message" } | { "type": "error_message" } | { "type": "thinking" } | { "type": "loading" };
+export type NormalizedEntryType = { "type": "user_message" } | { "type": "user_feedback", denied_tool: string, } | { "type": "assistant_message" } | { "type": "tool_use", tool_name: string, action_type: ActionType, status: ToolStatus, } | { "type": "system_message" } | { "type": "error_message" } | { "type": "thinking" } | { "type": "loading" };
 
 export type FileChange = { "action": "write", content: string, } | { "action": "delete" } | { "action": "rename", new_path: string, } | { "action": "edit", 
 /**


### PR DESCRIPTION
When interacting with an approval and the users chooses to deny the request with feedback, the feedback text should be displayed as a user message. Currently it's not displayed