### PR TITLE
Fix: Prevent form submission during IME composition

### DIFF
--- a/frontend/src/components/ui/auto-expanding-textarea.tsx
+++ b/frontend/src/components/ui/auto-expanding-textarea.tsx
@@ -50,7 +50,7 @@ const AutoExpandingTextarea = React.forwardRef<
     // Handle keyboard shortcuts
     const handleKeyDown = React.useCallback(
       (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-        if (e.key === 'Enter') {
+        if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
           if (e.metaKey && e.shiftKey) {
             onCommandShiftEnter?.(e);
           } else if (e.metaKey) {

--- a/frontend/src/components/ui/input.tsx
+++ b/frontend/src/components/ui/input.tsx
@@ -23,7 +23,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       if (e.key === 'Escape') {
         e.currentTarget.blur();
       }
-      if (e.key === 'Enter') {
+      if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
         if (e.metaKey && e.shiftKey) {
           onCommandShiftEnter?.(e);
         } else {


### PR DESCRIPTION
This fix issue #919 where pressing Enter during IME (Input Method Editor) composition incorrectly triggers form submission in task title and description fields.

Changes:
- Add isComposing check to Input component's Enter key handler
- Add isComposing check to AutoExpandingTextarea component's Enter key handler

This ensures that Enter key during IME composition (e.g., Japanese, Chinese, Korean input) only confirms the text conversion without accidentally submitting the form.

Fixes #919