### PR TITLE
Markdown renderer bug (vibe-kanban)

### DIFF
--- a/frontend/src/components/ui/markdown-renderer.tsx
+++ b/frontend/src/components/ui/markdown-renderer.tsx
@@ -152,7 +152,7 @@ function MarkdownRenderer({
       },
       h2: {
         component: ({ children, ...props }: any) => (
-          <h2 {...props} className="text-baseleading-tight font-medium">
+          <h2 {...props} className="text-base leading-tight font-medium">
             {children}
           </h2>
         ),
@@ -244,7 +244,10 @@ function MarkdownRenderer({
         </div>
       )}
       <div className={className}>
-        <Markdown options={{ overrides }}>{content}</Markdown>
+        {/* Disable raw HTML parsing to prevent invalid ref attributes from being passed to DOM elements */}
+        <Markdown options={{ overrides, disableParsingRawHTML: true }}>
+          {content}
+        </Markdown>
       </div>
     </div>
   );

--- a/frontend/src/components/ui/markdown-renderer.tsx
+++ b/frontend/src/components/ui/markdown-renderer.tsx
@@ -244,7 +244,6 @@ function MarkdownRenderer({
         </div>
       )}
       <div className={className}>
-        {/* Disable raw HTML parsing to prevent invalid ref attributes from being passed to DOM elements */}
         <Markdown options={{ overrides, disableParsingRawHTML: true }}>
           {content}
         </Markdown>


### PR DESCRIPTION
Fix React error #284 in the markdown-renderer component by preventing invalid ref attributes from being passed to DOM elements. The issue occurs because markdown-to-jsx parses raw HTML in user content and forwards all attributes (including invalid ref values) to the override components, which then spread these props onto DOM elements. Create a safeDomProps helper function that strips React-reserved props (ref, key, dangerouslySetInnerHTML) and optionally event handlers before spreading props to DOM nodes. Apply this helper to all markdown overrides in the component (strong, em, p, h1, h2, h3, ul, ol, li, and the InlineCodeOverride function) by replacing {...props} with {...safeDomProps(props)}. While you're in the file, also fix the typo on line 155 where text-baseleading-tight should be text-base leading-tight. Alternatively, if raw HTML parsing isn't needed, consider adding disableParsingRawHTML: true to the Markdown options to prevent this issue at the source.