### PR TITLE
Tweak keyboard shortcuts, arrow keys + enter (vibe-kanban)

### DIFF
--- a/docs/configuration-customisation/keyboard-shortcuts.mdx
+++ b/docs/configuration-customisation/keyboard-shortcuts.mdx
@@ -25,10 +25,10 @@ These shortcuts work when a task card is highlighted with the blue focus ring:
 
 | Shortcut | Action | Description |
 |----------|--------|-------------|
-| `↑` / `↓` | Vertical Navigation | Move focus to previous/next task in the current column |
-| `←` / `→` | Horizontal Navigation | Move focus to first task in previous/next non-empty column |
-| `Enter` / `Space` | Open Task | Open the Task Details panel for the focused task |
-| `Backspace` | Delete Task | Delete the currently focused task |
+| `k` / `j` | Vertical Navigation | Move focus up/down within the current column |
+| `h` / `l` | Horizontal Navigation | Move focus to first task in previous/next non-empty column |
+| `Enter` | Open Task | Open the Task Details panel for the focused task |
+| `d` | Delete Task | Delete the currently focused task |
 
 ## Form Submission
 
@@ -39,6 +39,7 @@ These shortcuts work in various forms and dialogs:
 | `⌘/Ctrl + Enter` | Submit | Create & Start (Task Form), Save (Template Editor) |
 | `⌘/Ctrl + Enter` | Send | Send follow-up message in Task Details |
 | `⌘/Ctrl + Enter` | Save Comment | Add or save comment in Diff Review |
+| `⌘/Ctrl + Enter` | Toggle Fullscreen | Toggle fullscreen view in Task Details |
 | `Escape` | Cancel/Clear | Clear draft in follow-up, cancel comment editing |
 
 ## Search

--- a/frontend/src/keyboard/registry.ts
+++ b/frontend/src/keyboard/registry.ts
@@ -91,28 +91,28 @@ export const keyBindings: KeyBinding[] = [
   },
   {
     action: Action.NAV_UP,
-    keys: ['up', 'k'],
+    keys: 'k',
     scopes: [Scope.KANBAN],
     description: 'Move up within column',
     group: 'Navigation',
   },
   {
     action: Action.NAV_DOWN,
-    keys: ['down', 'j'],
+    keys: 'j',
     scopes: [Scope.KANBAN],
     description: 'Move down within column',
     group: 'Navigation',
   },
   {
     action: Action.NAV_LEFT,
-    keys: ['left', 'h'],
+    keys: 'h',
     scopes: [Scope.KANBAN],
     description: 'Move to previous column',
     group: 'Navigation',
   },
   {
     action: Action.NAV_RIGHT,
-    keys: ['right', 'l'],
+    keys: 'l',
     scopes: [Scope.KANBAN],
     description: 'Move to next column',
     group: 'Navigation',
@@ -137,7 +137,7 @@ export const keyBindings: KeyBinding[] = [
   // Task panel actions
   {
     action: Action.TOGGLE_FULLSCREEN,
-    keys: 'enter',
+    keys: ['meta+enter', 'ctrl+enter'],
     scopes: [Scope.KANBAN],
     description: 'Toggle fullscreen view',
     group: 'Task Details',


### PR DESCRIPTION
Arrow keys and enter conflict with too many browser defaults, eg submit or navigating a dropdown.

While technically solvable, usability isn't great if you think you have something selected but it's not, and it's too easy to accidentally navigate to a different task while say trying to navigate a dropdown of branches.

This leaves hjkl and CMD+enter