### PR TITLE
Add blue external link icon to PR link (vibe-kanban)

### DIFF
--- a/frontend/src/components/tasks/Toolbar/GitOperations.tsx
+++ b/frontend/src/components/tasks/Toolbar/GitOperations.tsx
@@ -6,6 +6,7 @@ import {
   Settings,
   AlertTriangle,
   CheckCircle,
+  ExternalLink,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button.tsx';
 import { Card } from '@/components/ui/card';
@@ -398,6 +399,7 @@ function GitOperations({
                       <span className="text-xs font-medium">
                         PR #{Number(prMerge.pr_info.number)}
                       </span>
+                      <ExternalLink className="h-3 w-3" />
                     </button>
                   );
                 }


### PR DESCRIPTION
The PR link in frontend/src/components/tasks/Toolbar/GitOperations.tsx is hard to find, add a blue version of the external link icon. The icon is e.g. already used for the open in IDE button.