### PR TITLE
feat: Remove the `inline` or `split` diff view selector from diffs in the conversation logs (vibe-kanban)

### DIFF
--- a/frontend/src/components/NormalizedConversation/EditDiffRenderer.tsx
+++ b/frontend/src/components/NormalizedConversation/EditDiffRenderer.tsx
@@ -11,8 +11,6 @@ import { getHighLightLanguageFromPath } from '@/utils/extToLanguage';
 import { getActualTheme } from '@/utils/theme';
 import '@/styles/diff-style-overrides.css';
 import '@/styles/edit-diff-overrides.css';
-import { useDiffViewMode } from '@/stores/useDiffViewStore';
-import DiffViewSwitch from '@/components/diff-view-switch';
 import { cn } from '@/lib/utils';
 
 type Props = {
@@ -77,8 +75,6 @@ function EditDiffRenderer({
   const effectiveExpanded = forceExpanded || expanded;
 
   const theme = getActualTheme(config?.theme);
-  const globalMode = useDiffViewMode();
-
   const { hunks, hideLineNumbers, additions, deletions, isValidDiff } = useMemo(
     () => processUnifiedDiff(unifiedDiff, hasLineNumbers),
     [path, unifiedDiff, hasLineNumbers]
@@ -121,20 +117,13 @@ function EditDiffRenderer({
 
       {effectiveExpanded && (
         <div className={'mt-2 border ' + hideLineNumbersClass}>
-          <div className="flex items-center justify-end border-b px-2 py-1">
-            <DiffViewSwitch />
-          </div>
           {isValidDiff ? (
             <DiffView
               data={diffData}
               diffViewWrap={false}
               diffViewTheme={theme}
               diffViewHighlight
-              diffViewMode={
-                globalMode === 'split'
-                  ? DiffModeEnum.Split
-                  : DiffModeEnum.Unified
-              }
+              diffViewMode={DiffModeEnum.Unified}
               diffViewFontSize={12}
             />
           ) : (


### PR DESCRIPTION
We should always display these diffs in `inline` view