### PR TITLE
Live Diff Service Refactor (vibe-kanban)

### DIFF
--- a/crates/local-deployment/src/container.rs
+++ b/crates/local-deployment/src/container.rs
@@ -618,7 +618,6 @@ impl LocalContainerService {
             base_commit.clone(),
             stats_only,
         )
-        .await
         .map_err(|e| ContainerError::Other(anyhow!("{e}")))
     }
 }

--- a/crates/local-deployment/src/container.rs
+++ b/crates/local-deployment/src/container.rs
@@ -1,11 +1,8 @@
 use std::{
-    collections::{HashMap, HashSet},
+    collections::HashMap,
     io,
     path::{Path, PathBuf},
-    sync::{
-        Arc,
-        atomic::{AtomicUsize, Ordering},
-    },
+    sync::{Arc, atomic::AtomicUsize},
     time::Duration,
 };
 
@@ -39,23 +36,18 @@ use executors::{
     },
 };
 use futures::{FutureExt, StreamExt, TryStreamExt, stream::select};
-use notify_debouncer_full::DebouncedEvent;
 use serde_json::json;
 use services::services::{
     analytics::AnalyticsContext,
     config::Config,
     container::{ContainerError, ContainerRef, ContainerService},
-    filesystem_watcher,
+    diff_stream::{self, DiffStreamWithWatcher},
     git::{Commit, DiffTarget, GitService},
     image::ImageService,
     notification::NotificationService,
     worktree_manager::WorktreeManager,
 };
-use tokio::{
-    sync::{RwLock, mpsc},
-    task::JoinHandle,
-};
-use tokio_stream::wrappers::UnboundedReceiverStream;
+use tokio::{sync::RwLock, task::JoinHandle};
 use tokio_util::io::ReaderStream;
 use utils::{
     log_msg::LogMsg,
@@ -65,33 +57,6 @@ use utils::{
 use uuid::Uuid;
 
 use crate::command;
-
-/// Stream wrapper that owns the filesystem watcher
-/// When this stream is dropped, the watcher is automatically cleaned up
-struct DiffStreamWithWatcher {
-    stream: futures::stream::BoxStream<'static, Result<LogMsg, std::io::Error>>,
-    _watcher_task: Option<JoinHandle<()>>,
-}
-
-impl futures::Stream for DiffStreamWithWatcher {
-    type Item = Result<LogMsg, std::io::Error>;
-
-    fn poll_next(
-        mut self: std::pin::Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<Option<Self::Item>> {
-        // Delegate to inner stream
-        std::pin::Pin::new(&mut self.stream).poll_next(cx)
-    }
-}
-
-impl Drop for DiffStreamWithWatcher {
-    fn drop(&mut self) {
-        if let Some(handle) = self._watcher_task.take() {
-            handle.abort();
-        }
-    }
-}
 
 #[derive(Clone)]
 pub struct LocalContainerService {
@@ -105,59 +70,6 @@ pub struct LocalContainerService {
 }
 
 impl LocalContainerService {
-    // Max cumulative content bytes allowed per diff stream
-    const MAX_CUMULATIVE_DIFF_BYTES: usize = 200 * 1024 * 1024; // 200MB
-
-    // Apply stream-level omit policy based on cumulative bytes.
-    // If adding this diff's contents exceeds the cap, strip contents and set stats.
-    fn apply_stream_omit_policy(
-        diff: &mut utils::diff::Diff,
-        sent_bytes: &Arc<AtomicUsize>,
-        stats_only: bool,
-    ) {
-        if stats_only {
-            Self::omit_diff_contents(diff);
-            return;
-        }
-
-        // Compute size of current diff payload
-        let mut size = 0usize;
-        if let Some(ref s) = diff.old_content {
-            size += s.len();
-        }
-        if let Some(ref s) = diff.new_content {
-            size += s.len();
-        }
-
-        if size == 0 {
-            return; // nothing to account
-        }
-
-        let current = sent_bytes.load(Ordering::Relaxed);
-        if current.saturating_add(size) > Self::MAX_CUMULATIVE_DIFF_BYTES {
-            Self::omit_diff_contents(diff);
-        } else {
-            // safe to include; account for it
-            let _ = sent_bytes.fetch_add(size, Ordering::Relaxed);
-        }
-    }
-
-    fn omit_diff_contents(diff: &mut utils::diff::Diff) {
-        if diff.additions.is_none()
-            && diff.deletions.is_none()
-            && (diff.old_content.is_some() || diff.new_content.is_some())
-        {
-            let old = diff.old_content.as_deref().unwrap_or("");
-            let new = diff.new_content.as_deref().unwrap_or("");
-            let (add, del) = utils::diff::compute_line_change_counts(old, new);
-            diff.additions = Some(add);
-            diff.deletions = Some(del);
-        }
-
-        diff.old_content = None;
-        diff.new_content = None;
-        diff.content_omitted = true;
-    }
     pub fn new(
         db: DBService,
         msg_stores: Arc<RwLock<HashMap<Uuid, Arc<MsgStore>>>>,
@@ -673,7 +585,7 @@ impl LocalContainerService {
         let diffs: Vec<_> = diffs
             .into_iter()
             .map(|mut d| {
-                Self::apply_stream_omit_policy(&mut d, &cum, stats_only);
+                diff_stream::apply_stream_omit_policy(&mut d, &cum, stats_only);
                 d
             })
             .collect();
@@ -689,10 +601,7 @@ impl LocalContainerService {
         }))
         .boxed();
 
-        Ok(DiffStreamWithWatcher {
-            stream,
-            _watcher_task: None, // Merged diffs are static, no watcher needed
-        })
+        Ok(DiffStreamWithWatcher::from_stream(stream))
     }
 
     /// Create a live diff log stream for ongoing attempts for WebSocket
@@ -703,214 +612,16 @@ impl LocalContainerService {
         base_commit: &Commit,
         stats_only: bool,
     ) -> Result<DiffStreamWithWatcher, ContainerError> {
-        // Get initial snapshot
-        let git_service = self.git().clone();
-        let initial_diffs = git_service.get_diffs(
-            DiffTarget::Worktree {
-                worktree_path,
-                base_commit,
-            },
-            None,
-        )?;
+        let handle = diff_stream::create(
+            self.git().clone(),
+            worktree_path.to_path_buf(),
+            base_commit.clone(),
+            stats_only,
+        )
+        .await
+        .map_err(|e| ContainerError::Other(anyhow!("{}", e)))?;
 
-        let cumulative = Arc::new(AtomicUsize::new(0));
-        let full_sent = Arc::new(std::sync::RwLock::new(HashSet::<String>::new()));
-        let initial_diffs: Vec<_> = initial_diffs
-            .into_iter()
-            .map(|mut d| {
-                Self::apply_stream_omit_policy(&mut d, &cumulative, stats_only);
-                d
-            })
-            .collect();
-
-        // Record which paths were sent with full content
-        {
-            let mut guard = full_sent.write().unwrap();
-            for d in &initial_diffs {
-                if !d.content_omitted {
-                    let p = GitService::diff_path(d);
-                    guard.insert(p);
-                }
-            }
-        }
-
-        let (tx, rx) = mpsc::unbounded_channel::<Result<LogMsg, std::io::Error>>();
-        for diff in initial_diffs {
-            let entry_index = GitService::diff_path(&diff);
-            let patch =
-                ConversationPatch::add_diff(escape_json_pointer_segment(&entry_index), diff);
-            if tx.send(Ok(LogMsg::JsonPatch(patch))).is_err() {
-                break;
-            }
-        }
-
-        let rx_stream = UnboundedReceiverStream::new(rx).boxed();
-
-        let worktree_path_buf = worktree_path.to_path_buf();
-
-        let watcher_task = {
-            let git_service = git_service.clone();
-            let cumulative = Arc::clone(&cumulative);
-            let full_sent = Arc::clone(&full_sent);
-            let stats_only = stats_only;
-            let tx_sender = tx.clone();
-            let worktree_path = worktree_path_buf;
-            let base_commit = base_commit.clone();
-
-            tokio::spawn(async move {
-                let worktree_path_for_spawn = worktree_path.clone();
-                let watcher_result = tokio::task::spawn_blocking(move || {
-                    filesystem_watcher::async_watcher(worktree_path_for_spawn)
-                })
-                .await;
-
-                match watcher_result {
-                    Ok(Ok((debouncer, mut watcher_rx, canonical_worktree_path))) => {
-                        let _debouncer_guard = debouncer;
-                        while let Some(result) = watcher_rx.next().await {
-                            match result {
-                                Ok(events) => {
-                                    let changed_paths = Self::extract_changed_paths(
-                                        &events,
-                                        &canonical_worktree_path,
-                                        &worktree_path,
-                                    );
-
-                                    if !changed_paths.is_empty() {
-                                        match Self::process_file_changes(
-                                            &git_service,
-                                            &worktree_path,
-                                            &base_commit,
-                                            &changed_paths,
-                                            &cumulative,
-                                            &full_sent,
-                                            stats_only,
-                                        ) {
-                                            Ok(messages) => {
-                                                for msg in messages {
-                                                    if tx_sender.send(Ok(msg)).is_err() {
-                                                        return;
-                                                    }
-                                                }
-                                            }
-                                            Err(e) => {
-                                                tracing::error!(
-                                                    "Error processing file changes: {}",
-                                                    e
-                                                );
-                                                let _ = tx_sender
-                                                    .send(Err(io::Error::other(e.to_string())));
-                                                return;
-                                            }
-                                        }
-                                    }
-                                }
-                                Err(errors) => {
-                                    let error_msg = errors
-                                        .iter()
-                                        .map(|e| e.to_string())
-                                        .collect::<Vec<_>>()
-                                        .join("; ");
-                                    tracing::error!("Filesystem watcher error: {}", error_msg);
-                                    let _ = tx_sender.send(Err(io::Error::other(error_msg)));
-                                    return;
-                                }
-                            }
-                        }
-                    }
-                    Ok(Err(e)) => {
-                        tracing::error!("Failed to start filesystem watcher: {}", e);
-                        let _ = tx_sender.send(Err(io::Error::other(e.to_string())));
-                    }
-                    Err(join_err) => {
-                        let err_msg = format!("Failed to spawn watcher setup: {join_err}");
-                        tracing::error!("{}", err_msg);
-                        let _ = tx_sender.send(Err(io::Error::other(err_msg)));
-                    }
-                }
-            })
-        };
-
-        drop(tx);
-
-        Ok(DiffStreamWithWatcher {
-            stream: rx_stream,
-            _watcher_task: Some(watcher_task),
-        })
-    }
-
-    /// Extract changed file paths from filesystem events
-    fn extract_changed_paths(
-        events: &[DebouncedEvent],
-        canonical_worktree_path: &Path,
-        worktree_path: &Path,
-    ) -> Vec<String> {
-        events
-            .iter()
-            .flat_map(|event| &event.paths)
-            .filter_map(|path| {
-                path.strip_prefix(canonical_worktree_path)
-                    .or_else(|_| path.strip_prefix(worktree_path))
-                    .ok()
-                    .map(|p| p.to_string_lossy().replace('\\', "/"))
-            })
-            .filter(|s| !s.is_empty())
-            .collect()
-    }
-
-    /// Process file changes and generate diff messages (for WS)
-    fn process_file_changes(
-        git_service: &GitService,
-        worktree_path: &Path,
-        base_commit: &Commit,
-        changed_paths: &[String],
-        cumulative_bytes: &Arc<AtomicUsize>,
-        full_sent_paths: &Arc<std::sync::RwLock<HashSet<String>>>,
-        stats_only: bool,
-    ) -> Result<Vec<LogMsg>, ContainerError> {
-        let path_filter: Vec<&str> = changed_paths.iter().map(|s| s.as_str()).collect();
-
-        let current_diffs = git_service.get_diffs(
-            DiffTarget::Worktree {
-                worktree_path,
-                base_commit,
-            },
-            Some(&path_filter),
-        )?;
-
-        let mut msgs = Vec::new();
-        let mut files_with_diffs = HashSet::new();
-
-        // Add/update files that have diffs
-        for mut diff in current_diffs {
-            let file_path = GitService::diff_path(&diff);
-            files_with_diffs.insert(file_path.clone());
-            // Apply stream-level omit policy (affects contents and stats)
-            Self::apply_stream_omit_policy(&mut diff, cumulative_bytes, stats_only);
-
-            if diff.content_omitted {
-                if full_sent_paths.read().unwrap().contains(&file_path) {
-                    continue;
-                }
-            } else {
-                let mut guard = full_sent_paths.write().unwrap();
-                guard.insert(file_path.clone());
-            }
-
-            let patch = ConversationPatch::add_diff(escape_json_pointer_segment(&file_path), diff);
-            msgs.push(LogMsg::JsonPatch(patch));
-        }
-
-        // Remove files that changed but no longer have diffs
-        for changed_path in changed_paths {
-            if !files_with_diffs.contains(changed_path) {
-                let patch =
-                    ConversationPatch::remove_diff(escape_json_pointer_segment(changed_path));
-                msgs.push(LogMsg::JsonPatch(patch));
-            }
-        }
-
-        Ok(msgs)
+        Ok(DiffStreamWithWatcher::new(handle))
     }
 }
 

--- a/crates/services/src/services/diff_stream.rs
+++ b/crates/services/src/services/diff_stream.rs
@@ -1,0 +1,363 @@
+use std::{
+    collections::HashSet,
+    io,
+    path::{Path, PathBuf},
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+};
+
+use executors::logs::utils::{ConversationPatch, patch::escape_json_pointer_segment};
+use futures::StreamExt;
+use notify_debouncer_full::DebouncedEvent;
+use thiserror::Error;
+use tokio::{sync::mpsc, task::JoinHandle};
+use tokio_stream::wrappers::UnboundedReceiverStream;
+use utils::{
+    diff::{self, Diff},
+    log_msg::LogMsg,
+};
+
+use crate::services::{
+    filesystem_watcher::{self, FilesystemWatcherError},
+    git::{Commit, DiffTarget, GitService, GitServiceError},
+};
+
+/// Maximum cumulative diff bytes to stream before omitting content (200MB)
+pub const MAX_CUMULATIVE_DIFF_BYTES: usize = 200 * 1024 * 1024;
+
+/// Errors that can occur during diff stream creation and operation
+#[derive(Error, Debug)]
+pub enum DiffStreamError {
+    #[error("Git service error: {0}")]
+    GitService(#[from] GitServiceError),
+    #[error("Filesystem watcher error: {0}")]
+    FilesystemWatcher(#[from] FilesystemWatcherError),
+    #[error("Task join error: {0}")]
+    TaskJoin(#[from] tokio::task::JoinError),
+}
+
+pub struct DiffStreamHandle {
+    pub stream: futures::stream::BoxStream<'static, Result<LogMsg, io::Error>>,
+    pub watcher_task: Option<JoinHandle<()>>,
+}
+
+/// Stream wrapper that owns the filesystem watcher task
+/// When this stream is dropped, the watcher is automatically cleaned up
+pub struct DiffStreamWithWatcher {
+    stream: futures::stream::BoxStream<'static, Result<LogMsg, io::Error>>,
+    _watcher_task: Option<JoinHandle<()>>,
+}
+
+impl futures::Stream for DiffStreamWithWatcher {
+    type Item = Result<LogMsg, io::Error>;
+
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        // Delegate to inner stream
+        std::pin::Pin::new(&mut self.stream).poll_next(cx)
+    }
+}
+
+impl Drop for DiffStreamWithWatcher {
+    fn drop(&mut self) {
+        if let Some(handle) = self._watcher_task.take() {
+            handle.abort();
+        }
+    }
+}
+
+impl DiffStreamWithWatcher {
+    /// Create a new DiffStreamWithWatcher from a DiffStreamHandle
+    pub fn new(handle: DiffStreamHandle) -> Self {
+        Self {
+            stream: handle.stream,
+            _watcher_task: handle.watcher_task,
+        }
+    }
+
+    /// Create a new DiffStreamWithWatcher from a static stream (no watcher)
+    pub fn from_stream(
+        stream: futures::stream::BoxStream<'static, Result<LogMsg, io::Error>>,
+    ) -> Self {
+        Self {
+            stream,
+            _watcher_task: None,
+        }
+    }
+}
+
+struct DiffWatcherContext {
+    git_service: GitService,
+    worktree_path: PathBuf,
+    base_commit: Commit,
+    cumulative: Arc<AtomicUsize>,
+    full_sent: Arc<std::sync::RwLock<HashSet<String>>>,
+    stats_only: bool,
+    tx: mpsc::UnboundedSender<Result<LogMsg, io::Error>>,
+}
+
+impl DiffWatcherContext {
+    fn handle_events(&self, events: Vec<DebouncedEvent>, canonical_worktree_path: &Path) -> bool {
+        let changed_paths =
+            extract_changed_paths(&events, canonical_worktree_path, &self.worktree_path);
+
+        if changed_paths.is_empty() {
+            return true;
+        }
+
+        match process_file_changes(
+            &self.git_service,
+            &self.worktree_path,
+            &self.base_commit,
+            &changed_paths,
+            &self.cumulative,
+            &self.full_sent,
+            self.stats_only,
+        ) {
+            Ok(messages) => send_messages(&self.tx, messages),
+            Err(err) => {
+                tracing::error!("Error processing file changes: {}", err);
+                send_error(&self.tx, err.to_string());
+                false
+            }
+        }
+    }
+}
+
+pub async fn create(
+    git_service: GitService,
+    worktree_path: PathBuf,
+    base_commit: Commit,
+    stats_only: bool,
+) -> Result<DiffStreamHandle, DiffStreamError> {
+    let initial_diffs_raw = git_service.get_diffs(
+        DiffTarget::Worktree {
+            worktree_path: &worktree_path,
+            base_commit: &base_commit,
+        },
+        None,
+    )?;
+
+    let cumulative = Arc::new(AtomicUsize::new(0));
+    let full_sent = Arc::new(std::sync::RwLock::new(HashSet::<String>::new()));
+    let mut initial_diffs = Vec::with_capacity(initial_diffs_raw.len());
+    for mut diff in initial_diffs_raw {
+        apply_stream_omit_policy(&mut diff, &cumulative, stats_only);
+        initial_diffs.push(diff);
+    }
+
+    {
+        let mut guard = full_sent.write().unwrap();
+        for diff in &initial_diffs {
+            if !diff.content_omitted {
+                guard.insert(GitService::diff_path(diff));
+            }
+        }
+    }
+
+    let (tx, rx) = mpsc::unbounded_channel::<Result<LogMsg, io::Error>>();
+    if !send_initial_diffs(&tx, initial_diffs) {
+        return Ok(DiffStreamHandle {
+            stream: UnboundedReceiverStream::new(rx).boxed(),
+            watcher_task: None,
+        });
+    }
+
+    let tx_clone = tx.clone();
+    let ctx = DiffWatcherContext {
+        git_service,
+        worktree_path: worktree_path.clone(),
+        base_commit,
+        cumulative,
+        full_sent,
+        stats_only,
+        tx: tx_clone,
+    };
+
+    // Start the watcher setup - fail fast if this fails
+    let worktree_path_for_spawn = worktree_path.clone();
+    let watcher_result = tokio::task::spawn_blocking(move || {
+        filesystem_watcher::async_watcher(worktree_path_for_spawn)
+    })
+    .await
+    .map_err(DiffStreamError::TaskJoin)?
+    .map_err(DiffStreamError::FilesystemWatcher)?;
+
+    let (debouncer, mut watcher_rx, canonical_worktree_path) = watcher_result;
+
+    let watcher_task = tokio::spawn(async move {
+        let _debouncer_guard = debouncer;
+
+        while let Some(result) = watcher_rx.next().await {
+            match result {
+                Ok(events) => {
+                    if !ctx.handle_events(events, &canonical_worktree_path) {
+                        return;
+                    }
+                }
+                Err(errors) => {
+                    let message = errors
+                        .iter()
+                        .map(|e| e.to_string())
+                        .collect::<Vec<_>>()
+                        .join("; ");
+                    tracing::error!("Filesystem watcher error: {}", message);
+                    send_error(&ctx.tx, message);
+                    return;
+                }
+            }
+        }
+    });
+
+    drop(tx);
+
+    Ok(DiffStreamHandle {
+        stream: UnboundedReceiverStream::new(rx).boxed(),
+        watcher_task: Some(watcher_task),
+    })
+}
+
+fn send_initial_diffs(
+    tx: &mpsc::UnboundedSender<Result<LogMsg, io::Error>>,
+    diffs: Vec<Diff>,
+) -> bool {
+    for diff in diffs {
+        let entry_index = GitService::diff_path(&diff);
+        let patch = ConversationPatch::add_diff(escape_json_pointer_segment(&entry_index), diff);
+        if tx.send(Ok(LogMsg::JsonPatch(patch))).is_err() {
+            return false;
+        }
+    }
+    true
+}
+
+fn send_messages(
+    tx: &mpsc::UnboundedSender<Result<LogMsg, io::Error>>,
+    messages: Vec<LogMsg>,
+) -> bool {
+    for msg in messages {
+        if tx.send(Ok(msg)).is_err() {
+            return false;
+        }
+    }
+    true
+}
+
+fn send_error(tx: &mpsc::UnboundedSender<Result<LogMsg, io::Error>>, message: String) {
+    let _ = tx.send(Err(io::Error::other(message)));
+}
+
+pub fn apply_stream_omit_policy(diff: &mut Diff, sent_bytes: &Arc<AtomicUsize>, stats_only: bool) {
+    if stats_only {
+        omit_diff_contents(diff);
+        return;
+    }
+
+    let mut size = 0usize;
+    if let Some(ref s) = diff.old_content {
+        size += s.len();
+    }
+    if let Some(ref s) = diff.new_content {
+        size += s.len();
+    }
+
+    if size == 0 {
+        return;
+    }
+
+    let current = sent_bytes.load(Ordering::Relaxed);
+    if current.saturating_add(size) > MAX_CUMULATIVE_DIFF_BYTES {
+        omit_diff_contents(diff);
+    } else {
+        let _ = sent_bytes.fetch_add(size, Ordering::Relaxed);
+    }
+}
+
+fn omit_diff_contents(diff: &mut Diff) {
+    if diff.additions.is_none()
+        && diff.deletions.is_none()
+        && (diff.old_content.is_some() || diff.new_content.is_some())
+    {
+        let old = diff.old_content.as_deref().unwrap_or("");
+        let new = diff.new_content.as_deref().unwrap_or("");
+        let (add, del) = diff::compute_line_change_counts(old, new);
+        diff.additions = Some(add);
+        diff.deletions = Some(del);
+    }
+
+    diff.old_content = None;
+    diff.new_content = None;
+    diff.content_omitted = true;
+}
+
+fn extract_changed_paths(
+    events: &[DebouncedEvent],
+    canonical_worktree_path: &Path,
+    worktree_path: &Path,
+) -> Vec<String> {
+    events
+        .iter()
+        .flat_map(|event| &event.paths)
+        .filter_map(|path| {
+            path.strip_prefix(canonical_worktree_path)
+                .or_else(|_| path.strip_prefix(worktree_path))
+                .ok()
+                .map(|p| p.to_string_lossy().replace('\\', "/"))
+        })
+        .filter(|s| !s.is_empty())
+        .collect()
+}
+
+fn process_file_changes(
+    git_service: &GitService,
+    worktree_path: &Path,
+    base_commit: &Commit,
+    changed_paths: &[String],
+    cumulative_bytes: &Arc<AtomicUsize>,
+    full_sent_paths: &Arc<std::sync::RwLock<HashSet<String>>>,
+    stats_only: bool,
+) -> Result<Vec<LogMsg>, DiffStreamError> {
+    let path_filter: Vec<&str> = changed_paths.iter().map(|s| s.as_str()).collect();
+
+    let current_diffs = git_service.get_diffs(
+        DiffTarget::Worktree {
+            worktree_path,
+            base_commit,
+        },
+        Some(&path_filter),
+    )?;
+
+    let mut msgs = Vec::new();
+    let mut files_with_diffs = HashSet::new();
+
+    for mut diff in current_diffs {
+        let file_path = GitService::diff_path(&diff);
+        files_with_diffs.insert(file_path.clone());
+        apply_stream_omit_policy(&mut diff, cumulative_bytes, stats_only);
+
+        if diff.content_omitted {
+            if full_sent_paths.read().unwrap().contains(&file_path) {
+                continue;
+            }
+        } else {
+            let mut guard = full_sent_paths.write().unwrap();
+            guard.insert(file_path.clone());
+        }
+
+        let patch = ConversationPatch::add_diff(escape_json_pointer_segment(&file_path), diff);
+        msgs.push(LogMsg::JsonPatch(patch));
+    }
+
+    for changed_path in changed_paths {
+        if !files_with_diffs.contains(changed_path) {
+            let patch = ConversationPatch::remove_diff(escape_json_pointer_segment(changed_path));
+            msgs.push(LogMsg::JsonPatch(patch));
+        }
+    }
+
+    Ok(msgs)
+}

--- a/crates/services/src/services/filesystem_watcher.rs
+++ b/crates/services/src/services/filesystem_watcher.rs
@@ -46,27 +46,26 @@ fn build_gitignore_set(root: &Path) -> Result<Gitignore, FilesystemWatcherError>
     let mut builder = GitignoreBuilder::new(root);
 
     // Walk once to collect all .gitignore files under root
-    for result in WalkBuilder::new(root)
+    WalkBuilder::new(root)
         .follow_links(false)
         .hidden(false) // we *want* to see .gitignore
-        .standard_filters(false) // do not apply default ignores while walking
-        .git_ignore(false) // we'll add them manually
-        .git_exclude(false)
+        .filter_entry(|entry| {
+            // only recurse into directories and .gitignore files
+            entry.file_type().map(|ft| ft.is_dir()).unwrap_or(false)
+                || entry
+                    .file_name()
+                    .to_str()
+                    .is_some_and(|name| name == ".gitignore")
+        })
         .build()
-    {
-        let dir_entry = result?;
-        if dir_entry
-            .file_type()
-            .map(|ft| ft.is_file())
-            .unwrap_or(false)
-            && dir_entry
-                .path()
-                .file_name()
-                .is_some_and(|name| name == ".gitignore")
-        {
-            builder.add(dir_entry.path());
-        }
-    }
+        .for_each(|result| {
+            // everything that is not a directory and is named .gitignore
+            if let Ok(dir_entry) = result
+                && !dir_entry.file_type().map(|ft| ft.is_dir()).unwrap_or(false)
+            {
+                builder.add(dir_entry.path());
+            }
+        });
 
     // Optionally include repo-local excludes
     let info_exclude = root.join(".git/info/exclude");

--- a/crates/services/src/services/mod.rs
+++ b/crates/services/src/services/mod.rs
@@ -3,6 +3,7 @@ pub mod approvals;
 pub mod auth;
 pub mod config;
 pub mod container;
+pub mod diff_stream;
 pub mod drafts;
 pub mod events;
 pub mod file_ranker;


### PR DESCRIPTION
- Fix initial diff not being sent before filesystem watcher is ready, causing slow diffs
- Refactor live diffs
- Improve filesystem watcher `.gitignore` discovery performance