### PR TITLE
fix: set fetch-depth to 0 for full history in checkout step

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -40,6 +40,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ssh-key: ${{ secrets.DEPLOY_KEY }}
+          fetch-depth: 0
 
       - name: Setup Node
         uses: ./.github/actions/setup-node


### PR DESCRIPTION
fixes rare case where
- user uses vk to develop vk
- vk pre-release github action runs and makes a commit, this commit is orphaned
- user does *not* `git pull` on main
- user creates a new task attempt with `origin/main` as base branch
- users git history is now only two commits long, the version bump from the action and one before.

Fix by fetching the full history in the github action.