### PR TITLE
Better delete task workflow for tasks with family (vibe-kanban)

### DIFF
--- a/crates/db/.sqlx/query-01a0f9724e5fce7d3312a742e72cded85605ee540150972e2a8364919f56d5c0.json
+++ b/crates/db/.sqlx/query-01a0f9724e5fce7d3312a742e72cded85605ee540150972e2a8364919f56d5c0.json
@@ -46,12 +46,12 @@
       {
         "name": "has_in_progress_attempt!: i64",
         "ordinal": 8,
-        "type_info": "Null"
+        "type_info": "Integer"
       },
       {
         "name": "last_attempt_failed!: i64",
         "ordinal": 9,
-        "type_info": "Null"
+        "type_info": "Integer"
       },
       {
         "name": "executor!: String",
@@ -71,8 +71,8 @@
       true,
       false,
       false,
-      null,
-      null,
+      false,
+      false,
       true
     ]
   },

--- a/crates/db/migrations/20251007000000_set_null_parent_task_attempt_on_delete.sql
+++ b/crates/db/migrations/20251007000000_set_null_parent_task_attempt_on_delete.sql
@@ -1,0 +1,32 @@
+PRAGMA foreign_keys = OFF;
+
+-- Create new tasks table with updated foreign key constraint
+CREATE TABLE tasks_new (
+    id          BLOB PRIMARY KEY,
+    project_id  BLOB NOT NULL,
+    title       TEXT NOT NULL,
+    description TEXT,
+    status      TEXT NOT NULL DEFAULT 'todo'
+                   CHECK (status IN ('todo','inprogress','done','cancelled','inreview')),
+    parent_task_attempt BLOB,
+    created_at  TEXT NOT NULL DEFAULT (datetime('now', 'subsec')),
+    updated_at  TEXT NOT NULL DEFAULT (datetime('now', 'subsec')),
+    FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE,
+    FOREIGN KEY (parent_task_attempt) REFERENCES task_attempts(id) ON DELETE SET NULL
+);
+
+-- Copy data from old table to new table
+INSERT INTO tasks_new (id, project_id, title, description, status, parent_task_attempt, created_at, updated_at)
+SELECT id, project_id, title, description, status, parent_task_attempt, created_at, updated_at
+FROM tasks;
+
+-- Drop old table
+DROP TABLE tasks;
+
+-- Rename new table to original name
+ALTER TABLE tasks_new RENAME TO tasks;
+
+-- Recreate index for parent_task_attempt lookups
+CREATE INDEX idx_tasks_parent_task_attempt ON tasks(parent_task_attempt);
+
+PRAGMA foreign_keys = ON;


### PR DESCRIPTION
When a task is deleted, we don't deal with child tasks/parent attempts correctly. We should decouple them, not delete everything.