### PR TITLE
fix: align read_port_file path logic with write_port_file

### DIFF
--- a/crates/utils/src/port_file.rs
+++ b/crates/utils/src/port_file.rs
@@ -12,16 +12,8 @@ pub async fn write_port_file(port: u16) -> std::io::Result<PathBuf> {
 }
 
 pub async fn read_port_file(app_name: &str) -> std::io::Result<u16> {
-    let base = if cfg!(target_os = "linux") {
-        match env::var("XDG_RUNTIME_DIR") {
-            Ok(val) if !val.is_empty() => PathBuf::from(val),
-            _ => env::temp_dir(),
-        }
-    } else {
-        env::temp_dir()
-    };
-
-    let path = base.join(app_name).join(format!("{app_name}.port"));
+    let dir = env::temp_dir().join(app_name);
+    let path = dir.join(format!("{app_name}.port"));
     tracing::debug!("Reading port from {:?}", path);
 
     let content = fs::read_to_string(&path).await?;


### PR DESCRIPTION
In `read_port_file`, the base directory on Linux was derived from `XDG_RUNTIME_DIR`, while `write_port_file` always used `env::temp_dir()`. This caused an inconsistency between the read and write paths.
