### PR TITLE
Bound the diff-stream channel

### DIFF
--- a/crates/local-deployment/src/container.rs
+++ b/crates/local-deployment/src/container.rs
@@ -618,6 +618,7 @@ impl LocalContainerService {
             base_commit.clone(),
             stats_only,
         )
+        .await
         .map_err(|e| ContainerError::Other(anyhow!("{e}")))
     }
 }


### PR DESCRIPTION
The bounded channel applies backpressure, so the filewatcher writer pauses when the channel is full.