### PR TITLE
fix: retry modal horizontal overflow

### DIFF
--- a/frontend/src/components/dialogs/tasks/RestoreLogsDialog.tsx
+++ b/frontend/src/components/dialogs/tasks/RestoreLogsDialog.tsx
@@ -202,7 +202,7 @@ export const RestoreLogsDialog = NiceModal.create<RestoreLogsDialogProps>(
                           <p className="mt-2 text-xs text-muted-foreground">
                             Your worktree will be restored to this commit.
                           </p>
-                          <div className="mt-1 flex items-center gap-2 min-w-0">
+                          <div className="mt-1 flex flex-wrap items-center gap-2 min-w-0">
                             <GitCommit className="h-3.5 w-3.5 text-muted-foreground" />
                             {short && (
                               <span className="font-mono text-xs px-2 py-0.5 rounded bg-muted">
@@ -342,7 +342,7 @@ export const RestoreLogsDialog = NiceModal.create<RestoreLogsDialogProps>(
                           <p className="mt-2 text-xs text-muted-foreground">
                             Your worktree will be restored to this commit.
                           </p>
-                          <div className="mt-1 flex items-center gap-2 min-w-0">
+                          <div className="mt-1 flex flex-wrap items-center gap-2 min-w-0">
                             <GitCommit className="h-3.5 w-3.5 text-muted-foreground" />
                             <span className="font-mono text-xs px-2 py-0.5 rounded bg-muted">
                               {short}


### PR DESCRIPTION
Break content onto the next line when horizontal space runs out.

<details>
<summary>Before</summary>
<img width="1186" height="1360" alt="image" src="https://github.com/user-attachments/assets/685f4f17-d446-4308-8725-90821de8798c" />
</details>


<details>
<summary>After</summary>
<img width="1186" height="1360" alt="image" src="https://github.com/user-attachments/assets/a5513448-39ca-4954-bcf5-854cdf533dd3" />
</details>
