### PR TITLE
Simplify agent prompt

### DIFF
--- a/crates/db/src/models/task.rs
+++ b/crates/db/src/models/task.rs
@@ -99,7 +99,7 @@ pub struct UpdateTask {
 impl Task {
     pub fn to_prompt(&self) -> String {
         if let Some(description) = self.description.as_ref().filter(|d| !d.trim().is_empty()) {
-            format!("Title: {}\n\nDescription: {}", &self.title, description)
+            format!("{}\n\n{}", &self.title, description)
         } else {
             self.title.clone()
         }


### PR DESCRIPTION
Remove the explicit `Title:` and `Description:` formatting from the prompts, as they can reduce agent performance in simple tasks, especially since there is no additional context/prompting.