### PR TITLE
Dont change log size on tab switch (vibe-kanban)

### DIFF
--- a/frontend/src/components/layout/TasksLayout.tsx
+++ b/frontend/src/components/layout/TasksLayout.tsx
@@ -30,7 +30,8 @@ function loadSizes(key: string, fallback: SplitSizes): SplitSizes {
     const saved = localStorage.getItem(key);
     if (!saved) return fallback;
     const parsed = JSON.parse(saved);
-    if (Array.isArray(parsed) && parsed.length === 2) return parsed as SplitSizes;
+    if (Array.isArray(parsed) && parsed.length === 2)
+      return parsed as SplitSizes;
     return fallback;
   } catch {
     return fallback;


### PR DESCRIPTION
Changing between preview and diff tabs changes the size of the conversation log, it should instead stay the same size 