### PR TITLE
Include project title in page title (vibe-kanban)

### DIFF
--- a/frontend/src/contexts/project-context.tsx
+++ b/frontend/src/contexts/project-context.tsx
@@ -1,4 +1,10 @@
-import { createContext, useContext, ReactNode, useMemo, useEffect } from 'react';
+import {
+  createContext,
+  useContext,
+  ReactNode,
+  useMemo,
+  useEffect,
+} from 'react';
 import { useLocation } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { projectsApi } from '@/lib/api';


### PR DESCRIPTION
Page title should be <project> | vibe-kanban so users can identify which tab was which project.
(#1005)