### PR TITLE
Always show git actions (vibe-kanban)

### DIFF
--- a/frontend/src/components/panels/DiffsPanel.tsx
+++ b/frontend/src/components/panels/DiffsPanel.tsx
@@ -102,14 +102,6 @@ export function DiffsPanel({ selectedAttempt, gitOps }: DiffsPanelProps) {
     );
   }
 
-  if (loading) {
-    return (
-      <div className="flex items-center justify-center h-full">
-        <Loader />
-      </div>
-    );
-  }
-
   return (
     <DiffsPanelContent
       diffs={diffs}
@@ -122,6 +114,7 @@ export function DiffsPanel({ selectedAttempt, gitOps }: DiffsPanelProps) {
       toggle={toggle}
       selectedAttempt={selectedAttempt}
       gitOps={gitOps}
+      loading={loading}
     />
   );
 }
@@ -137,6 +130,7 @@ interface DiffsPanelContentProps {
   toggle: (id: string) => void;
   selectedAttempt: TaskAttempt | null;
   gitOps?: GitOperationsInputs;
+  loading: boolean;
 }
 
 function DiffsPanelContent({
@@ -150,6 +144,7 @@ function DiffsPanelContent({
   toggle,
   selectedAttempt,
   gitOps,
+  loading,
 }: DiffsPanelContentProps) {
   return (
     <div className="h-full flex flex-col relative">
@@ -206,7 +201,11 @@ function DiffsPanelContent({
         </div>
       )}
       <div className="flex-1 overflow-y-auto px-3">
-        {diffs.length === 0 ? (
+        {loading ? (
+          <div className="flex items-center justify-center h-full">
+            <Loader />
+          </div>
+        ) : diffs.length === 0 ? (
           <div className="flex items-center justify-center h-full text-sm text-muted-foreground">
             No changes have been made yet
           </div>


### PR DESCRIPTION
In fullscreen the diff tab should always show git actions, even if not changes have been made yet.