### PR TITLE
Fix edit task collapse (vibe-kanban)

### DIFF
--- a/frontend/src/components/ui/auto-expanding-textarea.tsx
+++ b/frontend/src/components/ui/auto-expanding-textarea.tsx
@@ -19,10 +19,6 @@ const AutoExpandingTextarea = React.forwardRef<
       .current;
     if (!textarea) return;
 
-    // Temporarily remove overflow to get accurate scrollHeight
-    const originalOverflow = textarea.style.overflow;
-    textarea.style.overflow = 'hidden';
-
     // Reset height to auto to get the natural height
     textarea.style.height = 'auto';
 
@@ -38,10 +34,7 @@ const AutoExpandingTextarea = React.forwardRef<
     // Set the height to scrollHeight, but cap at maxHeight
     const newHeight = Math.min(textarea.scrollHeight, maxHeight);
     textarea.style.height = `${newHeight}px`;
-
-    // Restore overflow
-    textarea.style.overflow = originalOverflow;
-  }, [maxRows, textareaRef]);
+  }, [maxRows]);
 
   // Adjust height on mount and when content changes
   React.useEffect(() => {


### PR DESCRIPTION
When clicking edit on task title/description, the view collapses into a small edit box. Increase the max size of that box!