### PR TITLE
Use the first found port for frontend preview detection (vibe-kanban)

### DIFF
--- a/frontend/src/hooks/useDevserverUrl.ts
+++ b/frontend/src/hooks/useDevserverUrl.ts
@@ -74,13 +74,15 @@ export const useDevserverUrlFromLogs = (
     }
 
     let detectedUrl: DevserverUrlInfo | undefined;
-    for (let i = lastIndexRef.current; i < logs.length; i += 1) {
-      const detected = detectDevserverUrl(logs[i].content);
+    const newEntries = logs.slice(lastIndexRef.current);
+    newEntries.some((entry) => {
+      const detected = detectDevserverUrl(entry.content);
       if (detected) {
         detectedUrl = detected;
-        break;
+        return true;
       }
-    }
+      return false;
+    });
 
     if (detectedUrl) {
       setUrlInfo((prev) => prev ?? detectedUrl);


### PR DESCRIPTION
Use the first found dev server preview URL and stop searching after.

Without this, all dev logs are continuously searched and regex matched for a URL