### PR TITLE
Prevent user messages in the agent log from overflowing (vibe-kanban)

### DIFF
--- a/frontend/src/components/ui/markdown-renderer.tsx
+++ b/frontend/src/components/ui/markdown-renderer.tsx
@@ -201,9 +201,6 @@ function MarkdownRenderer({
         component: ({ children, ...props }: any) => (
           <pre
             {...props}
-            // whitespace-pre-wrap: Override default pre behavior (white-space: pre) to allow line wrapping
-            // break-words: Force breaks in long unbroken strings (e.g., long commands) to prevent horizontal overflow
-            // overflow-x-auto: Fallback scrollbar if content still overflows
             className="overflow-x-auto whitespace-pre-wrap break-words font-mono text-sm bg-muted/50 rounded-sm p-2 my-2"
           >
             {children}


### PR DESCRIPTION
BEFORE:
<img width="3456" height="2160" alt="CleanShot 2025-10-18 at 15 56 47@2x" src="https://github.com/user-attachments/assets/d75c10d4-7dc2-4670-819c-b36edfdc56a3" />


AFTER:
<img width="3680" height="2382" alt="CleanShot 2025-10-18 at 15 57 11@2x" src="https://github.com/user-attachments/assets/b8a51d9c-0aa2-44c1-b87a-168bb5b75e56" />
