### PR TITLE
disable unnecessary collapsing behaviour in task panel (vibe-kanban)

### DIFF
--- a/frontend/src/components/layout/TasksLayout.tsx
+++ b/frontend/src/components/layout/TasksLayout.tsx
@@ -141,8 +141,7 @@ function RightWorkArea({
               order={2}
               defaultSize={innerSizes[1]}
               minSize={MIN_PANEL_SIZE}
-              collapsible
-              collapsedSize={0}
+              collapsible={false}
               className="min-w-0 min-h-0 overflow-hidden"
               role="region"
               aria-label={mode === 'preview' ? 'Preview' : 'Diffs'}


### PR DESCRIPTION
IMO the collapsing behaviour is useful for collapsing agent logs so that the preview or code diff can be viewed in full screen.
I'm not sure about all other behaviour:
- expanding the agent logs to cover the kanban board
- collapsing the agent logs to only show the kanban board
- expanding the agent logs to cover the preview/diff