### PR TITLE
bump amp to 0.0.1761050239-g36fe88 (vibe-kanban)

### DIFF
--- a/crates/executors/src/executors/amp.rs
+++ b/crates/executors/src/executors/amp.rs
@@ -33,7 +33,7 @@ pub struct Amp {
 
 impl Amp {
     fn build_command_builder(&self) -> CommandBuilder {
-        let mut builder = CommandBuilder::new("npx -y @sourcegraph/amp@0.0.1759507289-g3e67fa")
+        let mut builder = CommandBuilder::new("npx -y @sourcegraph/amp@0.0.1761050239-g36fe88")
             .params(["--execute", "--stream-json"]);
         if self.dangerously_allow_all.unwrap_or(false) {
             builder = builder.extend_params(["--dangerously-allow-all"]);


### PR DESCRIPTION
They have a new subagent: https://ampcode.com/news/librarian