### PR TITLE
Send enable-button message to click-to-component iframe (vibe-kanban)

### DIFF
--- a/frontend/src/utils/previewBridge.ts
+++ b/frontend/src/utils/previewBridge.ts
@@ -86,7 +86,7 @@ export class ClickToComponentListener {
             const enableMsg: ClickToComponentEnableMessage = {
               source: 'click-to-component',
               version: 1,
-              type: 'enable-button'
+              type: 'enable-button',
             };
             (event.source as Window).postMessage(enableMsg, '*');
           }


### PR DESCRIPTION
Send enable-button message to click-to-component iframe

### Context
The click-to-component iframe button visibility is being changed from automatic iframe detection to explicit enablement via postMessage. The iframe now waits for a signal from the parent before showing the button.

### Changes needed in `frontend/src/utils/previewBridge.ts`:

**1. Add new TypeScript type** (after the existing interfaces):
```typescript
export interface ClickToComponentEnableMessage {
  source: 'click-to-component';
  version: 1;
  type: 'enable-button';
}
```

**2. Update the `ClickToComponentMessage` type** to include the new message:
```typescript
export interface ClickToComponentMessage {
  source: 'click-to-component';
  version: number;
  type: 'ready' | 'open-in-editor' | 'enable-button';
  payload?: OpenInEditorPayload;
}
```

**3. Send enable message when iframe is ready:**

In the `ClickToComponentListener` class, update the message handler's `'ready'` case to send the enable message back. You'll need access to the iframe reference, so either:

**Option A:** Extend the `onReady` handler signature to include event source:
```typescript
case 'ready':
  // Send enable message back to iframe
  if (event.source) {
    const enableMsg: ClickToComponentEnableMessage = {
      source: 'click-to-component',
      version: 1,
      type: 'enable-button'
    };
    (event.source as Window).postMessage(enableMsg, '*');
  }
  this.handlers.onReady?.();
  break;
```

**Option B:** Pass the event to the onReady handler:
```typescript
export interface EventHandlers {
  onReady?: (event: MessageEvent) => void;
  // ... rest
}

// In message listener:
case 'ready':
  this.handlers.onReady?.(event);
  break;

// Then in your usage code, send the enable message there
```

**Recommendation:** Use Option A for simplicity - send the enable message directly in the previewBridge when ready is received.

### Expected behavior:
- Child iframe sends `{ source: 'click-to-component', type: 'ready' }` on mount
- Parent receives ready message and immediately responds with `{ source: 'click-to-component', version: 1, type: 'enable-button' }`
- Child iframe receives enable message and shows the click-to-edit button

---