### PR TITLE
Display parent task attempt (vibe-kanban)

### DIFF
--- a/frontend/src/components/panels/TaskPanel.tsx
+++ b/frontend/src/components/panels/TaskPanel.tsx
@@ -94,7 +94,9 @@ const TaskPanel = ({ task }: TaskPanelProps) => {
                 isLoading={isParentLoading}
                 navigateToAttempt={(attempt) => {
                   if (projectId) {
-                    navigate(paths.attempt(projectId, attempt.task_id, attempt.id));
+                    navigate(
+                      paths.attempt(projectId, attempt.task_id, attempt.id)
+                    );
                   }
                 }}
                 formatTimeAgo={formatTimeAgo}
@@ -215,7 +217,9 @@ function AttemptsTable({
 }) {
   if (isLoading) {
     return (
-      <div className="text-muted-foreground">{t('taskPanel.loadingAttempts')}</div>
+      <div className="text-muted-foreground">
+        {t('taskPanel.loadingAttempts')}
+      </div>
     );
   }
   if (isError) {


### PR DESCRIPTION
If there is a parent task attempt, display a box with summary info about it and allow the user to navigate to that

frontend/src/components/panels/TaskPanel.tsx

<img width="759" height="371" alt="Screenshot 2025-10-22 at 14 41 51" src="https://github.com/user-attachments/assets/294ae3a9-26de-47e8-a217-7e2ca3664d69" />
