### PR TITLE
Always enable merge/rebase (vibe-kanban)

### DIFF
--- a/frontend/src/components/tasks/Toolbar/GitOperations.tsx
+++ b/frontend/src/components/tasks/Toolbar/GitOperations.tsx
@@ -468,11 +468,7 @@ function GitOperations({
 
             <Button
               onClick={handleRebaseDialogOpen}
-              disabled={
-                rebasing ||
-                isAttemptRunning ||
-                hasConflictsCalculated
-              }
+              disabled={rebasing || isAttemptRunning || hasConflictsCalculated}
               variant="outline"
               size="xs"
               className="border-warning text-warning hover:bg-warning gap-1 shrink-0"


### PR DESCRIPTION
Currently the frontend disables merge when the task branch is not ahead and disables rebase when the task branch isn't behind. We want to remove these conditions.