### PR TITLE
Diagnose script hang (vibe-kanban)

### DIFF
--- a/crates/executors/src/actions/script.rs
+++ b/crates/executors/src/actions/script.rs
@@ -46,7 +46,6 @@ impl Executable for ScriptRequest {
             .stdin(std::process::Stdio::null())
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped())
-            .env("COMPOSE_INTERACTIVE_NO_CLI", "1")
             .arg(shell_arg)
             .arg(&self.script)
             .current_dir(current_dir);


### PR DESCRIPTION
Diagnose why this script:

```
#!/bin/bash
# test-db-setup.sh - Minimal reproduction of vibekanban-setup.sh database readiness logic

set -e

# Generate unique project name
WORKTREE_PATH=$(pwd)
PROJECT_NAME="test-$(echo "$WORKTREE_PATH" | md5sum | cut -c1-8)"
export COMPOSE_PROJECT_NAME="$PROJECT_NAME"

echo "ðŸ“¦ Using project name: $PROJECT_NAME"
echo "ðŸš€ Starting database service..."

# Start the service
docker compose up -d mysql-test

echo "â³ Waiting for database to be running..."
MAX_ATTEMPTS=120
ATTEMPT=0

# Method 1: Using docker compose exec (like the original script)
echo ""
echo "=== Method 1: docker compose exec ping ==="
while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
    ATTEMPT=$((ATTEMPT + 1))

    # Try to ping the database using docker compose exec -T
    if docker compose exec -T mysql-test mysqladmin ping -u root -proot >/dev/null 2>&1; then
        echo "âœ… Database is ready (Method 1 - attempt $ATTEMPT)"
        break
    fi

    # Show progress every 10 attempts
    if [ $((ATTEMPT % 10)) -eq 0 ]; then
        echo "  Waiting... ($ATTEMPT/$MAX_ATTEMPTS)"
    fi

    sleep 1
done

if [ $ATTEMPT -eq $MAX_ATTEMPTS ]; then
    echo "âŒ Database failed to become ready (Method 1)"
    exit 1
fi

# Method 2: Direct connection test
echo ""
echo "=== Method 2: Direct connection via CLI ==="
ATTEMPT=0
while [ $ATTEMPT -lt 30 ]; do
    ATTEMPT=$((ATTEMPT + 1))

    # Get the actual port
    PORT=$(docker compose port mysql-test 3306 | cut -d: -f2)

    if [ -z "$PORT" ]; then
        echo "  Waiting for port assignment... ($ATTEMPT/30)"
        sleep 1
        continue
    fi

    # Try direct connection
    if mysqladmin ping -h127.0.0.1 -P$PORT -u root -proot >/dev/null 2>&1; then
        echo "âœ… Database is ready (Method 2 - attempt $ATTEMPT)"
        echo "   Port: $PORT"
        break
    fi

    if [ $((ATTEMPT % 5)) -eq 0 ]; then
        echo "  Waiting for direct connection... ($ATTEMPT/30)"
    fi

    sleep 1
done

# Method 3: Check health status
echo ""
echo "=== Method 3: Check Docker health status ==="
ATTEMPT=0
while [ $ATTEMPT -lt 30 ]; do
    ATTEMPT=$((ATTEMPT + 1))

    HEALTH=$(docker compose ps mysql-test --format json 2>/dev/null | grep -o '"State":"[^"]*"' | cut -d'"' -f4)

    if [ "$HEALTH" = "running" ]; then
        echo "âœ… Container is running (Method 3 - attempt $ATTEMPT)"
        break
    fi

    if [ $((ATTEMPT % 5)) -eq 0 ]; then
        echo "  Waiting for container state... ($ATTEMPT/30)"
    fi

    sleep 1
done

echo ""
echo "ðŸ§¹ Cleaning up..."
docker compose down

echo "âœ… Test completed successfully!"
```

Hangs, with the last message: `=== Method 1: docker compose exec ping ===`

When I run using cargo dev, it doesn't hang. If I make a prod build, it does hang.

The script is being executed by @crates/executors/src/actions/script.rs 

Diagnose, check using the oracle, confirm with me before making changes