### PR TITLE
Handle a race condition between share action and activity notifications

### DIFF
--- a/crates/services/src/services/share/processor.rs
+++ b/crates/services/src/services/share/processor.rs
@@ -48,6 +48,7 @@ impl ActivityProcessor {
                             &self.db.pool,
                             &shared_task,
                             current_user_id,
+                            task.creator_user_id.as_deref(),
                         )
                         .await?;
                     } else {

--- a/crates/services/src/services/share/publisher.rs
+++ b/crates/services/src/services/share/publisher.rs
@@ -15,9 +15,7 @@ use reqwest::{Client as HttpClient, StatusCode};
 use tokio::sync::RwLock;
 use uuid::Uuid;
 
-use super::{
-    ShareConfig, ShareError, convert_remote_task, status, sync_local_task_for_shared_task,
-};
+use super::{ShareConfig, ShareError, convert_remote_task, status};
 use crate::services::{
     clerk::ClerkSession, config::Config, git::GitService, github_service::GitHubService,
 };


### PR DESCRIPTION
An activity event can arrive before sharing is completed, which could create local duplicates of the shared task.