### PR TITLE
Filter processes shown in conversation history

### DIFF
--- a/frontend/src/hooks/useConversationHistory.ts
+++ b/frontend/src/hooks/useConversationHistory.ts
@@ -45,7 +45,7 @@ interface UseConversationHistoryParams {
   onEntriesUpdated: OnEntriesUpdated;
 }
 
-interface UseConversationHistoryResult { }
+interface UseConversationHistoryResult {}
 
 const MIN_INITIAL_ENTRIES = 10;
 const REMAINING_BATCH_SIZE = 50;
@@ -219,9 +219,9 @@ export const useConversationHistory = ({
       .filter(
         (p) =>
           p.executionProcess.executor_action.typ.type ===
-          'CodingAgentFollowUpRequest' ||
+            'CodingAgentFollowUpRequest' ||
           p.executionProcess.executor_action.typ.type ===
-          'CodingAgentInitialRequest'
+            'CodingAgentInitialRequest'
       )
       .sort(
         (a, b) =>
@@ -254,9 +254,9 @@ export const useConversationHistory = ({
         const entries: PatchTypeWithKey[] = [];
         if (
           p.executionProcess.executor_action.typ.type ===
-          'CodingAgentInitialRequest' ||
+            'CodingAgentInitialRequest' ||
           p.executionProcess.executor_action.typ.type ===
-          'CodingAgentFollowUpRequest'
+            'CodingAgentFollowUpRequest'
         ) {
           // New user message
           const userNormalizedEntry: NormalizedEntry = {
@@ -359,9 +359,9 @@ export const useConversationHistory = ({
             executionProcess?.status === 'running'
               ? null
               : {
-                type: 'exit_code',
-                code: exitCode,
-              };
+                  type: 'exit_code',
+                  code: exitCode,
+                };
 
           const toolStatus: ToolStatus =
             executionProcess?.status === ExecutionProcessStatus.running


### PR DESCRIPTION
Previously we weren't filtering out dev servers from an upstream part of the conversation history pipeline, this caused issues.