### PR TITLE
fix: prevent resuming completed Claude Code sessions

### DIFF
--- a/crates/db/src/models/execution_process.rs
+++ b/crates/db/src/models/execution_process.rs
@@ -279,10 +279,11 @@ impl ExecutionProcess {
         let row = sqlx::query!(
             r#"SELECT es.session_id
                FROM execution_processes ep
-               JOIN executor_sessions es ON ep.id = es.execution_process_id  
+               JOIN executor_sessions es ON ep.id = es.execution_process_id
                WHERE ep.task_attempt_id = $1
                  AND ep.run_reason = 'codingagent'
                  AND ep.dropped = FALSE
+                 AND ep.status = 'running'
                  AND es.session_id IS NOT NULL
                ORDER BY ep.created_at DESC
                LIMIT 1"#,


### PR DESCRIPTION
## Problem

Follow-up requests were failing with "No assistant message found" error immediately after Claude Code spawned.

### Root Cause

The `find_latest_session_id_by_task_attempt` query didn't check the process status, so it returned session IDs from **completed** processes. Claude Code cannot resume terminated sessions using `--fork-session --resume`, causing immediate failures.

### Investigation Details

- Initial requests worked perfectly - Claude Code responded and completed normally
- Follow-up requests failed because they tried to resume a completed session
- Session files existed in `~/.claude/debug/{session_id}.txt` and showed `SessionEnd` events
- Manual invocation of Claude Code worked fine

## Solution

Added `ep.status = 'running'` condition to only return session IDs from active processes.

Now follow-up requests will:
- Resume an active session if Claude Code is still running
- Start a fresh initial request if the previous session completed

## Testing

Tested with multiple scenarios:
1. ✅ Initial comment → Claude Code responds successfully
2. ✅ Follow-up comment after completion → Creates new session successfully
3. ✅ Multiple follow-ups work as expected

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)