### PR TITLE
prevent draft restoration logic from overwriting changes to a message

### DIFF
--- a/frontend/src/components/NormalizedConversation/RetryEditorInline.tsx
+++ b/frontend/src/components/NormalizedConversation/RetryEditorInline.tsx
@@ -68,6 +68,7 @@ export function RetryEditorInline({
     setImages,
     handleImageUploaded,
     clearImagesAndUploads,
+    isMessageLocallyDirty,
   } = useDraftEditor({
     draft,
     taskId: attempt.task_id,
@@ -120,7 +121,7 @@ export function RetryEditorInline({
   useEffect(() => {
     if (!isRetryLoaded || !draft) return;
     const serverPrompt = draft.prompt || '';
-    if (message === '' && serverPrompt !== '') {
+    if (message === '' && serverPrompt !== '' && !isMessageLocallyDirty()) {
       setMessage(serverPrompt);
       if (import.meta.env.DEV) {
         // One-shot debug to validate hydration ordering in dev
@@ -138,6 +139,7 @@ export function RetryEditorInline({
     isRetryLoaded,
     message,
     setMessage,
+    isMessageLocallyDirty,
   ]);
 
   const onSend = async () => {

--- a/frontend/src/hooks/follow-up/useDraftEditor.ts
+++ b/frontend/src/hooks/follow-up/useDraftEditor.ts
@@ -20,6 +20,8 @@ export function useDraftEditor({ draft, taskId }: Args) {
   const localDirtyRef = useRef<boolean>(false);
   const imagesDirtyRef = useRef<boolean>(false);
 
+  const isMessageLocallyDirty = useCallback(() => localDirtyRef.current, []);
+
   // Sync message with server when not locally dirty
   useEffect(() => {
     if (!draft) return;
@@ -84,5 +86,6 @@ export function useDraftEditor({ draft, taskId }: Args) {
     newlyUploadedImageIds,
     handleImageUploaded,
     clearImagesAndUploads,
+    isMessageLocallyDirty,
   } as const;
 }


### PR DESCRIPTION
it was previously difficult to clear a follow-up up message as as if the final character were removed, the message would be empty thus triggering the draft restoration logic.