### PR TITLE
Max height for TaskFollowUpSection (vibe-kanban)

### DIFF
--- a/frontend/src/components/tasks/TaskFollowUpSection.tsx
+++ b/frontend/src/components/tasks/TaskFollowUpSection.tsx
@@ -451,8 +451,10 @@ export function TaskFollowUpSection({
 
             {/* Review comments preview */}
             {reviewMarkdown && (
-              <div className="text-sm mb-4">
-                <div className="whitespace-pre-wrap">{reviewMarkdown}</div>
+              <div className="mb-4">
+                <div className="text-sm whitespace-pre-wrap break-words max-h-[40vh] overflow-y-auto rounded-md border bg-muted p-3">
+                  {reviewMarkdown}
+                </div>
               </div>
             )}
 


### PR DESCRIPTION
frontend/src/components/tasks/TaskFollowUpSection.tsx

If reviewMarkdown is very long this can cause the view to become blocked as this takes up too much height. this should have a max height before scroll

<img width="3640" height="3024" alt="Screenshot 2025-10-29 at 21 25 43" src="https://github.com/user-attachments/assets/4eee2a58-db77-4e14-9025-7ebf17eb9f06" />
