### PR TITLE
Can't drag task onto kanban below page fold (vibe-kanban)

### DIFF
--- a/frontend/src/components/ui/shadcn-io/kanban/index.tsx
+++ b/frontend/src/components/ui/shadcn-io/kanban/index.tsx
@@ -203,7 +203,6 @@ function restrictToBoundingRectWithRightPadding(
   boundingRect: ClientRect,
   rightPadding: number
 ): Transform {
-  console.log(rect, boundingRect);
   const value = {
     ...transform,
   };
@@ -283,7 +282,7 @@ export const KanbanProvider = ({
     >
       <div
         className={cn(
-          'inline-grid grid-flow-col auto-cols-[minmax(200px,400px)] divide-x border-x items-start min-h-full',
+          'inline-grid grid-flow-col auto-cols-[minmax(200px,400px)] divide-x border-x items-stretch min-h-full',
           className
         )}
       >


### PR DESCRIPTION
I just noticed that when you drag a card between columns, it only works if you drag it onto the area above the page fold

frontend/src/pages/project-tasks.tsx
frontend/src/components/tasks/TaskKanbanBoard.tsx