### PR TITLE
increased handle width in task panel (vibe-kanban)

### DIFF
--- a/frontend/src/components/layout/TasksLayout.tsx
+++ b/frontend/src/components/layout/TasksLayout.tsx
@@ -1,6 +1,7 @@
 import { ReactNode, useState } from 'react';
 import { PanelGroup, Panel, PanelResizeHandle } from 'react-resizable-panels';
 import { AnimatePresence, motion } from 'framer-motion';
+import { cn } from '@/lib/utils';
 
 export type LayoutMode = 'preview' | 'diffs' | null;
 
@@ -126,9 +127,13 @@ function RightWorkArea({
 
             <PanelResizeHandle
               id="handle-aa"
-              className={`relative z-30 bg-border cursor-col-resize group touch-none focus:outline-none focus-visible:ring-2 focus-visible:ring-ring/60 focus-visible:ring-offset-1 focus-visible:ring-offset-background transition-all ${
+              className={cn(
+                'relative z-30 bg-border cursor-col-resize group touch-none',
+                'focus:outline-none focus-visible:ring-2 focus-visible:ring-ring/60',
+                'focus-visible:ring-offset-1 focus-visible:ring-offset-background',
+                'transition-all',
                 isAttemptCollapsed ? 'w-6' : 'w-1'
-              }`}
+              )}
               aria-label="Resize panels"
               role="separator"
               aria-orientation="vertical"
@@ -224,9 +229,13 @@ function DesktopSimple({
 
       <PanelResizeHandle
         id="handle-kr"
-        className={`relative z-30 bg-border cursor-col-resize group touch-none focus:outline-none focus-visible:ring-2 focus-visible:ring-ring/60 focus-visible:ring-offset-1 focus-visible:ring-offset-background transition-all ${
+        className={cn(
+          'relative z-30 bg-border cursor-col-resize group touch-none',
+          'focus:outline-none focus-visible:ring-2 focus-visible:ring-ring/60',
+          'focus-visible:ring-offset-1 focus-visible:ring-offset-background',
+          'transition-all',
           isKanbanCollapsed ? 'w-6' : 'w-1'
-        }`}
+        )}
         aria-label="Resize panels"
         role="separator"
         aria-orientation="vertical"


### PR DESCRIPTION
when we open a task, we're able to resize it. if we drag the handle all the way to the left edge of the screen, it becomes difficult to grab it as it conflicts with the left edge of the browser window. when in this full screen state, we should make it easier to grab the handle.