### PR TITLE
Add text wrap toggle to diff viewer

### DIFF
--- a/frontend/src/components/DiffCard.tsx
+++ b/frontend/src/components/DiffCard.tsx
@@ -32,6 +32,7 @@ import { ReviewCommentRenderer } from '@/components/diff/ReviewCommentRenderer';
 import {
   useDiffViewMode,
   useIgnoreWhitespaceDiff,
+  useWrapTextDiff,
 } from '@/stores/useDiffViewStore';
 import { useProject } from '@/contexts/ProjectContext';
 
@@ -84,6 +85,7 @@ export default function DiffCard({
   const { comments, drafts, setDraft } = useReview();
   const globalMode = useDiffViewMode();
   const ignoreWhitespace = useIgnoreWhitespaceDiff();
+  const wrapText = useWrapTextDiff();
   const { projectId } = useProject();
 
   const oldName = diff.oldPath || undefined;
@@ -301,7 +303,7 @@ export default function DiffCard({
         <div>
           <DiffView
             diffFile={diffFile}
-            diffViewWrap={false}
+            diffViewWrap={wrapText}
             diffViewTheme={theme}
             diffViewHighlight
             diffViewMode={

--- a/frontend/src/components/DiffViewSwitch.tsx
+++ b/frontend/src/components/DiffViewSwitch.tsx
@@ -1,10 +1,11 @@
-import { Columns, FileText, Pilcrow } from 'lucide-react';
+import { Columns, FileText, Pilcrow, WrapText } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { cn } from '@/lib/utils';
 import {
   useDiffViewMode,
   useDiffViewStore,
   useIgnoreWhitespaceDiff,
+  useWrapTextDiff,
 } from '@/stores/useDiffViewStore';
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 import {
@@ -24,8 +25,11 @@ export default function DiffViewSwitch({ className }: Props) {
   const setMode = useDiffViewStore((s) => s.setMode);
   const ignoreWhitespace = useIgnoreWhitespaceDiff();
   const setIgnoreWhitespace = useDiffViewStore((s) => s.setIgnoreWhitespace);
+  const wrapText = useWrapTextDiff();
+  const setWrapText = useDiffViewStore((s) => s.setWrapText);
 
   const whitespaceValue = ignoreWhitespace ? ['ignoreWhitespace'] : [];
+  const wrapTextValue = wrapText ? ['wrapText'] : [];
 
   return (
     <TooltipProvider>
@@ -89,6 +93,29 @@ export default function DiffViewSwitch({ className }: Props) {
             </TooltipTrigger>
             <TooltipContent side="bottom">
               {t('diff.ignoreWhitespace')}
+            </TooltipContent>
+          </Tooltip>
+        </ToggleGroup>
+
+        <ToggleGroup
+          type="multiple"
+          value={wrapTextValue}
+          onValueChange={(values) => setWrapText(values.includes('wrapText'))}
+          className="inline-flex gap-4"
+          aria-label={t('diff.wrapText', 'Wrap text')}
+        >
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <ToggleGroupItem
+                value="wrapText"
+                aria-label={t('diff.wrapText', 'Wrap text')}
+                active={wrapText}
+              >
+                <WrapText className="h-4 w-4" />
+              </ToggleGroupItem>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">
+              {t('diff.wrapText', 'Wrap text')}
             </TooltipContent>
           </Tooltip>
         </ToggleGroup>

--- a/frontend/src/stores/useDiffViewStore.ts
+++ b/frontend/src/stores/useDiffViewStore.ts
@@ -8,6 +8,8 @@ type State = {
   toggle: () => void;
   ignoreWhitespace: boolean;
   setIgnoreWhitespace: (value: boolean) => void;
+  wrapText: boolean;
+  setWrapText: (value: boolean) => void;
 };
 
 export const useDiffViewStore = create<State>((set) => ({
@@ -17,8 +19,11 @@ export const useDiffViewStore = create<State>((set) => ({
     set((s) => ({ mode: s.mode === 'unified' ? 'split' : 'unified' })),
   ignoreWhitespace: true,
   setIgnoreWhitespace: (value) => set({ ignoreWhitespace: value }),
+  wrapText: false,
+  setWrapText: (value) => set({ wrapText: value }),
 }));
 
 export const useDiffViewMode = () => useDiffViewStore((s) => s.mode);
 export const useIgnoreWhitespaceDiff = () =>
   useDiffViewStore((s) => s.ignoreWhitespace);
+export const useWrapTextDiff = () => useDiffViewStore((s) => s.wrapText);


### PR DESCRIPTION
## Summary
- Added a text wrap toggle button to the diff viewer controls
- Users can now toggle between wrapped and unwrapped text in diffs
- State is managed globally via Zustand store

## Changes
- Added `wrapText` state to `useDiffViewStore` (defaults to `false`)
- Added `WrapText` toggle button in `diff-view-switch.tsx` alongside existing controls
- Connected toggle state to `DiffView` component's `diffViewWrap` prop in `DiffCard.tsx`
