### PR TITLE
Require login for viewing orgs (vibe-kanban)

### DIFF
--- a/frontend/src/i18n/locales/en/organization.json
+++ b/frontend/src/i18n/locales/en/organization.json
@@ -58,6 +58,11 @@
     "deleteSuccess": "Organization deleted successfully",
     "deleteError": "Failed to delete organization"
   },
+  "loginRequired": {
+    "title": "Login Required",
+    "description": "You need to be logged in to manage organization settings.",
+    "action": "Login"
+  },
   "confirmRemoveMember": "Are you sure you want to remove this member from the organization?",
   "sharedProjects": {
     "title": "Shared Projects",

--- a/frontend/src/i18n/locales/es/organization.json
+++ b/frontend/src/i18n/locales/es/organization.json
@@ -58,6 +58,11 @@
     "deleteSuccess": "Organization deleted successfully",
     "deleteError": "Failed to delete organization"
   },
+  "loginRequired": {
+    "title": "Inicio de sesión requerido",
+    "description": "Debes iniciar sesión para administrar la configuración de la organización.",
+    "action": "Iniciar sesión"
+  },
   "confirmRemoveMember": "Are you sure you want to remove this member from the organization?",
   "sharedProjects": {
     "title": "Proyectos Compartidos",

--- a/frontend/src/i18n/locales/ja/organization.json
+++ b/frontend/src/i18n/locales/ja/organization.json
@@ -58,6 +58,11 @@
     "deleteSuccess": "Organization deleted successfully",
     "deleteError": "Failed to delete organization"
   },
+  "loginRequired": {
+    "title": "ログインが必要です",
+    "description": "組織設定を管理するにはログインする必要があります。",
+    "action": "ログイン"
+  },
   "confirmRemoveMember": "Are you sure you want to remove this member from the organization?",
   "sharedProjects": {
     "title": "共有プロジェクト",

--- a/frontend/src/i18n/locales/ko/organization.json
+++ b/frontend/src/i18n/locales/ko/organization.json
@@ -58,6 +58,11 @@
     "deleteSuccess": "Organization deleted successfully",
     "deleteError": "Failed to delete organization"
   },
+  "loginRequired": {
+    "title": "로그인 필요",
+    "description": "조직 설정을 관리하려면 로그인해야 합니다.",
+    "action": "로그인"
+  },
   "confirmRemoveMember": "Are you sure you want to remove this member from the organization?",
   "sharedProjects": {
     "title": "공유 프로젝트",

--- a/frontend/src/pages/settings/OrganizationSettings.tsx
+++ b/frontend/src/pages/settings/OrganizationSettings.tsx
@@ -23,6 +23,8 @@ import { useOrganizationMembers } from '@/hooks/useOrganizationMembers';
 import { useOrganizationInvitations } from '@/hooks/useOrganizationInvitations';
 import { useOrganizationMutations } from '@/hooks/useOrganizationMutations';
 import { useUserSystem } from '@/components/config-provider';
+import { useAuth } from '@/hooks/auth/useAuth';
+import { LoginRequiredPrompt } from '@/components/dialogs/shared/LoginRequiredPrompt';
 import NiceModal from '@ebay/nice-modal-react';
 import {
   InviteMemberDialog,
@@ -45,6 +47,7 @@ import { useProjectMutations } from '@/hooks/useProjectMutations';
 export function OrganizationSettings() {
   const { t } = useTranslation('organization');
   const { loginStatus } = useUserSystem();
+  const { isSignedIn, isLoaded } = useAuth();
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
 
@@ -244,11 +247,23 @@ export function OrganizationSettings() {
   // Check if current org is personal (cannot be deleted)
   const isPersonalOrg = selectedOrg?.slug.startsWith('personal-') ?? false;
 
-  if (orgsLoading) {
+  if (!isLoaded || orgsLoading) {
     return (
       <div className="flex items-center justify-center py-8">
         <Loader2 className="h-8 w-8 animate-spin" />
         <span className="ml-2">{t('settings.loadingOrganizations')}</span>
+      </div>
+    );
+  }
+
+  if (!isSignedIn) {
+    return (
+      <div className="py-8">
+        <LoginRequiredPrompt
+          title={t('loginRequired.title')}
+          description={t('loginRequired.description')}
+          actionLabel={t('loginRequired.action')}
+        />
       </div>
     );
   }


### PR DESCRIPTION
Viewing org settings should tell the user to login when they aren't instead of showing an empty dropdown