### PR TITLE
Hide share toggle for unlinked projects (vibe-kanban)

### DIFF
--- a/frontend/src/components/layout/navbar.tsx
+++ b/frontend/src/components/layout/navbar.tsx
@@ -90,7 +90,8 @@ export function Navbar() {
   // Navbar is global, but the share tasks toggle only makes sense on the tasks route
   const isTasksRoute = /^\/projects\/[^/]+\/tasks/.test(location.pathname);
   const showSharedTasks = searchParams.get('shared') !== 'off';
-  const shouldShowSharedToggle = isTasksRoute && active && project?.remote_project_id != null;
+  const shouldShowSharedToggle =
+    isTasksRoute && active && project?.remote_project_id != null;
 
   const handleSharedToggle = useCallback(
     (checked: boolean) => {


### PR DESCRIPTION
Hide share toggle in the frontend for projects without a shared project linked to it