### PR TITLE
Fix darkmode for github cli setup helper (vibe-kanban)

### DIFF
--- a/frontend/src/components/dialogs/tasks/CreatePRDialog.tsx
+++ b/frontend/src/components/dialogs/tasks/CreatePRDialog.tsx
@@ -280,10 +280,7 @@ const CreatePrDialog = NiceModal.create(() => {
                 />
               </div>
               {ghCliHelp?.variant && (
-                <Alert
-                  variant="default"
-                  className="border-primary/30 bg-primary/10 text-primary"
-                >
+                <Alert variant="default">
                   <AlertTitle>
                     {getGhCliHelpTitle(ghCliHelp.variant)}
                   </AlertTitle>


### PR DESCRIPTION
When creating a pull request and failing, the help text does not use proper semantic colours and is invisible to user on dark mode frontend/src/components/dialogs/tasks/CreatePRDialog.tsx

Resolves #1298