### PR TITLE
Fix hook invalidation after rebasing (vibe-kanban)

### DIFF
--- a/frontend/src/hooks/useRebase.ts
+++ b/frontend/src/hooks/useRebase.ts
@@ -40,6 +40,11 @@ export function useRebase(
           queryKey: ['branchStatus', attemptId],
         });
 
+        // Invalidate taskAttempt query to refresh attempt.target_branch
+        queryClient.invalidateQueries({
+          queryKey: ['taskAttempt', attemptId],
+        });
+
         // Refresh branch list used by PR dialog
         if (projectId) {
           queryClient.invalidateQueries({


### PR DESCRIPTION
The target/base branch for the create PR dialog gets set correctly after changing base branch using UI, but not after rebasing using UI. Most likely missing hook invalidation