### PR TITLE
Batch D: Fix low-priority 'any' and catch blocks (vibe-kanban)

### DIFF
--- a/frontend/src/components/dialogs/tasks/EditBranchNameDialog.tsx
+++ b/frontend/src/components/dialogs/tasks/EditBranchNameDialog.tsx
@@ -11,7 +11,7 @@ import {
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import NiceModal, { useModal } from '@ebay/nice-modal-react';
-import { defineModal } from '@/lib/modals';
+import { defineModal, getErrorMessage } from '@/lib/modals';
 import { useRenameBranch } from '@/hooks/useRenameBranch';
 
 export interface EditBranchNameDialogProps {
@@ -40,8 +40,8 @@ const EditBranchNameDialogImpl = NiceModal.create<EditBranchNameDialogProps>(
         } as EditBranchNameDialogResult);
         modal.hide();
       },
-      (err: any) => {
-        setError(err?.message || 'Failed to rename branch');
+      (err: unknown) => {
+        setError(getErrorMessage(err) || 'Failed to rename branch');
       }
     );
 

--- a/frontend/src/components/dialogs/tasks/TagEditDialog.tsx
+++ b/frontend/src/components/dialogs/tasks/TagEditDialog.tsx
@@ -16,7 +16,7 @@ import { Loader2 } from 'lucide-react';
 import { tagsApi } from '@/lib/api';
 import type { Tag, CreateTag, UpdateTag } from 'shared/types';
 import NiceModal, { useModal } from '@ebay/nice-modal-react';
-import { defineModal } from '@/lib/modals';
+import { defineModal, getErrorMessage } from '@/lib/modals';
 
 export interface TagEditDialogProps {
   tag?: Tag | null; // null for create mode
@@ -79,9 +79,10 @@ const TagEditDialogImpl = NiceModal.create<TagEditDialogProps>(({ tag }) => {
 
       modal.resolve('saved' as TagEditResult);
       modal.hide();
-    } catch (err: any) {
+    } catch (err: unknown) {
       setError(
-        err.message || t('settings.general.tags.dialog.errors.saveFailed')
+        getErrorMessage(err) ||
+          t('settings.general.tags.dialog.errors.saveFailed')
       );
     } finally {
       setSaving(false);

--- a/frontend/src/components/ui/ImageUploadSection.tsx
+++ b/frontend/src/components/ui/ImageUploadSection.tsx
@@ -151,10 +151,12 @@ export const ImageUploadSection = forwardRef<
             }
 
             setErrorMessage(null);
-          } catch (error: any) {
+          } catch (error: unknown) {
             console.error('Failed to upload image:', error);
             const message =
-              error.message || 'Failed to upload image. Please try again.';
+              error instanceof Error
+                ? error.message
+                : 'Failed to upload image. Please try again.';
             setErrorMessage(message);
           } finally {
             setUploadingFiles((prev) => {

--- a/frontend/src/lib/modals.ts
+++ b/frontend/src/lib/modals.ts
@@ -23,10 +23,13 @@ export function defineModal<P, R>(
   component: React.ComponentType<ComponentProps<P> & NiceModalHocProps>
 ): Modalized<P, R> {
   const c = component as unknown as Modalized<P, R>;
-  c.show = ((...args: any[]) =>
-    NiceModal.show(component as any, args[0])) as Modalized<P, R>['show'];
-  c.hide = () => NiceModal.hide(component as any);
-  c.remove = () => NiceModal.remove(component as any);
+  c.show = ((...args: ShowArgs<P>) =>
+    NiceModal.show(
+      component as React.FC<ComponentProps<P>>,
+      args[0] as ComponentProps<P>
+    ) as Promise<R>) as Modalized<P, R>['show'];
+  c.hide = () => NiceModal.hide(component as React.FC<ComponentProps<P>>);
+  c.remove = () => NiceModal.remove(component as React.FC<ComponentProps<P>>);
   return c;
 }
 

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -1,4 +1,8 @@
-import { ExecutionProcess } from 'shared/types';
+import {
+  ExecutionProcess,
+  NormalizedEntry,
+  ExecutionProcessStatus,
+} from 'shared/types';
 
 export type AttemptData = {
   processes: ExecutionProcess[];
@@ -6,12 +10,12 @@ export type AttemptData = {
 };
 
 export interface ConversationEntryDisplayType {
-  entry: any;
+  entry: NormalizedEntry;
   processId: string;
   processPrompt?: string;
-  processStatus: string;
+  processStatus: ExecutionProcessStatus;
   processIsRunning: boolean;
-  process: any;
+  process: ExecutionProcess;
   isFirstInProcess: boolean;
   processIndex: number;
   entryIndex: number;

--- a/frontend/src/pages/settings/McpSettings.tsx
+++ b/frontend/src/pages/settings/McpSettings.tsx
@@ -91,8 +91,11 @@ export function McpSettings() {
         const configJson = JSON.stringify(fullConfig, null, 2);
         setMcpServers(configJson);
         setMcpConfigPath(result.config_path);
-      } catch (err: any) {
-        if (err?.message && err.message.includes('does not support MCP')) {
+      } catch (err: unknown) {
+        if (
+          err instanceof Error &&
+          err.message.includes('does not support MCP')
+        ) {
           setMcpError(err.message);
         } else {
           console.error('Error loading MCP servers:', err);
@@ -210,14 +213,20 @@ export function McpSettings() {
     }
   };
 
-  const preconfigured = (mcpConfig?.preconfigured ?? {}) as Record<string, any>;
-  const meta = (preconfigured.meta ?? {}) as Record<
+  const preconfiguredObj = (mcpConfig?.preconfigured ?? {}) as Record<
     string,
-    { name?: string; description?: string; url?: string; icon?: string }
+    unknown
   >;
+  const meta =
+    typeof preconfiguredObj.meta === 'object' && preconfiguredObj.meta !== null
+      ? (preconfiguredObj.meta as Record<
+          string,
+          { name?: string; description?: string; url?: string; icon?: string }
+        >)
+      : {};
   const servers = Object.fromEntries(
-    Object.entries(preconfigured).filter(([k]) => k !== 'meta')
-  ) as Record<string, any>;
+    Object.entries(preconfiguredObj).filter(([k]) => k !== 'meta')
+  ) as Record<string, unknown>;
   const getMetaFor = (key: string) => meta[key] || {};
 
   if (!config) {


### PR DESCRIPTION
Fix remaining low-priority 'any' types (low risk):
- lib/types.ts (ConversationEntryDisplayType)
- lib/modals.ts
- Dialog components (EditBranchNameDialog, TagEditDialog, GhCliSetupDialog)
- components/ui/ImageUploadSection.tsx
- pages/settings/McpSettings.tsx

Use tsc to check, and pnpm run format