### PR TITLE
Bump Gemini to new version (vibe-kanban)

### DIFF
--- a/crates/executors/src/executors/gemini.rs
+++ b/crates/executors/src/executors/gemini.rs
@@ -21,7 +21,7 @@ pub enum GeminiModel {
 
 impl GeminiModel {
     fn base_command(&self) -> &'static str {
-        "npx -y @google/gemini-cli@0.15.3"
+        "npx -y @google/gemini-cli@0.16.0"
     }
 
     fn build_command_builder(&self) -> CommandBuilder {


### PR DESCRIPTION
0.16.0

crates/executors/src/executors/gemini.rs