### PR TITLE
New attempt does not choose user settings (vibe-kanban)

### DIFF
--- a/frontend/src/components/dialogs/tasks/CreateAttemptDialog.tsx
+++ b/frontend/src/components/dialogs/tasks/CreateAttemptDialog.tsx
@@ -92,9 +92,19 @@ const CreateAttemptDialogImpl = NiceModal.create<CreateAttemptDialogProps>(
 
     const defaultProfile: ExecutorProfileId | null = useMemo(() => {
       if (latestAttempt?.executor) {
+        const lastExec = latestAttempt.executor as BaseCodingAgent;
+        // If the last attempt used the same executor as the user's current preference,
+        // we assume they want to use their preferred variant as well.
+        // Otherwise, we default to the "default" variant (null) since we don't know
+        // what variant they used last time (TaskAttempt doesn't store it).
+        const variant =
+          config?.executor_profile?.executor === lastExec
+            ? config.executor_profile.variant
+            : null;
+
         return {
-          executor: latestAttempt.executor as BaseCodingAgent,
-          variant: null,
+          executor: lastExec,
+          variant,
         };
       }
       return config?.executor_profile ?? null;


### PR DESCRIPTION
The user's preferred executor variant is not chosen when a new attempt is made.

The issue is with variant, my settings are set to VARIANT1.

I start an attempt with VARIANT1.

If I create a new attempt, I see DEFAULT as the selected variant

frontend/src/components/dialogs/tasks/CreateAttemptDialog.tsx