### PR TITLE
refactor: `Container` and `Deployment`

### DIFF
--- a/crates/deployment/src/lib.rs
+++ b/crates/deployment/src/lib.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, sync::Arc};
+use std::sync::Arc;
 
 use anyhow::Error as AnyhowError;
 use async_trait::async_trait;
@@ -6,10 +6,8 @@ use axum::response::sse::Event;
 use db::{
     DBService,
     models::{
-        execution_process::{ExecutionProcess, ExecutionProcessRunReason, ExecutionProcessStatus},
         project::{CreateProject, Project},
-        task::{Task, TaskStatus},
-        task_attempt::{TaskAttempt, TaskAttemptError},
+        task_attempt::TaskAttemptError,
     },
 };
 use executors::executors::ExecutorError;
@@ -36,7 +34,7 @@ use services::services::{
 use sqlx::{Error as SqlxError, types::Uuid};
 use thiserror::Error;
 use tokio::sync::{Mutex, RwLock};
-use utils::{msg_store::MsgStore, sentry as sentry_utils};
+use utils::sentry as sentry_utils;
 
 #[derive(Debug, Clone, Copy, Error)]
 #[error("Remote client not configured")]
@@ -82,8 +80,6 @@ pub trait Deployment: Clone + Send + Sync + 'static {
 
     fn user_id(&self) -> &str;
 
-    fn shared_types() -> Vec<String>;
-
     fn config(&self) -> &Arc<RwLock<Config>>;
 
     fn db(&self) -> &DBService;
@@ -97,8 +93,6 @@ pub trait Deployment: Clone + Send + Sync + 'static {
     fn image(&self) -> &ImageService;
 
     fn filesystem(&self) -> &FilesystemService;
-
-    fn msg_stores(&self) -> &Arc<RwLock<HashMap<Uuid, Arc<MsgStore>>>>;
 
     fn events(&self) -> &EventService;
 
@@ -161,130 +155,6 @@ pub trait Deployment: Clone + Send + Sync + 'static {
         if analytics_enabled && let Some(analytics) = self.analytics() {
             analytics.track_event(self.user_id(), event_name, Some(properties.clone()));
         }
-    }
-
-    /// Cleanup executions marked as running in the db, call at startup
-    async fn cleanup_orphan_executions(&self) -> Result<(), DeploymentError> {
-        let running_processes = ExecutionProcess::find_running(&self.db().pool).await?;
-        for process in running_processes {
-            tracing::info!(
-                "Found orphaned execution process {} for task attempt {}",
-                process.id,
-                process.task_attempt_id
-            );
-            // Update the execution process status first
-            if let Err(e) = ExecutionProcess::update_completion(
-                &self.db().pool,
-                process.id,
-                ExecutionProcessStatus::Failed,
-                None, // No exit code for orphaned processes
-            )
-            .await
-            {
-                tracing::error!(
-                    "Failed to update orphaned execution process {} status: {}",
-                    process.id,
-                    e
-                );
-                continue;
-            }
-            // Capture after-head commit OID (best-effort)
-            if let Ok(Some(task_attempt)) =
-                TaskAttempt::find_by_id(&self.db().pool, process.task_attempt_id).await
-                && let Some(container_ref) = task_attempt.container_ref
-            {
-                let wt = std::path::PathBuf::from(container_ref);
-                if let Ok(head) = self.git().get_head_info(&wt) {
-                    let _ = ExecutionProcess::update_after_head_commit(
-                        &self.db().pool,
-                        process.id,
-                        &head.oid,
-                    )
-                    .await;
-                }
-            }
-            // Process marked as failed
-            tracing::info!("Marked orphaned execution process {} as failed", process.id);
-            // Update task status to InReview for coding agent and setup script failures
-            if matches!(
-                process.run_reason,
-                ExecutionProcessRunReason::CodingAgent
-                    | ExecutionProcessRunReason::SetupScript
-                    | ExecutionProcessRunReason::CleanupScript
-            ) && let Ok(Some(task_attempt)) =
-                TaskAttempt::find_by_id(&self.db().pool, process.task_attempt_id).await
-                && let Ok(Some(task)) = task_attempt.parent_task(&self.db().pool).await
-            {
-                match Task::update_status(&self.db().pool, task.id, TaskStatus::InReview).await {
-                    Ok(_) => {
-                        if let Ok(publisher) = self.share_publisher()
-                            && let Err(err) = publisher.update_shared_task_by_id(task.id).await
-                        {
-                            tracing::warn!(
-                                ?err,
-                                "Failed to propagate shared task update for {}",
-                                task.id
-                            );
-                        }
-                    }
-                    Err(e) => {
-                        tracing::error!(
-                            "Failed to update task status to InReview for orphaned attempt: {}",
-                            e
-                        );
-                    }
-                }
-            }
-        }
-        Ok(())
-    }
-
-    /// Backfill before_head_commit for legacy execution processes.
-    /// Rules:
-    /// - If a process has after_head_commit and missing before_head_commit,
-    ///   then set before_head_commit to the previous process's after_head_commit.
-    /// - If there is no previous process, set before_head_commit to the base branch commit.
-    async fn backfill_before_head_commits(&self) -> Result<(), DeploymentError> {
-        let pool = &self.db().pool;
-        let rows = ExecutionProcess::list_missing_before_context(pool).await?;
-        for row in rows {
-            // Skip if no after commit at all (shouldn't happen due to WHERE)
-            // Prefer previous process after-commit if present
-            let mut before = row.prev_after_head_commit.clone();
-
-            // Fallback to base branch commit OID
-            if before.is_none() {
-                let repo_path =
-                    std::path::Path::new(row.git_repo_path.as_deref().unwrap_or_default());
-                match self
-                    .git()
-                    .get_branch_oid(repo_path, row.target_branch.as_str())
-                {
-                    Ok(oid) => before = Some(oid),
-                    Err(e) => {
-                        tracing::warn!(
-                            "Backfill: Failed to resolve base branch OID for attempt {} (branch {}): {}",
-                            row.task_attempt_id,
-                            row.target_branch,
-                            e
-                        );
-                    }
-                }
-            }
-
-            if let Some(before_oid) = before
-                && let Err(e) =
-                    ExecutionProcess::update_before_head_commit(pool, row.id, &before_oid).await
-            {
-                tracing::warn!(
-                    "Backfill: Failed to update before_head_commit for process {}: {}",
-                    row.id,
-                    e
-                );
-            }
-        }
-
-        Ok(())
     }
 
     /// Trigger background auto-setup of default projects for new users

--- a/crates/local-deployment/src/lib.rs
+++ b/crates/local-deployment/src/lib.rs
@@ -38,7 +38,6 @@ pub struct LocalDeployment {
     user_id: String,
     db: DBService,
     analytics: Option<AnalyticsService>,
-    msg_stores: Arc<RwLock<HashMap<Uuid, Arc<MsgStore>>>>,
     container: LocalContainerService,
     git: GitService,
     image: ImageService,
@@ -183,8 +182,8 @@ impl Deployment for LocalDeployment {
             analytics_ctx,
             approvals.clone(),
             share_publisher.clone(),
-        );
-        container.spawn_worktree_cleanup().await;
+        )
+        .await;
 
         let events = EventService::new(db.clone(), events_msg_store, events_entry_count);
 
@@ -196,7 +195,6 @@ impl Deployment for LocalDeployment {
             user_id,
             db,
             analytics,
-            msg_stores,
             container,
             git,
             image,
@@ -222,10 +220,6 @@ impl Deployment for LocalDeployment {
 
     fn user_id(&self) -> &str {
         &self.user_id
-    }
-
-    fn shared_types() -> Vec<String> {
-        vec![]
     }
 
     fn config(&self) -> &Arc<RwLock<Config>> {
@@ -254,10 +248,6 @@ impl Deployment for LocalDeployment {
 
     fn filesystem(&self) -> &FilesystemService {
         &self.filesystem
-    }
-
-    fn msg_stores(&self) -> &Arc<RwLock<HashMap<Uuid, Arc<MsgStore>>>> {
-        &self.msg_stores
     }
 
     fn events(&self) -> &EventService {

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -47,8 +47,16 @@ async fn main() -> Result<(), VibeKanbanError> {
 
     let deployment = DeploymentImpl::new().await?;
     deployment.update_sentry_scope().await?;
-    deployment.cleanup_orphan_executions().await?;
-    deployment.backfill_before_head_commits().await?;
+    deployment
+        .container()
+        .cleanup_orphan_executions()
+        .await
+        .map_err(DeploymentError::from)?;
+    deployment
+        .container()
+        .backfill_before_head_commits()
+        .await
+        .map_err(DeploymentError::from)?;
     deployment.spawn_pr_monitor_service().await;
     deployment
         .track_if_analytics_allowed("session_start", serde_json::json!({}))

--- a/crates/utils/src/text.rs
+++ b/crates/utils/src/text.rs
@@ -22,3 +22,39 @@ pub fn short_uuid(u: &Uuid) -> String {
     let full = u.simple().to_string();
     full.chars().take(4).collect() // grab the first 4 chars
 }
+
+pub fn truncate_to_char_boundary(content: &str, max_len: usize) -> &str {
+    if content.len() <= max_len {
+        return content;
+    }
+
+    let cutoff = content
+        .char_indices()
+        .map(|(idx, _)| idx)
+        .chain(std::iter::once(content.len()))
+        .take_while(|&idx| idx <= max_len)
+        .last()
+        .unwrap_or(0);
+
+    debug_assert!(content.is_char_boundary(cutoff));
+    &content[..cutoff]
+}
+
+#[cfg(test)]
+mod tests {
+
+    #[test]
+    fn test_truncate_to_char_boundary() {
+        use super::truncate_to_char_boundary;
+
+        let input = "a".repeat(10);
+        assert_eq!(truncate_to_char_boundary(&input, 7), "a".repeat(7));
+
+        let input = "hello world";
+        assert_eq!(truncate_to_char_boundary(input, input.len()), input);
+
+        let input = "🔥🔥🔥"; // each fire emoji is 4 bytes
+        assert_eq!(truncate_to_char_boundary(input, 5), "🔥");
+        assert_eq!(truncate_to_char_boundary(input, 3), "");
+    }
+}


### PR DESCRIPTION
- Move execution logic down from `Deployment` into `Container`
- Move generic `Container` logic (e.g. task finalisation) out of `LocalContainer`
- Remove dead code