### PR TITLE
chore: bump @anthropic-ai/claude-code to 2.0.53

### DIFF
--- a/crates/executors/src/executors/claude.rs
+++ b/crates/executors/src/executors/claude.rs
@@ -38,7 +38,7 @@ fn base_command(claude_code_router: bool) -> &'static str {
     if claude_code_router {
         "npx -y @musistudio/claude-code-router@1.0.66 code"
     } else {
-        "npx -y @anthropic-ai/claude-code@2.0.42"
+        "npx -y @anthropic-ai/claude-code@2.0.53"
     }
 }
 


### PR DESCRIPTION
## Summary
- Bumps `@anthropic-ai/claude-code` from 2.0.42 to 2.0.53

## Test plan
- [ ] Verify Claude Code executor works with the new version

🤖 Generated with [Claude Code](https://claude.com/claude-code)