### PR TITLE
feat: add configurable version field for coding agents

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1058,7 +1058,7 @@ checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 
 [[package]]
 name = "db"
-version = "0.0.122"
+version = "0.0.123"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1087,7 +1087,7 @@ dependencies = [
 
 [[package]]
 name = "deployment"
-version = "0.0.122"
+version = "0.0.123"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1438,7 +1438,7 @@ dependencies = [
 
 [[package]]
 name = "executors"
-version = "0.0.122"
+version = "0.0.123"
 dependencies = [
  "agent-client-protocol",
  "async-trait",
@@ -2646,7 +2646,7 @@ dependencies = [
 
 [[package]]
 name = "local-deployment"
-version = "0.0.122"
+version = "0.0.123"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3684,7 +3684,7 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "remote"
-version = "0.0.122"
+version = "0.0.123"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4349,7 +4349,7 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.0.122"
+version = "0.0.123"
 dependencies = [
  "anyhow",
  "axum 0.8.6",
@@ -4395,7 +4395,7 @@ dependencies = [
 
 [[package]]
 name = "services"
-version = "0.0.122"
+version = "0.0.123"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5586,7 +5586,7 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utils"
-version = "0.0.122"
+version = "0.0.123"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "db"
-version = "0.0.122"
+version = "0.0.123"
 edition = "2024"
 
 [dependencies]

--- a/crates/deployment/Cargo.toml
+++ b/crates/deployment/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deployment"
-version = "0.0.122"
+version = "0.0.123"
 edition = "2024"
 
 [dependencies]

--- a/crates/executors/Cargo.toml
+++ b/crates/executors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "executors"
-version = "0.0.122"
+version = "0.0.123"
 edition = "2024"
 
 [dependencies]

--- a/crates/executors/src/executors/codex.rs
+++ b/crates/executors/src/executors/codex.rs
@@ -105,6 +105,12 @@ pub enum ReasoningSummaryFormat {
 pub struct Codex {
     #[serde(default)]
     pub append_prompt: AppendPrompt,
+    #[schemars(
+        title = "Version",
+        description = "Codex version to use (e.g., '0.60.1', 'latest'). Defaults to 'latest'."
+    )]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub sandbox: Option<SandboxMode>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -195,13 +201,16 @@ impl StandardCodingAgentExecutor for Codex {
     }
 }
 
+const DEFAULT_CODEX_VERSION: &str = "latest";
+
 impl Codex {
-    pub fn base_command() -> &'static str {
-        "npx -y @openai/codex@0.60.1"
+    pub fn base_command(version: Option<&str>) -> String {
+        let ver = version.unwrap_or(DEFAULT_CODEX_VERSION);
+        format!("npx -y @openai/codex@{}", ver)
     }
 
     fn build_command_builder(&self) -> CommandBuilder {
-        let mut builder = CommandBuilder::new(Self::base_command());
+        let mut builder = CommandBuilder::new(Self::base_command(self.version.as_deref()));
         builder = builder.extend_params(["app-server"]);
         if self.oss.unwrap_or(false) {
             builder = builder.extend_params(["--oss"]);

--- a/crates/executors/src/executors/gemini.rs
+++ b/crates/executors/src/executors/gemini.rs
@@ -14,10 +14,18 @@ use crate::{
     },
 };
 
+const DEFAULT_GEMINI_VERSION: &str = "latest";
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, TS, JsonSchema)]
 pub struct Gemini {
     #[serde(default)]
     pub append_prompt: AppendPrompt,
+    #[schemars(
+        title = "Version",
+        description = "Gemini CLI version to use (e.g., '0.16.0', 'latest'). Defaults to 'latest'."
+    )]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -28,7 +36,8 @@ pub struct Gemini {
 
 impl Gemini {
     fn build_command_builder(&self) -> CommandBuilder {
-        let mut builder = CommandBuilder::new("npx -y @google/gemini-cli@0.16.0");
+        let ver = self.version.as_deref().unwrap_or(DEFAULT_GEMINI_VERSION);
+        let mut builder = CommandBuilder::new(format!("npx -y @google/gemini-cli@{}", ver));
 
         if let Some(model) = &self.model {
             builder = builder.extend_params(["--model", model.as_str()]);

--- a/crates/executors/src/executors/opencode.rs
+++ b/crates/executors/src/executors/opencode.rs
@@ -94,10 +94,18 @@ struct OcToolState {
     title: Option<String>,
 }
 
+const DEFAULT_OPENCODE_VERSION: &str = "latest";
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, TS, JsonSchema)]
 pub struct Opencode {
     #[serde(default)]
     pub append_prompt: AppendPrompt,
+    #[schemars(
+        title = "Version",
+        description = "OpenCode version to use (e.g., '1.0.68', 'latest'). Defaults to 'latest'."
+    )]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -108,7 +116,8 @@ pub struct Opencode {
 
 impl Opencode {
     fn build_command_builder(&self) -> CommandBuilder {
-        let mut builder = CommandBuilder::new("npx -y opencode-ai@1.0.68 run").params([
+        let ver = self.version.as_deref().unwrap_or(DEFAULT_OPENCODE_VERSION);
+        let mut builder = CommandBuilder::new(format!("npx -y opencode-ai@{} run", ver)).params([
             "--print-logs",
             "--log-level",
             "ERROR",

--- a/crates/executors/src/executors/qwen.rs
+++ b/crates/executors/src/executors/qwen.rs
@@ -14,10 +14,18 @@ use crate::{
     },
 };
 
+const DEFAULT_QWEN_VERSION: &str = "latest";
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, TS, JsonSchema)]
 pub struct QwenCode {
     #[serde(default)]
     pub append_prompt: AppendPrompt,
+    #[schemars(
+        title = "Version",
+        description = "Qwen Code version to use (e.g., '0.2.1', 'latest'). Defaults to 'latest'."
+    )]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub yolo: Option<bool>,
     #[serde(flatten)]
@@ -26,7 +34,8 @@ pub struct QwenCode {
 
 impl QwenCode {
     fn build_command_builder(&self) -> CommandBuilder {
-        let mut builder = CommandBuilder::new("npx -y @qwen-code/qwen-code@0.2.1");
+        let ver = self.version.as_deref().unwrap_or(DEFAULT_QWEN_VERSION);
+        let mut builder = CommandBuilder::new(format!("npx -y @qwen-code/qwen-code@{}", ver));
 
         if self.yolo.unwrap_or(false) {
             builder = builder.extend_params(["--yolo"]);

--- a/crates/local-deployment/Cargo.toml
+++ b/crates/local-deployment/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "local-deployment"
-version = "0.0.122"
+version = "0.0.123"
 edition = "2024"
 
 [dependencies]

--- a/crates/remote/Cargo.toml
+++ b/crates/remote/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remote"
-version = "0.0.122"
+version = "0.0.123"
 edition = "2024"
 publish = false
 

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "server"
-version = "0.0.122"
+version = "0.0.123"
 edition = "2024"
 default-run = "server"
 

--- a/crates/server/src/routes/task_attempts/codex_setup.rs
+++ b/crates/server/src/routes/task_attempts/codex_setup.rs
@@ -55,7 +55,7 @@ pub async fn run_codex_setup(
 }
 
 async fn get_setup_helper_action(codex: &Codex) -> Result<ExecutorAction, ApiError> {
-    let mut login_command = CommandBuilder::new(Codex::base_command());
+    let mut login_command = CommandBuilder::new(Codex::base_command(codex.version.as_deref()));
     login_command = login_command.extend_params(["login"]);
     login_command = apply_overrides(login_command, &codex.cmd);
 

--- a/crates/services/Cargo.toml
+++ b/crates/services/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "services"
-version = "0.0.122"
+version = "0.0.123"
 edition = "2024"
 
 [features]

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "utils"
-version = "0.0.122"
+version = "0.0.123"
 edition = "2024"
 
 [dependencies]

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vibe-kanban",
   "private": true,
-  "version": "0.0.122",
+  "version": "0.0.123",
   "type": "module",
   "scripts": {
     "dev": "VITE_OPEN=${VITE_OPEN:-false} vite",

--- a/npx-cli/package.json
+++ b/npx-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vibe-kanban",
   "private": false,
-  "version": "0.0.122",
+  "version": "0.0.123",
   "main": "index.js",
   "bin": {
     "vibe-kanban": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-kanban",
-  "version": "0.0.122",
+  "version": "0.0.123",
   "private": true,
   "bin": {
     "vibe-kanban": "npx-cli/bin/cli.js"

--- a/shared/schemas/claude_code.json
+++ b/shared/schemas/claude_code.json
@@ -11,6 +11,14 @@
       "format": "textarea",
       "default": null
     },
+    "version": {
+      "title": "Version",
+      "description": "Claude Code version to use (e.g., '2.0.42', 'latest'). Defaults to 'latest'.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "claude_code_router": {
       "type": [
         "boolean",

--- a/shared/schemas/codex.json
+++ b/shared/schemas/codex.json
@@ -11,6 +11,14 @@
       "format": "textarea",
       "default": null
     },
+    "version": {
+      "title": "Version",
+      "description": "Codex version to use (e.g., '0.60.1', 'latest'). Defaults to 'latest'.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "sandbox": {
       "description": "Sandbox policy modes for Codex",
       "type": [

--- a/shared/schemas/gemini.json
+++ b/shared/schemas/gemini.json
@@ -11,6 +11,14 @@
       "format": "textarea",
       "default": null
     },
+    "version": {
+      "title": "Version",
+      "description": "Gemini CLI version to use (e.g., '0.16.0', 'latest'). Defaults to 'latest'.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "model": {
       "type": [
         "string",

--- a/shared/schemas/opencode.json
+++ b/shared/schemas/opencode.json
@@ -11,6 +11,14 @@
       "format": "textarea",
       "default": null
     },
+    "version": {
+      "title": "Version",
+      "description": "OpenCode version to use (e.g., '1.0.68', 'latest'). Defaults to 'latest'.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "model": {
       "type": [
         "string",

--- a/shared/schemas/qwen_code.json
+++ b/shared/schemas/qwen_code.json
@@ -11,6 +11,14 @@
       "format": "textarea",
       "default": null
     },
+    "version": {
+      "title": "Version",
+      "description": "Qwen Code version to use (e.g., '0.2.1', 'latest'). Defaults to 'latest'.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "yolo": {
       "type": [
         "boolean",

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -238,13 +238,13 @@ export type ExecutorConfigs = { executors: { [key in BaseCodingAgent]?: Executor
 
 export enum BaseAgentCapability { SESSION_FORK = "SESSION_FORK", SETUP_HELPER = "SETUP_HELPER" }
 
-export type ClaudeCode = { append_prompt: AppendPrompt, claude_code_router?: boolean | null, plan?: boolean | null, approvals?: boolean | null, model?: string | null, dangerously_skip_permissions?: boolean | null, base_command_override?: string | null, additional_params?: Array<string> | null, };
+export type ClaudeCode = { append_prompt: AppendPrompt, version?: string | null, claude_code_router?: boolean | null, plan?: boolean | null, approvals?: boolean | null, model?: string | null, dangerously_skip_permissions?: boolean | null, base_command_override?: string | null, additional_params?: Array<string> | null, };
 
-export type Gemini = { append_prompt: AppendPrompt, model?: string | null, yolo?: boolean | null, base_command_override?: string | null, additional_params?: Array<string> | null, };
+export type Gemini = { append_prompt: AppendPrompt, version?: string | null, model?: string | null, yolo?: boolean | null, base_command_override?: string | null, additional_params?: Array<string> | null, };
 
 export type Amp = { append_prompt: AppendPrompt, dangerously_allow_all?: boolean | null, base_command_override?: string | null, additional_params?: Array<string> | null, };
 
-export type Codex = { append_prompt: AppendPrompt, sandbox?: SandboxMode | null, ask_for_approval?: AskForApproval | null, oss?: boolean | null, model?: string | null, model_reasoning_effort?: ReasoningEffort | null, model_reasoning_summary?: ReasoningSummary | null, model_reasoning_summary_format?: ReasoningSummaryFormat | null, profile?: string | null, base_instructions?: string | null, include_plan_tool?: boolean | null, include_apply_patch_tool?: boolean | null, base_command_override?: string | null, additional_params?: Array<string> | null, };
+export type Codex = { append_prompt: AppendPrompt, version?: string | null, sandbox?: SandboxMode | null, ask_for_approval?: AskForApproval | null, oss?: boolean | null, model?: string | null, model_reasoning_effort?: ReasoningEffort | null, model_reasoning_summary?: ReasoningSummary | null, model_reasoning_summary_format?: ReasoningSummaryFormat | null, profile?: string | null, base_instructions?: string | null, include_plan_tool?: boolean | null, include_apply_patch_tool?: boolean | null, base_command_override?: string | null, additional_params?: Array<string> | null, };
 
 export type SandboxMode = "auto" | "read-only" | "workspace-write" | "danger-full-access";
 
@@ -260,9 +260,9 @@ export type CursorAgent = { append_prompt: AppendPrompt, force?: boolean | null,
 
 export type Copilot = { append_prompt: AppendPrompt, model?: string | null, allow_all_tools?: boolean | null, allow_tool?: string | null, deny_tool?: string | null, add_dir?: Array<string> | null, disable_mcp_server?: Array<string> | null, base_command_override?: string | null, additional_params?: Array<string> | null, };
 
-export type Opencode = { append_prompt: AppendPrompt, model?: string | null, agent?: string | null, base_command_override?: string | null, additional_params?: Array<string> | null, };
+export type Opencode = { append_prompt: AppendPrompt, version?: string | null, model?: string | null, agent?: string | null, base_command_override?: string | null, additional_params?: Array<string> | null, };
 
-export type QwenCode = { append_prompt: AppendPrompt, yolo?: boolean | null, base_command_override?: string | null, additional_params?: Array<string> | null, };
+export type QwenCode = { append_prompt: AppendPrompt, version?: string | null, yolo?: boolean | null, base_command_override?: string | null, additional_params?: Array<string> | null, };
 
 export type Droid = { append_prompt: AppendPrompt, autonomy: Autonomy, model?: string | null, reasoning_effort?: DroidReasoningEffort | null, base_command_override?: string | null, additional_params?: Array<string> | null, };
 


### PR DESCRIPTION
## Summary

- Add `version` field to coding agent configurations, allowing users to specify which version of each agent to use via **Settings > Agents** page
- All agents default to `"latest"` when version is not specified

### Affected agents:
| Agent | Package |
|-------|---------|
| Claude Code | `@anthropic-ai/claude-code` |
| Codex | `@openai/codex` |
| Gemini | `@google/gemini-cli` |
| Qwen Code | `@qwen-code/qwen-code` |
| OpenCode | `opencode-ai` |

## Test plan

- [ ] Verify version field appears in Settings > Agents for each agent type
- [ ] Test with `latest` (default) - agent should use latest version
- [ ] Test with specific version (e.g., `2.0.42` for Claude Code) - agent should use specified version
- [ ] Verify existing configurations without version field continue to work (defaults to latest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)