### PR TITLE
Parse tool_use_id in canusetool control request

### DIFF
--- a/crates/executors/src/executors/claude/protocol.rs
+++ b/crates/executors/src/executors/claude/protocol.rs
@@ -96,9 +96,10 @@ impl ProtocolPeer {
                 tool_name,
                 input,
                 permission_suggestions,
+                tool_use_id,
             } => {
                 match client
-                    .on_can_use_tool(tool_name, input, permission_suggestions)
+                    .on_can_use_tool(tool_name, input, permission_suggestions, tool_use_id)
                     .await
                 {
                     Ok(result) => {

--- a/crates/executors/src/executors/claude/types.rs
+++ b/crates/executors/src/executors/claude/types.rs
@@ -67,6 +67,8 @@ pub enum ControlRequestType {
         input: Value,
         #[serde(skip_serializing_if = "Option::is_none")]
         permission_suggestions: Option<Vec<PermissionUpdate>>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        tool_use_id: Option<String>,
     },
     HookCallback {
         #[serde(rename = "callback_id")]


### PR DESCRIPTION
Use `tool_use_id` provided by `CanUseTool` control request instead of caching the latest tool use id