### PR TITLE
Fix diff panel showing 'No changes' for large diffs

### DIFF
--- a/frontend/src/components/panels/DiffsPanel.tsx
+++ b/frontend/src/components/panels/DiffsPanel.tsx
@@ -40,10 +40,6 @@ export function DiffsPanel({ selectedAttempt, gitOps }: DiffsPanelProps) {
   }, [selectedAttempt?.id]);
 
   useEffect(() => {
-    setLoading(true);
-  }, [selectedAttempt?.id]);
-
-  useEffect(() => {
     if (diffs.length > 0 && loading) {
       setLoading(false);
     }


### PR DESCRIPTION
## Summary
- Fix issue where diff panel displayed "No changes have been made yet" when viewing task attempts with many changed files
- Move blocking `get_diffs` call to a background task so WebSocket stream returns immediately

## Changes
- **Backend**: Fetch initial diffs asynchronously using `spawn_blocking`, allowing the WebSocket connection to be established before diff computation completes
- **Frontend**: Remove duplicate `useEffect` that was redundantly calling `setLoading(true)` (also call it L38)

## Test plan
- [x] View a task attempt with a small number of changed files - diffs should load quickly
- [x] View a task attempt with many changed files (100+) - diffs should load without showing "No changes" message

Close #1375

🤖 Generated with [Claude Code](https://claude.com/claude-code)