### PR TITLE
chore: tune down debug logs in `worktree_manager` (vibe-kanban)

### DIFF
--- a/crates/services/src/services/worktree_manager.rs
+++ b/crates/services/src/services/worktree_manager.rs
@@ -6,7 +6,7 @@ use std::{
 
 use git2::{Error as GitError, Repository};
 use thiserror::Error;
-use tracing::{debug, info};
+use tracing::{debug, info, trace};
 use utils::shell::resolve_executable_path;
 
 use super::git::{GitService, GitServiceError};
@@ -109,7 +109,7 @@ impl WorktreeManager {
 
         // Check if worktree already exists and is properly set up
         if Self::is_worktree_properly_set_up(repo_path, worktree_path).await? {
-            debug!("Worktree already properly set up at path: {}", path_str);
+            trace!("Worktree already properly set up at path: {}", path_str);
             return Ok(());
         }
 

--- a/crates/utils/src/path.rs
+++ b/crates/utils/src/path.rs
@@ -6,7 +6,7 @@ pub const VIBE_IMAGES_DIR: &str = ".vibe-images";
 /// Convert absolute paths to relative paths based on worktree path
 /// This is a robust implementation that handles symlinks and edge cases
 pub fn make_path_relative(path: &str, worktree_path: &str) -> String {
-    tracing::debug!("Making path relative: {} -> {}", path, worktree_path);
+    tracing::trace!("Making path relative: {} -> {}", path, worktree_path);
 
     let path_obj = normalize_macos_private_alias(Path::new(&path));
     let worktree_path_obj = normalize_macos_private_alias(Path::new(worktree_path));
@@ -18,7 +18,7 @@ pub fn make_path_relative(path: &str, worktree_path: &str) -> String {
 
     if let Ok(relative_path) = path_obj.strip_prefix(&worktree_path_obj) {
         let result = relative_path.to_string_lossy().to_string();
-        tracing::debug!("Successfully made relative: '{}' -> '{}'", path, result);
+        tracing::trace!("Successfully made relative: '{}' -> '{}'", path, result);
         if result.is_empty() {
             return ".".to_string();
         }


### PR DESCRIPTION
We should use trace rather than debug logs for routine activity like "Worktree already properly set up at path" and "Making path relative".

These logs are noisy and uninformative.