### PR TITLE
fix: image attachment bug

### DIFF
--- a/crates/db/src/models/image.rs
+++ b/crates/db/src/models/image.rs
@@ -177,36 +177,6 @@ impl Image {
 }
 
 impl TaskImage {
-    pub async fn create(pool: &SqlitePool, data: &CreateTaskImage) -> Result<Self, sqlx::Error> {
-        let id = Uuid::new_v4();
-        sqlx::query_as!(
-            TaskImage,
-            r#"INSERT INTO task_images (id, task_id, image_id)
-               VALUES ($1, $2, $3)
-               RETURNING id as "id!: Uuid",
-                         task_id as "task_id!: Uuid",
-                         image_id as "image_id!: Uuid", 
-                         created_at as "created_at!: DateTime<Utc>""#,
-            id,
-            data.task_id,
-            data.image_id,
-        )
-        .fetch_one(pool)
-        .await
-    }
-
-    pub async fn associate_many(
-        pool: &SqlitePool,
-        task_id: Uuid,
-        image_ids: &[Uuid],
-    ) -> Result<(), sqlx::Error> {
-        for &image_id in image_ids {
-            let task_image = CreateTaskImage { task_id, image_id };
-            TaskImage::create(pool, &task_image).await?;
-        }
-        Ok(())
-    }
-
     /// Associate multiple images with a task, skipping duplicates.
     pub async fn associate_many_dedup(
         pool: &SqlitePool,

--- a/crates/server/src/routes/tasks.rs
+++ b/crates/server/src/routes/tasks.rs
@@ -151,7 +151,7 @@ pub async fn create_task_and_start(
     let task = Task::create(&deployment.db().pool, &payload.task, task_id).await?;
 
     if let Some(image_ids) = &payload.task.image_ids {
-        TaskImage::associate_many(&deployment.db().pool, task.id, image_ids).await?;
+        TaskImage::associate_many_dedup(&deployment.db().pool, task.id, image_ids).await?;
     }
 
     deployment


### PR DESCRIPTION
Fixes a bug where you couldn't create an task a task with an image if the same image had previously been removed from the task.

Also removes some unused methods.