### PR TITLE
Add link to discord in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ We use [GitHub Discussions](https://github.com/BloopAI/vibe-kanban/discussions) 
 
 ## Contributing
 
-We would prefer that ideas and changes are first raised with the core team via [GitHub Discussions](https://github.com/BloopAI/vibe-kanban/discussions) or Discord, where we can discuss implementation details and alignment with the existing roadmap. Please do not open PRs without first discussing your proposal with the team.
+We would prefer that ideas and changes are first raised with the core team via [GitHub Discussions](https://github.com/BloopAI/vibe-kanban/discussions) or [Discord](https://discord.gg/AC4nwVtJM3), where we can discuss implementation details and alignment with the existing roadmap. Please do not open PRs without first discussing your proposal with the team.
 
 ## Development
 


### PR DESCRIPTION
Add a link to the Discord server in the README.

I was looking at the README to get some help and it was talking about a Discord server but did not include any link.
Having the link in the README might lead more users to the Discord server.