### PR TITLE
Remove logo from Navbar

### DIFF
--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -20,7 +20,6 @@ import {
   LogOut,
   LogIn,
 } from 'lucide-react';
-import { Logo } from '@/components/Logo';
 import { SearchBar } from '@/components/SearchBar';
 import { useSearch } from '@/contexts/SearchContext';
 import { openTaskForm } from '@/lib/openTaskForm';
@@ -138,9 +137,6 @@ export function Navbar() {
       <div className="w-full px-3">
         <div className="flex items-center h-12 py-2">
           <div className="flex-1 flex items-center">
-            <Link to="/projects">
-              <Logo />
-            </Link>
             <a
               href="https://discord.gg/AC4nwVtJM3"
               target="_blank"


### PR DESCRIPTION
## Summary
- Remove the Logo component from the Navbar

## Changes
- Removed the `Logo` import from `@/components/Logo`
- Removed the `<Link to="/projects"><Logo /></Link>` wrapper that displayed the logo in the navbar's left section

The Discord badge now appears at the left edge of the navbar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)