### PR TITLE
Remove navbar logo link (Vibe Kanban)

### DIFF
--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -20,7 +20,6 @@ import {
   LogOut,
   LogIn,
 } from 'lucide-react';
-import { Logo } from '@/components/Logo';
 import { SearchBar } from '@/components/SearchBar';
 import { useSearch } from '@/contexts/SearchContext';
 import { openTaskForm } from '@/lib/openTaskForm';
@@ -138,9 +137,6 @@ export function Navbar() {
       <div className="w-full px-3">
         <div className="flex items-center h-12 py-2">
           <div className="flex-1 flex items-center">
-            <Link to="/projects">
-              <Logo />
-            </Link>
             <a
               href="https://discord.gg/AC4nwVtJM3"
               target="_blank"


### PR DESCRIPTION
## Summary
- remove the `Logo` import and link in the global navbar so the branding mark no longer renders there
- keep the Discord CTA as the lead element to preserve layout without adding replacements

## Rationale
The `vk/180b-remove-the-logo` task requires stripping the header logo from the UI. Removing the component at its only usage point ensures nothing renders while minimizing collateral changes elsewhere.

## Implementation Notes
- only `frontend/src/components/layout/Navbar.tsx` changed; no other files or logic were touched
- no CSS adjustments were needed because the remaining flex container already spans the space

This PR was written using [Vibe Kanban](https://vibekanban.com)
