### PR TITLE
Remove logo from Navbar (Vibe Kanban)

### DIFF
--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -20,7 +20,6 @@ import {
   LogOut,
   LogIn,
 } from 'lucide-react';
-import { Logo } from '@/components/Logo';
 import { SearchBar } from '@/components/SearchBar';
 import { useSearch } from '@/contexts/SearchContext';
 import { openTaskForm } from '@/lib/openTaskForm';
@@ -138,9 +137,6 @@ export function Navbar() {
       <div className="w-full px-3">
         <div className="flex items-center h-12 py-2">
           <div className="flex-1 flex items-center">
-            <Link to="/projects">
-              <Logo />
-            </Link>
             <a
               href="https://discord.gg/AC4nwVtJM3"
               target="_blank"


### PR DESCRIPTION
## Summary

Remove the Logo component from the Navbar to simplify the header layout.

## Changes Made

- Removed the `Logo` component import from `Navbar.tsx`
- Removed the `<Link to="/projects"><Logo /></Link>` element from the navbar's left section

## Implementation Details

The Logo SVG component (`frontend/src/components/Logo.tsx`) is retained in the codebase but is no longer rendered in the Navbar. The Discord online count badge is now the first element in the left section of the navbar.

---

This PR was written using [Vibe Kanban](https://vibekanban.com)