### PR TITLE
Add multi-repo support for push and force push (Vibe Kanban)

### DIFF
--- a/crates/server/src/bin/generate_types.rs
+++ b/crates/server/src/bin/generate_types.rs
@@ -104,6 +104,7 @@ fn generate_types_content() -> String {
         server::routes::task_attempts::ChangeTargetBranchRequest::decl(),
         server::routes::task_attempts::ChangeTargetBranchResponse::decl(),
         server::routes::task_attempts::MergeTaskAttemptRequest::decl(),
+        server::routes::task_attempts::PushTaskAttemptRequest::decl(),
         server::routes::task_attempts::RenameBranchRequest::decl(),
         server::routes::task_attempts::RenameBranchResponse::decl(),
         server::routes::task_attempts::CommitCompareResult::decl(),

--- a/frontend/src/components/dialogs/git/ForcePushDialog.tsx
+++ b/frontend/src/components/dialogs/git/ForcePushDialog.tsx
@@ -17,12 +17,13 @@ import { useTranslation } from 'react-i18next';
 
 export interface ForcePushDialogProps {
   attemptId: string;
+  repoId: string;
   branchName?: string;
 }
 
 const ForcePushDialogImpl = NiceModal.create<ForcePushDialogProps>((props) => {
   const modal = useModal();
-  const { attemptId, branchName } = props;
+  const { attemptId, repoId, branchName } = props;
   const [error, setError] = useState<string | null>(null);
   const { t } = useTranslation(['tasks', 'common']);
   const branchLabel = branchName ? ` "${branchName}"` : '';
@@ -47,7 +48,7 @@ const ForcePushDialogImpl = NiceModal.create<ForcePushDialogProps>((props) => {
   const handleConfirm = async () => {
     setError(null);
     try {
-      await forcePush.mutateAsync();
+      await forcePush.mutateAsync({ repo_id: repoId });
     } catch {
       // Error already handled by onError callback
     }

--- a/frontend/src/components/tasks/Toolbar/GitOperations.tsx
+++ b/frontend/src/components/tasks/Toolbar/GitOperations.tsx
@@ -201,7 +201,9 @@ function GitOperations({
   const handlePushClick = async () => {
     try {
       setPushing(true);
-      await git.actions.push();
+      const repoId = getSelectedRepoId();
+      if (!repoId) return;
+      await git.actions.push({ repo_id: repoId });
       setPushSuccess(true);
       setTimeout(() => setPushSuccess(false), 2000);
     } finally {

--- a/frontend/src/hooks/useForcePush.ts
+++ b/frontend/src/hooks/useForcePush.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { attemptsApi } from '@/lib/api';
-import type { PushError } from 'shared/types';
+import type { PushError, PushTaskAttemptRequest } from 'shared/types';
 
 class ForcePushErrorWithData extends Error {
   constructor(
@@ -19,10 +19,10 @@ export function useForcePush(
 ) {
   const queryClient = useQueryClient();
 
-  return useMutation({
-    mutationFn: async () => {
+  return useMutation<void, unknown, PushTaskAttemptRequest>({
+    mutationFn: async (params: PushTaskAttemptRequest) => {
       if (!attemptId) return;
-      const result = await attemptsApi.forcePush(attemptId);
+      const result = await attemptsApi.forcePush(attemptId, params);
       if (!result.success) {
         throw new ForcePushErrorWithData(
           result.message || 'Force push failed',

--- a/frontend/src/hooks/useGitOperations.ts
+++ b/frontend/src/hooks/useGitOperations.ts
@@ -5,7 +5,7 @@ import { useForcePush } from './useForcePush';
 import { useChangeTargetBranch } from './useChangeTargetBranch';
 import { useGitOperationsError } from '@/contexts/GitOperationsContext';
 import { Result } from '@/lib/api';
-import type { GitOperationError } from 'shared/types';
+import type { GitOperationError, PushTaskAttemptRequest } from 'shared/types';
 import { ForcePushDialog } from '@/components/dialogs/git/ForcePushDialog';
 
 export function useGitOperations(
@@ -58,12 +58,12 @@ export function useGitOperations(
   const push = usePush(
     attemptId,
     () => setError(null),
-    async (err: unknown, errorData) => {
+    async (err: unknown, errorData, params?: PushTaskAttemptRequest) => {
       // Handle typed push errors
       if (errorData?.type === 'force_push_required') {
         // Show confirmation dialog - dialog handles the force push internally
-        if (attemptId) {
-          await ForcePushDialog.show({ attemptId });
+        if (attemptId && params?.repo_id) {
+          await ForcePushDialog.show({ attemptId, repoId: params.repo_id });
         }
         return;
       }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -84,6 +84,7 @@ import {
   QueueStatus,
   PrCommentsResponse,
   MergeTaskAttemptRequest,
+  PushTaskAttemptRequest,
   RepoBranchStatus,
   AbortConflictsRequest,
 } from 'shared/types';
@@ -555,18 +556,26 @@ export const attemptsApi = {
     return handleApiResponse<void>(response);
   },
 
-  push: async (attemptId: string): Promise<Result<void, PushError>> => {
+  push: async (
+    attemptId: string,
+    data: PushTaskAttemptRequest
+  ): Promise<Result<void, PushError>> => {
     const response = await makeRequest(`/api/task-attempts/${attemptId}/push`, {
       method: 'POST',
+      body: JSON.stringify(data),
     });
     return handleApiResponseAsResult<void, PushError>(response);
   },
 
-  forcePush: async (attemptId: string): Promise<Result<void, PushError>> => {
+  forcePush: async (
+    attemptId: string,
+    data: PushTaskAttemptRequest
+  ): Promise<Result<void, PushError>> => {
     const response = await makeRequest(
       `/api/task-attempts/${attemptId}/push/force`,
       {
         method: 'POST',
+        body: JSON.stringify(data),
       }
     );
     return handleApiResponseAsResult<void, PushError>(response);

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -208,6 +208,8 @@ export type ChangeTargetBranchResponse = { repo_id: string, new_target_branch: s
 
 export type MergeTaskAttemptRequest = { repo_id: string, };
 
+export type PushTaskAttemptRequest = { repo_id: string, };
+
 export type RenameBranchRequest = { new_branch_name: string, };
 
 export type RenameBranchResponse = { branch: string, };


### PR DESCRIPTION
## Summary

Added multi-repo support for push and force push operations, following the same pattern used for merge and rebase. This ensures push operations work correctly in projects with multiple repositories.

## Changes

### Backend (Rust)
- Added `PushTaskAttemptRequest` struct with `repo_id` field to specify which repository to push
- Updated `push_task_attempt_branch` endpoint to accept `repo_id` and build the correct worktree path for that repository
- Updated `force_push_task_attempt_branch` endpoint with the same multi-repo support
- Added type export in `generate_types.rs` to expose `PushTaskAttemptRequest` to TypeScript

### Frontend (TypeScript)
- Updated `api.ts` to pass `PushTaskAttemptRequest` with `repo_id` to push/forcePush endpoints
- Updated `usePush` and `useForcePush` hooks to use `PushTaskAttemptRequest` from shared types (not local types)
- Updated `ForcePushDialog` to accept and pass `repoId`
- Updated `useGitOperations` to pass `repoId` to the ForcePushDialog when push fails with `force_push_required`
- Updated `GitOperations` component to pass the selected repo's ID when pushing

## Implementation Details

The implementation follows the existing pattern from merge (`MergeTaskAttemptRequest`):
1. Frontend sends `{ repo_id: string }` in the request body
2. Backend looks up the `AttemptRepo` and `Repo` records using the provided `repo_id`
3. Backend constructs the worktree path as `workspace_path.join(repo.name)`
4. Push/force push operations are performed on the correct repository worktree

This ensures type safety by using the generated `PushTaskAttemptRequest` type from `shared/types.ts`, which will catch any type mismatches if the backend type changes.

---

This PR was written using [Vibe Kanban](https://vibekanban.com)