### PR TITLE
docs: document PORT environment variable with dev/prod behavior (Vibe Kanban)

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,8 +105,9 @@ The following environment variables can be configured at build time or runtime:
 |----------|------|---------|-------------|
 | `POSTHOG_API_KEY` | Build-time | Empty | PostHog analytics API key (disables analytics if empty) |
 | `POSTHOG_API_ENDPOINT` | Build-time | Empty | PostHog analytics endpoint (disables analytics if empty) |
-| `BACKEND_PORT` | Runtime | `0` (auto-assign) | Backend server port |
-| `FRONTEND_PORT` | Runtime | `3000` | Frontend development server port |
+| `PORT` | Runtime | Auto-assign | **Production**: Server port. **Dev**: Frontend port (backend uses PORT+1) |
+| `BACKEND_PORT` | Runtime | `0` (auto-assign) | Backend server port (dev mode only, overrides PORT+1) |
+| `FRONTEND_PORT` | Runtime | `3000` | Frontend dev server port (dev mode only, overrides PORT) |
 | `HOST` | Runtime | `127.0.0.1` | Backend server host |
 | `DISABLE_WORKTREE_ORPHAN_CLEANUP` | Runtime | Not set | Disable git worktree cleanup (for debugging) |
 


### PR DESCRIPTION
## Summary

- Added documentation for the `PORT` environment variable in the README
- Clarified different behavior between development and production modes
- Updated descriptions for `BACKEND_PORT` and `FRONTEND_PORT` to indicate they are dev-mode-only overrides

## Why

The README previously documented `FRONTEND_PORT` and `BACKEND_PORT` but was missing documentation for the simpler `PORT` environment variable. The actual behavior is:

- **Production** (`npx vibe-kanban`): Single port serves both frontend and API. Set via `PORT` or `BACKEND_PORT`.
- **Development** (`pnpm run dev`): Two separate ports. `PORT` sets frontend with backend at PORT+1. Or use `FRONTEND_PORT`/`BACKEND_PORT` individually.

## Changes Made

Updated the Environment Variables table in README.md to:
1. Add `PORT` with description of its dual dev/prod behavior
2. Clarify that `BACKEND_PORT` overrides PORT+1 in dev mode only
3. Clarify that `FRONTEND_PORT` overrides PORT in dev mode only

---

This PR was written using [Vibe Kanban](https://vibekanban.com)