### PR TITLE
fix: preserve preceding space when inserting tag/file from typeahead (Vibe Kanban)

### DIFF
--- a/frontend/src/components/ui/wysiwyg/plugins/file-tag-typeahead-plugin.tsx
+++ b/frontend/src/components/ui/wysiwyg/plugins/file-tag-typeahead-plugin.tsx
@@ -100,26 +100,19 @@ export function FileTagTypeaheadPlugin({ projectId }: { projectId?: string }) {
         return {
           leadOffset: offset,
           matchingString: match[1],
-          replaceableString: match[0],
+          replaceableString: match[0].slice(match[0].indexOf('@')),
         };
       }}
       options={options}
       onQueryChange={onQueryChange}
       onSelectOption={(option, nodeToReplace, closeMenu) => {
         editor.update(() => {
-          let textToInsert =
+          const textToInsert =
             option.item.type === 'tag'
               ? (option.item.tag?.content ?? '')
               : (option.item.file?.path ?? '');
 
           if (!nodeToReplace) return;
-
-          // Check if the text being replaced started with whitespace
-          // (the trigger regex captures preceding space as part of the match)
-          const replacedText = nodeToReplace.getTextContent();
-          if (replacedText.length > 0 && /^\s/.test(replacedText)) {
-            textToInsert = ' ' + textToInsert;
-          }
 
           // Create the node we want to insert
           const textNode = $createTextNode(textToInsert);


### PR DESCRIPTION
## Summary
- Fixed a bug where selecting a tag or file from the `@` typeahead menu would delete the preceding space
- For example, typing `"some text @tag"` and selecting would result in `"some textTAG_CONTENT"` instead of `"some text TAG_CONTENT"`

## Changes
Single line fix in `frontend/src/components/ui/wysiwyg/plugins/file-tag-typeahead-plugin.tsx`:

```typescript
// Before:
replaceableString: match[0],

// After:
replaceableString: match[0].slice(match[0].indexOf('@')),
```

## Root Cause
The trigger regex `(?:^|\s)@([^\s@]*)$` captures the preceding whitespace as part of the match. When `replaceableString` was set to `match[0]`, it included the space (e.g., `" @tag"`). Upon selection, the entire `replaceableString` was replaced, inadvertently deleting the space.

## Solution
By slicing `match[0]` to start at the `@` character, `replaceableString` now only contains `"@tag"` instead of `" @tag"`, so the preceding space is never part of what gets replaced.

---

This PR was written using [Vibe Kanban](https://vibekanban.com)