### PR TITLE
feat: Order projects by most recently used (Vibe Kanban)

### DIFF
--- a/crates/db/.sqlx/query-88175c5268b94a7390de8bf63f7e8e4b4f3b633c3a547a0d58915aaeca0fc86f.json
+++ b/crates/db/.sqlx/query-88175c5268b94a7390de8bf63f7e8e4b4f3b633c3a547a0d58915aaeca0fc86f.json
@@ -1,6 +1,6 @@
 {
   "db_name": "SQLite",
-  "query": "SELECT id as \"id!: Uuid\",\n                      name,\n                      git_repo_path,\n                      setup_script,\n                      dev_script,\n                      cleanup_script,\n                      copy_files,\n                      parallel_setup_script as \"parallel_setup_script!: bool\",\n                      remote_project_id as \"remote_project_id: Uuid\",\n                      created_at as \"created_at!: DateTime<Utc>\",\n                      updated_at as \"updated_at!: DateTime<Utc>\"\n               FROM projects\n               ORDER BY created_at DESC",
+  "query": "SELECT p.id as \"id!: Uuid\",\n                      p.name,\n                      p.git_repo_path,\n                      p.setup_script,\n                      p.dev_script,\n                      p.cleanup_script,\n                      p.copy_files,\n                      p.parallel_setup_script as \"parallel_setup_script!: bool\",\n                      p.remote_project_id as \"remote_project_id: Uuid\",\n                      p.created_at as \"created_at!: DateTime<Utc>\",\n                      p.updated_at as \"updated_at!: DateTime<Utc>\"\n               FROM projects p\n               LEFT JOIN (\n                   SELECT t.project_id, MAX(ta.updated_at) as last_activity\n                   FROM tasks t\n                   INNER JOIN task_attempts ta ON ta.task_id = t.id\n                   GROUP BY t.project_id\n               ) activity ON activity.project_id = p.id\n               ORDER BY activity.last_activity DESC NULLS LAST, p.created_at DESC",
   "describe": {
     "columns": [
       {
@@ -76,5 +76,5 @@
       false
     ]
   },
-  "hash": "5ae74dcee62a835018743862b2beceb7231696a0775ba2f144a0b1ecc8bfd56d"
+  "hash": "88175c5268b94a7390de8bf63f7e8e4b4f3b633c3a547a0d58915aaeca0fc86f"
 }

--- a/crates/db/src/models/project.rs
+++ b/crates/db/src/models/project.rs
@@ -85,19 +85,25 @@ impl Project {
     pub async fn find_all(pool: &SqlitePool) -> Result<Vec<Self>, sqlx::Error> {
         sqlx::query_as!(
             Project,
-            r#"SELECT id as "id!: Uuid",
-                      name,
-                      git_repo_path,
-                      setup_script,
-                      dev_script,
-                      cleanup_script,
-                      copy_files,
-                      parallel_setup_script as "parallel_setup_script!: bool",
-                      remote_project_id as "remote_project_id: Uuid",
-                      created_at as "created_at!: DateTime<Utc>",
-                      updated_at as "updated_at!: DateTime<Utc>"
-               FROM projects
-               ORDER BY created_at DESC"#
+            r#"SELECT p.id as "id!: Uuid",
+                      p.name,
+                      p.git_repo_path,
+                      p.setup_script,
+                      p.dev_script,
+                      p.cleanup_script,
+                      p.copy_files,
+                      p.parallel_setup_script as "parallel_setup_script!: bool",
+                      p.remote_project_id as "remote_project_id: Uuid",
+                      p.created_at as "created_at!: DateTime<Utc>",
+                      p.updated_at as "updated_at!: DateTime<Utc>"
+               FROM projects p
+               LEFT JOIN (
+                   SELECT t.project_id, MAX(ta.updated_at) as last_activity
+                   FROM tasks t
+                   INNER JOIN task_attempts ta ON ta.task_id = t.id
+                   GROUP BY t.project_id
+               ) activity ON activity.project_id = p.id
+               ORDER BY activity.last_activity DESC NULLS LAST, p.created_at DESC"#
         )
         .fetch_all(pool)
         .await


### PR DESCRIPTION
## Summary

This PR updates the project listing to order projects from most to least recently used, improving discoverability of active projects.

## Changes

- Modified `Project::find_all()` in `crates/db/src/models/project.rs` to order projects by recent task activity
- Uses a LEFT JOIN with a subquery that finds the maximum `task_attempts.updated_at` per project
- Projects with recent task activity appear first
- Projects without any task activity fall back to ordering by `created_at DESC`

## Implementation Details

The query uses:
```sql
LEFT JOIN (
    SELECT t.project_id, MAX(ta.updated_at) as last_activity
    FROM tasks t
    INNER JOIN task_attempts ta ON ta.task_id = t.id
    GROUP BY t.project_id
) activity ON activity.project_id = p.id
ORDER BY activity.last_activity DESC NULLS LAST, p.created_at DESC
```

This approach:
- Avoids direct GROUP BY on the main query which causes SQLx type inference issues
- Uses `NULLS LAST` to ensure projects without activity appear after active ones
- Preserves chronological ordering (newest first) for projects with no task attempts

---

This PR was written using [Vibe Kanban](https://vibekanban.com)