### PR TITLE
fix git diff performance on large git repos

### DIFF
--- a/crates/services/src/services/git/cli.rs
+++ b/crates/services/src/services/git/cli.rs
@@ -689,6 +689,8 @@ impl GitCli {
 
         if stdin.is_some() {
             cmd.stdin(Stdio::piped());
+        } else {
+            cmd.stdin(Stdio::null());
         }
 
         cmd.stdout(Stdio::piped());


### PR DESCRIPTION
Resolves https://github.com/BloopAI/vibe-kanban/discussions/1239.

To make `diff_status` faster on large repos, we collect changed and untracked file names from the worktree index, which benefits from caching, before adding them to the temporary index to track renames accurately.