### PR TITLE
PR comments multi repo support (vibe-kanban)

### DIFF
--- a/crates/server/src/bin/generate_types.rs
+++ b/crates/server/src/bin/generate_types.rs
@@ -130,6 +130,7 @@ fn generate_types_content() -> String {
         server::routes::task_attempts::pr::AttachPrResponse::decl(),
         server::routes::task_attempts::pr::PrCommentsResponse::decl(),
         server::routes::task_attempts::pr::GetPrCommentsError::decl(),
+        server::routes::task_attempts::pr::GetPrCommentsQuery::decl(),
         services::services::github::UnifiedPrComment::decl(),
         server::routes::task_attempts::RepoBranchStatus::decl(),
         services::services::filesystem::DirectoryEntry::decl(),

--- a/frontend/src/components/dialogs/tasks/GitHubCommentsDialog.tsx
+++ b/frontend/src/components/dialogs/tasks/GitHubCommentsDialog.tsx
@@ -19,6 +19,7 @@ import type { UnifiedPrComment } from 'shared/types';
 
 export interface GitHubCommentsDialogProps {
   attemptId: string;
+  repoId: string;
 }
 
 export interface GitHubCommentsDialogResult {
@@ -32,10 +33,13 @@ function getCommentId(comment: UnifiedPrComment): string {
 }
 
 const GitHubCommentsDialogImpl = NiceModal.create<GitHubCommentsDialogProps>(
-  ({ attemptId }) => {
+  ({ attemptId, repoId }) => {
     const { t } = useTranslation(['tasks', 'common']);
     const modal = useModal();
-    const { data, isLoading, isError, error } = usePrComments(attemptId);
+    const { data, isLoading, isError, error } = usePrComments(
+      attemptId,
+      repoId
+    );
     const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
 
     const comments = data?.comments ?? [];

--- a/frontend/src/components/tasks/TaskFollowUpSection.tsx
+++ b/frontend/src/components/tasks/TaskFollowUpSection.tsx
@@ -537,9 +537,12 @@ export function TaskFollowUpSection({
   // Handler for GitHub comments insertion
   const handleGitHubCommentClick = useCallback(async () => {
     if (!selectedAttemptId) return;
+    const repoId = branchStatus?.[0]?.repo_id;
+    if (!repoId) return;
 
     const result = await GitHubCommentsDialog.show({
       attemptId: selectedAttemptId,
+      repoId,
     });
     if (result.comments.length > 0) {
       // Build markdown for all selected comments
@@ -581,7 +584,7 @@ export function TaskFollowUpSection({
         });
       }
     }
-  }, [selectedAttemptId]);
+  }, [selectedAttemptId, branchStatus]);
 
   // Stable onChange handler for WYSIWYGEditor
   const handleEditorChange = useCallback(

--- a/frontend/src/hooks/usePrComments.ts
+++ b/frontend/src/hooks/usePrComments.ts
@@ -4,20 +4,24 @@ import type { PrCommentsResponse } from 'shared/types';
 
 export const prCommentsKeys = {
   all: ['prComments'] as const,
-  byAttempt: (attemptId: string | undefined) =>
-    ['prComments', attemptId] as const,
+  byAttempt: (attemptId: string | undefined, repoId: string | undefined) =>
+    ['prComments', attemptId, repoId] as const,
 };
 
 type Options = {
   enabled?: boolean;
 };
 
-export function usePrComments(attemptId?: string, opts?: Options) {
-  const enabled = (opts?.enabled ?? true) && !!attemptId;
+export function usePrComments(
+  attemptId?: string,
+  repoId?: string,
+  opts?: Options
+) {
+  const enabled = (opts?.enabled ?? true) && !!attemptId && !!repoId;
 
   return useQuery<PrCommentsResponse>({
-    queryKey: prCommentsKeys.byAttempt(attemptId),
-    queryFn: () => attemptsApi.getPrComments(attemptId!),
+    queryKey: prCommentsKeys.byAttempt(attemptId, repoId),
+    queryFn: () => attemptsApi.getPrComments(attemptId!, repoId!),
     enabled,
     staleTime: 30_000, // Cache for 30s - comments don't change frequently
     retry: 2,

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -699,9 +699,12 @@ export const attemptsApi = {
     );
   },
 
-  getPrComments: async (attemptId: string): Promise<PrCommentsResponse> => {
+  getPrComments: async (
+    attemptId: string,
+    repoId: string
+  ): Promise<PrCommentsResponse> => {
     const response = await makeRequest(
-      `/api/task-attempts/${attemptId}/pr/comments`
+      `/api/task-attempts/${attemptId}/pr/comments?repo_id=${encodeURIComponent(repoId)}`
     );
     return handleApiResponse<PrCommentsResponse>(response);
   },

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -276,6 +276,8 @@ export type PrCommentsResponse = { comments: Array<UnifiedPrComment>, };
 
 export type GetPrCommentsError = { "type": "no_pr_attached" } | { "type": "github_cli_not_installed" } | { "type": "github_cli_not_logged_in" };
 
+export type GetPrCommentsQuery = { repo_id: string, };
+
 export type UnifiedPrComment = { "comment_type": "general", id: string, author: string, author_association: string, body: string, created_at: string, url: string, } | { "comment_type": "review", id: bigint, author: string, author_association: string, body: string, created_at: string, url: string, path: string, line: bigint | null, diff_hunk: string, };
 
 export type RepoBranchStatus = { repo_id: string, repo_name: string, commits_behind: number | null, commits_ahead: number | null, has_uncommitted_changes: boolean | null, head_oid: string | null, uncommitted_count: number | null, untracked_count: number | null, target_branch_name: string, remote_commits_behind: number | null, remote_commits_ahead: number | null, merges: Array<Merge>, 


### PR DESCRIPTION
Add multi repo support fetching PR comments in the same way it was done for merge in crates/server/src/routes/task\_attempts.rs

Make sure to do the frontend as well. Look at the last commit for reference

```javascript


```

```javascript


```