### PR TITLE
Move repo path migration to Rust backend (Vibe Kanban)

### DIFF
--- a/crates/db/.sqlx/query-256f9e937384933464e6d4d00ee977bbb2915ef80930c8b5c0b0525367a5264d.json
+++ b/crates/db/.sqlx/query-256f9e937384933464e6d4d00ee977bbb2915ef80930c8b5c0b0525367a5264d.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "UPDATE repos SET name = $1, display_name = $2, updated_at = datetime('now', 'subsec') WHERE id = $3",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 3
+    },
+    "nullable": []
+  },
+  "hash": "256f9e937384933464e6d4d00ee977bbb2915ef80930c8b5c0b0525367a5264d"
+}

--- a/crates/db/.sqlx/query-c6ca04f8ad0f3f918e83a3960b78f1f5215066f9bb46917fc8e50afe86a6da73.json
+++ b/crates/db/.sqlx/query-c6ca04f8ad0f3f918e83a3960b78f1f5215066f9bb46917fc8e50afe86a6da73.json
@@ -1,0 +1,50 @@
+{
+  "db_name": "SQLite",
+  "query": "SELECT id as \"id!: Uuid\",\n                      path,\n                      name,\n                      display_name,\n                      created_at as \"created_at!: DateTime<Utc>\",\n                      updated_at as \"updated_at!: DateTime<Utc>\"\n               FROM repos\n               WHERE name = '__NEEDS_BACKFILL__'",
+  "describe": {
+    "columns": [
+      {
+        "name": "id!: Uuid",
+        "ordinal": 0,
+        "type_info": "Blob"
+      },
+      {
+        "name": "path",
+        "ordinal": 1,
+        "type_info": "Text"
+      },
+      {
+        "name": "name",
+        "ordinal": 2,
+        "type_info": "Text"
+      },
+      {
+        "name": "display_name",
+        "ordinal": 3,
+        "type_info": "Text"
+      },
+      {
+        "name": "created_at!: DateTime<Utc>",
+        "ordinal": 4,
+        "type_info": "Text"
+      },
+      {
+        "name": "updated_at!: DateTime<Utc>",
+        "ordinal": 5,
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Right": 0
+    },
+    "nullable": [
+      true,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "c6ca04f8ad0f3f918e83a3960b78f1f5215066f9bb46917fc8e50afe86a6da73"
+}

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -57,6 +57,11 @@ async fn main() -> Result<(), VibeKanbanError> {
         .backfill_before_head_commits()
         .await
         .map_err(DeploymentError::from)?;
+    deployment
+        .container()
+        .backfill_repo_names()
+        .await
+        .map_err(DeploymentError::from)?;
     deployment.spawn_pr_monitor_service().await;
     deployment
         .track_if_analytics_allowed("session_start", serde_json::json!({}))

--- a/crates/server/src/routes/task_attempts.rs
+++ b/crates/server/src/routes/task_attempts.rs
@@ -26,7 +26,6 @@ use db::models::{
     attempt_repo::{AttemptRepo, CreateAttemptRepo, RepoWithTargetBranch},
     execution_process::{ExecutionProcess, ExecutionProcessRunReason, ExecutionProcessStatus},
     merge::{Merge, MergeStatus, PrMerge, PullRequestInfo},
-    project_repo::ProjectRepo,
     repo::{Repo, RepoError},
     scratch::{Scratch, ScratchType},
     task::{Task, TaskRelationships, TaskStatus},

--- a/crates/services/src/services/container.rs
+++ b/crates/services/src/services/container.rs
@@ -19,6 +19,7 @@ use db::{
             CreateExecutionProcessRepoState, ExecutionProcessRepoState,
         },
         executor_session::{CreateExecutorSession, ExecutorSession},
+        repo::Repo,
         task::{Task, TaskStatus},
         task_attempt::{TaskAttempt, TaskAttemptError},
     },
@@ -348,6 +349,31 @@ pub trait ContainerService {
                     e
                 );
             }
+        }
+
+        Ok(())
+    }
+
+    /// Backfill repo names that were migrated with a sentinel placeholder.
+    async fn backfill_repo_names(&self) -> Result<(), ContainerError> {
+        let pool = &self.db().pool;
+        let repos = Repo::list_needing_name_fix(pool).await?;
+
+        if repos.is_empty() {
+            return Ok(());
+        }
+
+        tracing::info!("Backfilling {} repo names", repos.len());
+
+        for repo in repos {
+            let name = repo
+                .path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or(&repo.id.to_string())
+                .to_string();
+
+            Repo::update_name(pool, repo.id, &name, &name).await?;
         }
 
         Ok(())


### PR DESCRIPTION
## Summary
Move repo path migration (name/display_name backfill) from fragile SQL to Rust backend for reliability. This fixes issues with repo name extraction on Windows and other edge cases.

## Changes Made

### Migration Fix
- Moved repo `name`/`display_name` backfill from fragile SQL to Rust backend startup
- Migration now uses `__NEEDS_BACKFILL__` sentinel value for repo names
- Rust code detects repos needing backfill and extracts names from paths correctly (handles Windows paths properly)
- Added `Repo::list_needing_name_fix()` and `Repo::update_name()` methods
- Backfill runs at server startup via `ContainerService::backfill_repo_names()`

### Files Changed
- `crates/db/src/models/repo.rs` - Added `list_needing_name_fix()` and `update_name()` methods
- `crates/server/src/main.rs` - Call backfill at startup
- `crates/services/src/services/container.rs` - Added `backfill_repo_names()` implementation
- `crates/db/migrations/20251209000000_add_project_repositories.sql` - Updated to use sentinel value

---
This PR was written using [Vibe Kanban](https://vibekanban.com)