### PR TITLE
Set codex default to xhigh

### DIFF
--- a/crates/executors/default_profiles.json
+++ b/crates/executors/default_profiles.json
@@ -59,6 +59,7 @@
       "APPROVALS": {
         "CODEX": {
           "model": "gpt-5.2",
+          "model_reasoning_effort": "xhigh",
           "sandbox": "workspace-write",
           "ask_for_approval": "unless-trusted"
         }


### PR DESCRIPTION
`xhigh` improves results for complex tasks, but doesn't degrade response speed for simple queries.

<img width="850" height="246" alt="image" src="https://github.com/user-attachments/assets/658cb90d-f1b1-4bec-a690-b7a2d54edfcc" />
