### PR TITLE
Hide Open in IDE button for multi-repo projects (Vibe Kanban)

### DIFF
--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -1,7 +1,6 @@
 import { Link, useLocation, useSearchParams } from 'react-router-dom';
 import { useCallback } from 'react';
 import { siDiscord } from 'simple-icons';
-import { useQuery } from '@tanstack/react-query';
 import { Button } from '@/components/ui/button';
 import {
   DropdownMenu,
@@ -28,7 +27,7 @@ import { openTaskForm } from '@/lib/openTaskForm';
 import { useProject } from '@/contexts/ProjectContext';
 import { useOpenProjectInEditor } from '@/hooks/useOpenProjectInEditor';
 import { OpenInIdeButton } from '@/components/ide/OpenInIdeButton';
-import { projectsApi } from '@/lib/api';
+import { useBranches } from '@/hooks/useBranches';
 import { useDiscordOnlineCount } from '@/hooks/useDiscordOnlineCount';
 import { useTranslation } from 'react-i18next';
 import { Switch } from '@/components/ui/switch';
@@ -81,12 +80,7 @@ export function Navbar() {
   const { data: onlineCount } = useDiscordOnlineCount();
   const { loginStatus, reloadSystem } = useUserSystem();
 
-  const { data: repos } = useQuery({
-    queryKey: ['project-repositories', projectId],
-    queryFn: () => projectsApi.getRepositories(projectId!),
-    enabled: !!projectId,
-  });
-
+  const { data: repos } = useBranches(projectId);
   const isSingleRepoProject = repos?.length === 1;
 
   const setSearchBarRef = useCallback(

--- a/frontend/src/components/projects/ProjectCard.tsx
+++ b/frontend/src/components/projects/ProjectCard.tsx
@@ -23,13 +23,13 @@ import {
 } from 'lucide-react';
 import { Project } from 'shared/types';
 import { useEffect, useRef } from 'react';
-import { useQuery } from '@tanstack/react-query';
 import { useOpenProjectInEditor } from '@/hooks/useOpenProjectInEditor';
 import { useNavigateWithSearch } from '@/hooks';
 import { projectsApi } from '@/lib/api';
 import { LinkProjectDialog } from '@/components/dialogs/projects/LinkProjectDialog';
 import { useTranslation } from 'react-i18next';
 import { useProjectMutations } from '@/hooks/useProjectMutations';
+import { useBranches } from '@/hooks/useBranches';
 
 type Props = {
   project: Project;
@@ -51,11 +51,7 @@ function ProjectCard({
   const handleOpenInEditor = useOpenProjectInEditor(project);
   const { t } = useTranslation('projects');
 
-  const { data: repos } = useQuery({
-    queryKey: ['project-repositories', project.id],
-    queryFn: () => projectsApi.getRepositories(project.id),
-  });
-
+  const { data: repos } = useBranches(project.id);
   const isSingleRepoProject = repos?.length === 1;
 
   const { unlinkProject } = useProjectMutations({


### PR DESCRIPTION
## Summary

This PR updates the "Open project in IDE" button behavior to only display for single-repository projects. For multi-repository projects, the button is hidden since the current implementation only opens the first repository, which could be confusing for users.

## Changes

### `frontend/src/components/layout/Navbar.tsx`
- Added `useBranches` hook to fetch repository information for the current project
- Added `isSingleRepoProject` check to conditionally render the `OpenInIdeButton`
- Button now only appears when the project has exactly one repository

### `frontend/src/components/projects/ProjectCard.tsx`
- Added `useBranches` hook to fetch repository information for each project card
- Added `isSingleRepoProject` check to conditionally render the "Open in IDE" dropdown menu item
- Menu item now only appears when the project has exactly one repository

## Why

The backend currently opens only the first repository when multiple repositories exist. Rather than potentially confusing users by opening an unexpected repository, we hide the button entirely for multi-repo projects until proper multi-repo support can be implemented.

---

This PR was written using [Vibe Kanban](https://vibekanban.com)