### PR TITLE
Fix WebSocket events lost when creating execution processes (Vibe Kanban)

### DIFF
--- a/crates/db/src/models/execution_process_repo_state.rs
+++ b/crates/db/src/models/execution_process_repo_state.rs
@@ -1,6 +1,6 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use sqlx::{FromRow, Sqlite, SqlitePool, Transaction};
+use sqlx::{FromRow, SqlitePool};
 use ts_rs::TS;
 use uuid::Uuid;
 
@@ -28,7 +28,7 @@ pub struct CreateExecutionProcessRepoState {
 
 impl ExecutionProcessRepoState {
     pub async fn create_many(
-        tx: &mut Transaction<'_, Sqlite>,
+        pool: &SqlitePool,
         execution_process_id: Uuid,
         entries: &[CreateExecutionProcessRepoState],
     ) -> Result<(), sqlx::Error> {
@@ -60,7 +60,7 @@ impl ExecutionProcessRepoState {
                 now,
                 now
             )
-            .execute(&mut **tx)
+            .execute(pool)
             .await?;
         }
 


### PR DESCRIPTION
## Summary

Fixes a bug where users needed to refresh the page to see new logs after sending a follow-up message. This was a regression introduced during multi-repo support changes.

## Root Cause

The `ExecutionProcess::create` function was changed to wrap the insert in a SQLite transaction for multi-repo support. However, SQLite update hooks fire **during** transactions (before commit), and the hook spawns an async task that queries `find_by_rowid` on a **different** database connection. This connection cannot see uncommitted rows, causing the WebSocket event to be silently lost.

## Changes

- **`crates/db/src/models/execution_process.rs`**: Removed the transaction wrapper and added a doc comment explaining why transactions should not be used here
- **`crates/db/src/models/execution_process_repo_state.rs`**: Changed `create_many` to accept `&SqlitePool` directly instead of a transaction executor

## Why This Fix Works

Single SQL statements in SQLite are auto-committed, so each INSERT is immediately visible to other connections. The update hook still fires, but by the time the async task queries the row, it has already been committed and is visible.

## Alternative Considered

The proper SQLite pattern for this would be a "queue-and-flush" approach using `update_hook` + `commit_hook` + `rollback_hook`. However, this would require significant refactoring of the event system, so the pragmatic fix of avoiding transactions for tables with update hooks was chosen.

---

This PR was written using [Vibe Kanban](https://vibekanban.com)