### PR TITLE
Remove unused compare_commit_to_head endpoint (Vibe Kanban)

### DIFF
--- a/crates/server/src/bin/generate_types.rs
+++ b/crates/server/src/bin/generate_types.rs
@@ -112,7 +112,6 @@ fn generate_types_content() -> String {
         server::routes::task_attempts::PushTaskAttemptRequest::decl(),
         server::routes::task_attempts::RenameBranchRequest::decl(),
         server::routes::task_attempts::RenameBranchResponse::decl(),
-        server::routes::task_attempts::CommitCompareResult::decl(),
         server::routes::task_attempts::OpenEditorRequest::decl(),
         server::routes::task_attempts::OpenEditorResponse::decl(),
         server::routes::shared_tasks::AssignSharedTaskRequest::decl(),

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -72,7 +72,6 @@ import {
   Invitation,
   RemoteProject,
   ListInvitationsResponse,
-  CommitCompareResult,
   OpenEditorResponse,
   OpenEditorRequest,
   CreatePrError,
@@ -736,21 +735,6 @@ export const attemptsApi = {
       `/api/task-attempts/${attemptId}/pr/comments?repo_id=${encodeURIComponent(repoId)}`
     );
     return handleApiResponse<PrCommentsResponse>(response);
-  },
-};
-
-// Extra helpers
-export const commitsApi = {
-  compareToHead: async (
-    attemptId: string,
-    sha: string
-  ): Promise<CommitCompareResult> => {
-    const response = await makeRequest(
-      `/api/task-attempts/${attemptId}/commit-compare?sha=${encodeURIComponent(
-        sha
-      )}`
-    );
-    return handleApiResponse(response);
   },
 };
 

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -224,8 +224,6 @@ export type RenameBranchRequest = { new_branch_name: string, };
 
 export type RenameBranchResponse = { branch: string, };
 
-export type CommitCompareResult = { subject: string, head_oid: string, target_oid: string, ahead_from_head: number, behind_from_head: number, is_linear: boolean, };
-
 export type OpenEditorRequest = { editor_type: string | null, file_path: string | null, };
 
 export type OpenEditorResponse = { url: string | null, };


### PR DESCRIPTION
## Summary

Removes the unused `compare_commit_to_head` endpoint and all related code. This endpoint was implemented but never used in the frontend.

## Changes Made

- **Backend** (`crates/server/src/routes/task_attempts.rs`)
  - Removed `CommitCompareResult` struct
  - Removed `compare_commit_to_head` handler function  
  - Removed route registration for `/commit-compare`

- **Type Generation** (`crates/server/src/bin/generate_types.rs`)
  - Removed `CommitCompareResult::decl()` from TypeScript type exports

- **Frontend** (`frontend/src/lib/api.ts`)
  - Removed `CommitCompareResult` import
  - Removed the entire `commitsApi` object

- **Shared Types** (`shared/types.ts`)
  - `CommitCompareResult` type automatically removed via `pnpm run generate-types`

## Why

The endpoint was created for a feature that was either removed or never completed on the frontend side. Confirmed that `commitsApi.compareToHead` was defined but never called anywhere in the codebase.

## Verification

- `pnpm run check` passes (frontend TypeScript + backend cargo check)
- `pnpm run generate-types` regenerates types successfully

---

This PR was written using [Vibe Kanban](https://vibekanban.com)