### PR TITLE
Add multi-repo support to MCP task server (Vibe Kanban)

### DIFF
--- a/crates/db/src/models/attempt_repo.rs
+++ b/crates/db/src/models/attempt_repo.rs
@@ -26,7 +26,7 @@ pub struct CreateAttemptRepo {
     pub target_branch: String,
 }
 
-#[derive(Debug, Clone, Serialize, TS)]
+#[derive(Debug, Clone, Serialize, Deserialize, TS)]
 #[ts(export)]
 pub struct RepoWithTargetBranch {
     #[serde(flatten)]

--- a/crates/db/src/models/task_attempt.rs
+++ b/crates/db/src/models/task_attempt.rs
@@ -8,7 +8,11 @@ use thiserror::Error;
 use ts_rs::TS;
 use uuid::Uuid;
 
-use super::{attempt_repo::AttemptRepo, project::Project, task::Task};
+use super::{
+    attempt_repo::{AttemptRepo, RepoWithTargetBranch},
+    project::Project,
+    task::Task,
+};
 
 #[derive(Debug, Error)]
 pub enum TaskAttemptError {
@@ -77,7 +81,7 @@ pub struct TaskAttemptContext {
     pub task_attempt: TaskAttempt,
     pub task: Task,
     pub project: Project,
-    pub attempt_repos: Vec<AttemptRepo>,
+    pub attempt_repos: Vec<RepoWithTargetBranch>,
 }
 
 #[derive(Debug, Deserialize, TS)]
@@ -177,7 +181,8 @@ impl TaskAttempt {
             .await?
             .ok_or(TaskAttemptError::ProjectNotFound)?;
 
-        let attempt_repos = AttemptRepo::find_by_attempt_id(pool, attempt_id).await?;
+        let attempt_repos =
+            AttemptRepo::find_repos_with_target_branch_for_attempt(pool, attempt_id).await?;
 
         Ok(TaskAttemptContext {
             task_attempt,


### PR DESCRIPTION
## Summary

This PR adds proper multi-repository support to the MCP (Model Context Protocol) task server, enabling AI agents to work with projects that have multiple repositories.

## Changes

### New `list_repos` tool
- Added new MCP tool to list repositories for a project
- Accepts `project_id` parameter and returns repo IDs and names
- Follows the same pattern as `list_tasks`

### Updated `get_context` tool
- Changed `attempt_target_branch` (single string) to `attempt_repos` (array)
- Each repo in `attempt_repos` includes:
  - `repo_id` - unique identifier
  - `repo_name` - repository name  
  - `target_branch` - the target branch for this repo in the attempt

### Updated `start_task_attempt` tool
- Changed `base_branch` (single string) to `repos` (array)
- Each entry in `repos` includes:
  - `repo_id` - which repository
  - `base_branch` - the base branch to use for that repo
- Validates that at least one repository is specified

### Updated server instructions
- Added `list_repos` to the TOOLS list in server instructions

## Implementation Details

- Added `McpRepoContext` struct for repo info in attempt context
- Added `McpRepoSummary` struct for listing repos
- Added `McpAttemptRepoInput` struct for starting attempts with per-repo branches
- Maps between MCP types and internal `AttemptRepoInput`/`RepoWithTargetBranch` types
- Removed obsolete single-repo fields (`git_repo_path`, `setup_script`, etc.) from `ProjectSummary`

---

This PR was written using [Vibe Kanban](https://vibekanban.com)