### PR TITLE
Make the queue button in followup section not look disabled

### DIFF
--- a/frontend/src/components/tasks/TaskFollowUpSection.tsx
+++ b/frontend/src/components/tasks/TaskFollowUpSection.tsx
@@ -888,7 +888,6 @@ export function TaskFollowUpSection({
                       !clickedMarkdown)
                   }
                   size="sm"
-                  variant="secondary"
                 >
                   {isQueueLoading ? (
                     <Loader2 className="animate-spin h-4 w-4 mr-2" />


### PR DESCRIPTION
Before 
<img width="103" height="60" alt="Screenshot 2025-12-15 at 12 14 49" src="https://github.com/user-attachments/assets/28b4bb57-ff8f-4ef8-8fba-ee779bb76d82" />

After
<img width="100" height="62" alt="Screenshot 2025-12-15 at 12 13 40" src="https://github.com/user-attachments/assets/d725b4ca-eb3d-46c5-84df-6fa64823177e" />
