### PR TITLE
Fix git actions modal overflow for multi-repo projects (Vibe Kanban)

### DIFF
--- a/frontend/src/components/tasks/Toolbar/GitOperations.tsx
+++ b/frontend/src/components/tasks/Toolbar/GitOperations.tsx
@@ -426,21 +426,19 @@ function GitOperations({
       <div className={containerClasses}>
         {isVertical ? (
           <>
+            {repos.length > 1 && (
+              <RepoSelector
+                repos={repos}
+                selectedRepoId={getSelectedRepoId() ?? null}
+                onRepoSelect={setSelectedRepoId}
+                disabled={isAttemptRunning}
+                placeholder={t('repos.selector.placeholder', 'Select repo')}
+              />
+            )}
             <div className="flex flex-wrap items-center gap-2 min-w-0">
-              {repos.length > 0 && (
-                <RepoSelector
-                  repos={repos}
-                  selectedRepoId={getSelectedRepoId() ?? null}
-                  onRepoSelect={setSelectedRepoId}
-                  disabled={isAttemptRunning}
-                  placeholder={t('repos.selector.placeholder', 'Select repo')}
-                />
-              )}
-              <div className="flex items-center gap-2 min-w-0">
-                {branchChips}
-              </div>
+              {branchChips}
+              {statusChips}
             </div>
-            {statusChips}
           </>
         ) : (
           <>


### PR DESCRIPTION
## Summary

Fixes horizontal overflow in the Git Actions modal dialog when working with multi-repo projects.

## Problem

After multi-repo project support was added, the Git Actions modal would overflow horizontally because it tried to fit too many elements on a single row:
- RepoSelector
- Task branch chip
- Arrow icon
- Target branch chip + settings button

## Solution

Restructured the vertical layout to give each logical group its own space:

**Before:**
```
Row 1: [RepoSelector] [taskBranch] → [targetBranch] [⚙️]  <-- overflows
Row 2: [status chips]
Row 3: [Merge] [PR] [Rebase]
```

**After:**
```
Row 1: [RepoSelector]                          <-- only shown for multi-repo
Row 2: [taskBranch] → [targetBranch] [status]  <-- branch flow + status together
Row 3: [Merge] [PR] [Rebase]
```

## Changes

- Moved `RepoSelector` to its own row, only displayed when `repos.length > 1`
- Combined branch chips and status chips on the same row with `flex-wrap` for graceful overflow
- Removed unnecessary nested div wrapper

## Files Modified

- `frontend/src/components/tasks/Toolbar/GitOperations.tsx`

---

- [x] tested

---

This PR was written using [Vibe Kanban](https://vibekanban.com)