### PR TITLE
Fix file autocomplete to include repo name prefix for single-repo projects (Vibe Kanban)

### DIFF
--- a/crates/services/src/services/project.rs
+++ b/crates/services/src/services/project.rs
@@ -276,13 +276,7 @@ impl ProjectService {
             return Ok(vec![]);
         }
 
-        // Simple search in single-repo case
-        if repositories.len() == 1 {
-            let repo = &repositories[0];
-            return self.search_single_repo(cache, &repo.path, query).await;
-        }
-
-        // Multi repo: search in parallel and prefix paths
+        // Search in parallel and prefix paths with repo name
         let search_futures: Vec<_> = repositories
             .iter()
             .map(|repo| {


### PR DESCRIPTION
## Summary

- Fixed file autocomplete to always include the repository name prefix in file paths
- Previously, single-repo projects returned paths like `src/components/file.tsx`, while multi-repo projects returned `repo-name/src/components/file.tsx`
- Now all projects consistently return paths with the repo name prefix

## Changes Made

Removed the single-repo special case in `crates/services/src/services/project.rs` that bypassed the path prefixing logic. The existing multi-repo code path already handles any number of repositories correctly (including 1), so the special case was unnecessary and caused inconsistent behavior.

## Implementation Details

The fix removes 7 lines of code that short-circuited single-repo searches:
```rust
// Removed:
if repositories.len() == 1 {
    let repo = &repositories[0];
    return self.search_single_repo(cache, &repo.path, query).await;
}
```

Now all file searches go through the same code path that prefixes results with the repo name.

- [x] tested

---

This PR was written using [Vibe Kanban](https://vibekanban.com)