### PR TITLE
Fix Create PR dialog to default to attempt target branch instead of repo current branch (Vibe Kanban)

### DIFF
--- a/frontend/src/components/dialogs/tasks/CreatePRDialog.tsx
+++ b/frontend/src/components/dialogs/tasks/CreatePRDialog.tsx
@@ -38,10 +38,11 @@ interface CreatePRDialogProps {
   attempt: TaskAttempt;
   task: TaskWithAttemptStatus;
   repoId: string;
+  targetBranch?: string;
 }
 
 const CreatePRDialogImpl = NiceModal.create<CreatePRDialogProps>(
-  ({ attempt, task, repoId }) => {
+  ({ attempt, task, repoId, targetBranch }) => {
     const modal = useModal();
     const { t } = useTranslation('tasks');
     const { isLoaded } = useAuth();
@@ -84,12 +85,18 @@ const CreatePRDialogImpl = NiceModal.create<CreatePRDialogProps>(
     // Set default base branch when branches are loaded
     useEffect(() => {
       if (branches.length > 0 && !prBaseBranch) {
+        // First priority: use the target branch from attempt config
+        if (targetBranch && branches.some((b) => b.name === targetBranch)) {
+          setPrBaseBranch(targetBranch);
+          return;
+        }
+        // Fallback: use the current branch
         const currentBranch = branches.find((b) => b.is_current);
         if (currentBranch) {
           setPrBaseBranch(currentBranch.name);
         }
       }
-    }, [branches, prBaseBranch]);
+    }, [branches, prBaseBranch, targetBranch]);
 
     const isMacEnvironment = useMemo(
       () => environment?.os_type?.toLowerCase().includes('mac'),

--- a/frontend/src/components/tasks/Toolbar/GitOperations.tsx
+++ b/frontend/src/components/tasks/Toolbar/GitOperations.tsx
@@ -254,6 +254,7 @@ function GitOperations({
       attempt: selectedAttempt,
       task,
       repoId: getSelectedRepoId(),
+      targetBranch: getSelectedRepoStatus()?.target_branch_name,
     });
   };
 


### PR DESCRIPTION
## Summary

Fixes a regression where the Create PR dialog was defaulting to the repository's current checked-out branch (`is_current`) instead of the task attempt's configured target branch.

## Background

The original implementation used the task attempt's `base_branch` as the default for PR creation. During the multi-repo refactor (#1516), target branches became per-repo (stored in `AttemptRepo` table), and the logic to use this target branch as the default was inadvertently lost. The recent branch fetching refactor (#1560) further simplified the code but did not restore this behavior.

## Changes Made

### `frontend/src/components/dialogs/tasks/CreatePRDialog.tsx`
- Added `targetBranch?: string` to the props interface
- Updated the default branch selection logic to prioritize `targetBranch` over `is_current`
- Falls back to the current branch only if target branch is not set or not found in the branch list

### `frontend/src/components/tasks/Toolbar/GitOperations.tsx`
- Pass `targetBranch: getSelectedRepoStatus()?.target_branch_name` when showing the dialog

## Behavior After Fix

When opening the Create PR dialog:
1. **First priority**: Uses the attempt's configured target branch (from `RepoBranchStatus.target_branch_name`)
2. **Fallback**: Uses the repo's current checked-out branch (`is_current`) if target branch is unavailable

This restores the original intended behavior where PRs default to merge into the branch the user configured when starting the task.

---

This PR was written using [Vibe Kanban](https://vibekanban.com)