### PR TITLE
Disable optional logs for git status calls

### DIFF
--- a/crates/services/src/services/git/cli.rs
+++ b/crates/services/src/services/git/cli.rs
@@ -156,7 +156,10 @@ impl GitCli {
 
     /// Return true if there are any changes in the working tree (staged or unstaged).
     pub fn has_changes(&self, worktree_path: &Path) -> Result<bool, GitCliError> {
-        let out = self.git(worktree_path, ["status", "--porcelain"])?;
+        let out = self.git(
+            worktree_path,
+            ["--no-optional-locks", "status", "--porcelain"],
+        )?;
         Ok(!out.is_empty())
     }
 
@@ -229,6 +232,7 @@ impl GitCli {
         // Using -z for NUL-separated output which correctly handles paths with special chars.
         // Format: XY<space>PATH<NUL>[ORIGPATH<NUL>] where ORIGPATH only present for R/C.
         let args = Self::apply_default_excludes(vec![
+            "--no-optional-locks",
             "status",
             "--porcelain",
             "-z",


### PR DESCRIPTION
Fixes auto-commit failing after agent finishes:
```
Failed to commit in repo 'my-repo': Invalid repository: git commit failed: git command failed: --- stdout
fatal: Unable to create '/Users/anastasiia/Projects/my-repo/.git/worktrees/my-repo3/index.lock': File exists.

Another git process seems to be running in this repository, e.g.
an editor opened by 'git commit'. Please make sure all processes
are terminated then try again. If it still fails, a git process
may have crashed in this repository earlier:
remove the file manually to continue.
```