### PR TITLE
#1411 : strip yaml frontmatter introduction (`---`) from rendering to allow rendering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1616,7 +1616,7 @@ checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 
 [[package]]
 name = "db"
-version = "0.0.138"
+version = "0.0.139"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1645,7 +1645,7 @@ dependencies = [
 
 [[package]]
 name = "deployment"
-version = "0.0.138"
+version = "0.0.139"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2015,7 +2015,7 @@ dependencies = [
 
 [[package]]
 name = "executors"
-version = "0.0.138"
+version = "0.0.139"
 dependencies = [
  "agent-client-protocol",
  "async-trait",
@@ -3401,7 +3401,7 @@ dependencies = [
 
 [[package]]
 name = "local-deployment"
-version = "0.0.138"
+version = "0.0.139"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4511,7 +4511,7 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "remote"
-version = "0.0.138"
+version = "0.0.139"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -4605,7 +4605,7 @@ dependencies = [
 
 [[package]]
 name = "review"
-version = "0.0.138"
+version = "0.0.139"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5296,7 +5296,7 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.0.138"
+version = "0.0.139"
 dependencies = [
  "anyhow",
  "axum",
@@ -5343,7 +5343,7 @@ dependencies = [
 
 [[package]]
 name = "services"
-version = "0.0.138"
+version = "0.0.139"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6588,7 +6588,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "utils"
-version = "0.0.138"
+version = "0.0.139"
 dependencies = [
  "axum",
  "bytes",

--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "db"
-version = "0.0.138"
+version = "0.0.139"
 edition = "2024"
 
 [dependencies]

--- a/crates/deployment/Cargo.toml
+++ b/crates/deployment/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deployment"
-version = "0.0.138"
+version = "0.0.139"
 edition = "2024"
 
 [dependencies]

--- a/crates/executors/Cargo.toml
+++ b/crates/executors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "executors"
-version = "0.0.138"
+version = "0.0.139"
 edition = "2024"
 
 [dependencies]

--- a/crates/local-deployment/Cargo.toml
+++ b/crates/local-deployment/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "local-deployment"
-version = "0.0.138"
+version = "0.0.139"
 edition = "2024"
 
 [dependencies]

--- a/crates/remote/Cargo.toml
+++ b/crates/remote/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remote"
-version = "0.0.138"
+version = "0.0.139"
 edition = "2024"
 publish = false
 

--- a/crates/review/Cargo.toml
+++ b/crates/review/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "review"
-version = "0.0.138"
+version = "0.0.139"
 edition = "2024"
 publish = false
 

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "server"
-version = "0.0.138"
+version = "0.0.139"
 edition = "2024"
 default-run = "server"
 

--- a/crates/services/Cargo.toml
+++ b/crates/services/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "services"
-version = "0.0.138"
+version = "0.0.139"
 edition = "2024"
 
 [features]

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "utils"
-version = "0.0.138"
+version = "0.0.139"
 edition = "2024"
 
 [dependencies]

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vibe-kanban",
   "private": true,
-  "version": "0.0.138",
+  "version": "0.0.139",
   "type": "module",
   "scripts": {
     "dev": "VITE_OPEN=${VITE_OPEN:-false} vite",

--- a/frontend/src/components/ui/wysiwyg/plugins/markdown-sync-plugin.tsx
+++ b/frontend/src/components/ui/wysiwyg/plugins/markdown-sync-plugin.tsx
@@ -41,6 +41,7 @@ export function MarkdownSyncPlugin({
 
     try {
       editor.update(() => {
+        if(value.startsWith(`---`))value = value.replace(`---`, '');
         if (value.trim() === '') {
           $getRoot().clear();
         } else {

--- a/frontend/src/hooks/useConversationHistory.ts
+++ b/frontend/src/hooks/useConversationHistory.ts
@@ -45,7 +45,7 @@ interface UseConversationHistoryParams {
   onEntriesUpdated: OnEntriesUpdated;
 }
 
-interface UseConversationHistoryResult {}
+interface UseConversationHistoryResult { }
 
 const MIN_INITIAL_ENTRIES = 10;
 const REMAINING_BATCH_SIZE = 50;
@@ -177,9 +177,9 @@ export const useConversationHistory = ({
       .filter(
         (p) =>
           p.executionProcess.executor_action.typ.type ===
-            'CodingAgentFollowUpRequest' ||
+          'CodingAgentFollowUpRequest' ||
           p.executionProcess.executor_action.typ.type ===
-            'CodingAgentInitialRequest'
+          'CodingAgentInitialRequest'
       )
       .sort(
         (a, b) =>
@@ -225,9 +225,9 @@ export const useConversationHistory = ({
           const entries: PatchTypeWithKey[] = [];
           if (
             p.executionProcess.executor_action.typ.type ===
-              'CodingAgentInitialRequest' ||
+            'CodingAgentInitialRequest' ||
             p.executionProcess.executor_action.typ.type ===
-              'CodingAgentFollowUpRequest'
+            'CodingAgentFollowUpRequest'
           ) {
             // New user message
             const userNormalizedEntry: NormalizedEntry = {
@@ -352,9 +352,9 @@ export const useConversationHistory = ({
               executionProcess?.status === 'running'
                 ? null
                 : {
-                    type: 'exit_code',
-                    code: exitCode,
-                  };
+                  type: 'exit_code',
+                  code: exitCode,
+                };
 
             const toolStatus: ToolStatus =
               executionProcess?.status === ExecutionProcessStatus.running
@@ -410,7 +410,12 @@ export const useConversationHistory = ({
         );
       }
 
-      return allEntries;
+      return allEntries.map(e => {
+        if (typeof e.content === 'object' && 'content' in e.content) {
+          if (e.content.content.startsWith(`---`)) e.content.content = e.content.content.replace(`---`, '');
+        }
+        return e;
+      });
     },
     []
   );

--- a/frontend/src/hooks/useConversationHistory.ts
+++ b/frontend/src/hooks/useConversationHistory.ts
@@ -410,12 +410,7 @@ export const useConversationHistory = ({
         );
       }
 
-      return allEntries.map(e => {
-        if (typeof e.content === 'object' && 'content' in e.content) {
-          if (e.content.content.startsWith(`---`)) e.content.content = e.content.content.replace(`---`, '');
-        }
-        return e;
-      });
+      return allEntries;
     },
     []
   );

--- a/npx-cli/package.json
+++ b/npx-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vibe-kanban",
   "private": false,
-  "version": "0.0.138",
+  "version": "0.0.139",
   "main": "index.js",
   "bin": {
     "vibe-kanban": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-kanban",
-  "version": "0.0.138",
+  "version": "0.0.139",
   "private": true,
   "bin": {
     "vibe-kanban": "npx-cli/bin/cli.js"


### PR DESCRIPTION
I also ran into this issue and ended up fixing the problem at its source, the rendering. LLM summaries with YAML frontmatter make no sense, so this PR strips it out when rendering messages.

Hopefully fixes #1411 