### PR TITLE
Auto-generate CLAUDE.md and AGENTS.md in workspaces with @import syntax (Vibe Kanban)

### DIFF
--- a/crates/local-deployment/src/container.rs
+++ b/crates/local-deployment/src/container.rs
@@ -748,7 +748,6 @@ impl LocalContainerService {
         for config_file in CONFIG_FILES {
             let workspace_config_path = workspace_dir.join(config_file);
 
-            // Skip if file already exists (idempotent)
             if workspace_config_path.exists() {
                 tracing::debug!(
                     "Workspace config file {} already exists, skipping",
@@ -757,7 +756,6 @@ impl LocalContainerService {
                 continue;
             }
 
-            // Collect repos that have this config file
             let mut import_lines = Vec::new();
             for repo in repos {
                 let repo_config_path = workspace_dir.join(&repo.name).join(config_file);
@@ -766,7 +764,6 @@ impl LocalContainerService {
                 }
             }
 
-            // Skip if no repos have this config file
             if import_lines.is_empty() {
                 tracing::debug!(
                     "No repos have {}, skipping workspace config creation",
@@ -775,7 +772,6 @@ impl LocalContainerService {
                 continue;
             }
 
-            // Create the workspace config file with import lines
             let content = import_lines.join("\n") + "\n";
             if let Err(e) = tokio::fs::write(&workspace_config_path, &content).await {
                 tracing::warn!(
@@ -783,7 +779,6 @@ impl LocalContainerService {
                     config_file,
                     e
                 );
-                // Don't fail workspace creation for config file issues
                 continue;
             }
 
@@ -951,7 +946,6 @@ impl ContainerService for LocalContainerService {
         self.copy_files_and_images(&created_workspace.workspace_dir, workspace)
             .await?;
 
-        // Create workspace-level CLAUDE.md and AGENTS.md with imports from each repo
         Self::create_workspace_config_files(&created_workspace.workspace_dir, &repositories)
             .await?;
 
@@ -1015,7 +1009,6 @@ impl ContainerService for LocalContainerService {
         self.copy_files_and_images(&workspace_dir, workspace)
             .await?;
 
-        // Create workspace-level CLAUDE.md and AGENTS.md (no-op if already exist)
         Self::create_workspace_config_files(&workspace_dir, &repositories).await?;
 
         Ok(workspace_dir.to_string_lossy().to_string())


### PR DESCRIPTION
## Summary

Automatically generates workspace-level `CLAUDE.md` and `AGENTS.md` files that import configuration from each repository using Claude Code's `@import` syntax.

When a workspace is created, the system now:
- Checks each repository for `CLAUDE.md` and `AGENTS.md` files
- Creates workspace-level config files with `@repo-name/FILENAME.md` import lines
- Supports multi-repo projects by importing from all repos that have these files

### Example

For a workspace with repos `frontend` and `backend` where both have `CLAUDE.md`:

```markdown
@frontend/CLAUDE.md
@backend/CLAUDE.md
```

## Why

Previously, coding agents running in workspaces didn't have access to repository-level Claude or Agents configuration. This change ensures that:
- Claude Code and other agents can read project-specific instructions
- Multi-repo projects get configuration from all repositories
- The native `@import` syntax is used (no symlinks required)

## Implementation Details

- Added `create_workspace_config_files()` function to `LocalContainerService`
- Called during both `create()` (initial workspace creation) and `ensure_container_exists()` (cold restart scenarios)
- Idempotent: skips creation if workspace config files already exist
- Gracefully handles missing source files (just skips that repo)
- Non-blocking: warns but doesn't fail workspace creation on errors

## Test Plan

- [x] tested

---

This PR was written using [Vibe Kanban](https://vibekanban.com)