### PR TITLE
Prevent copy files from overwriting existing files (Vibe Kanban)

### DIFF
--- a/crates/local-deployment/src/copy.rs
+++ b/crates/local-deployment/src/copy.rs
@@ -100,11 +100,7 @@ fn copy_single_file(
 
     let target_file = target_root.join(relative_path);
 
-    // Skip if target exists with same size
-    if let Ok(target_meta) = fs::metadata(&target_file)
-        && let Ok(source_meta) = fs::metadata(source_file)
-        && target_meta.len() == source_meta.len()
-    {
+    if target_file.exists() {
         return Ok(false);
     }
 


### PR DESCRIPTION
## Summary

- Relaxed the copy file check to only create files when they don't exist
- Previously, files were overwritten if they existed with a different size
- Now, user-specified copy files are never overwritten - they are only created initially if missing

## Changes

Modified `crates/local-deployment/src/copy.rs` to simplify the file existence check:

**Before:**
```rust
// Skip if target exists with same size
if let Ok(target_meta) = fs::metadata(&target_file)
    && let Ok(source_meta) = fs::metadata(source_file)
    && target_meta.len() == source_meta.len()
{
    return Ok(false);
}
```

**After:**
```rust
if target_file.exists() {
    return Ok(false);
}
```

## Why

Copy files (like `.env`, config files, etc.) specified by users should be treated as user-owned files. The copy operation should only seed these files initially when they're missing, not overwrite any changes the user may have made.

## Test Plan

- [x] Tested - all 10 existing copy tests pass

This PR was written using [Vibe Kanban](https://vibekanban.com)