### PR TITLE
Bump Claude Code to 2.0.75 + disallow AskUserQuestion tool

### DIFF
--- a/crates/executors/src/executors/claude.rs
+++ b/crates/executors/src/executors/claude.rs
@@ -112,6 +112,7 @@ impl ClaudeCode {
             "--output-format=stream-json",
             "--input-format=stream-json",
             "--include-partial-messages",
+            "--disallowedTools=AskUserQuestion",
         ]);
 
         apply_overrides(builder, &self.cmd)


### PR DESCRIPTION
## Summary
- Bump `@anthropic-ai/claude-code` from `2.0.54` to `2.0.75`
- Disallow `AskUserQuestion` tool via `--disallowedTools` flag to prevent Claude from asking questions

## Changes
- Updated version in `crates/executors/src/executors/claude.rs`
- Added `--disallowedTools=AskUserQuestion` to CLI arguments

🤖 Generated with [Claude Code](https://claude.com/claude-code)