### PR TITLE
feat: add font family and font size customization

### DIFF
--- a/crates/services/src/services/config/mod.rs
+++ b/crates/services/src/services/config/mod.rs
@@ -17,15 +17,15 @@ pub enum ConfigError {
     ValidationError(String),
 }
 
-pub type Config = versions::v8::Config;
-pub type NotificationConfig = versions::v8::NotificationConfig;
-pub type EditorConfig = versions::v8::EditorConfig;
-pub type ThemeMode = versions::v8::ThemeMode;
-pub type SoundFile = versions::v8::SoundFile;
-pub type EditorType = versions::v8::EditorType;
-pub type GitHubConfig = versions::v8::GitHubConfig;
-pub type UiLanguage = versions::v8::UiLanguage;
-pub type ShowcaseState = versions::v8::ShowcaseState;
+pub type Config = versions::v9::Config;
+pub type NotificationConfig = versions::v9::NotificationConfig;
+pub type EditorConfig = versions::v9::EditorConfig;
+pub type ThemeMode = versions::v9::ThemeMode;
+pub type SoundFile = versions::v9::SoundFile;
+pub type EditorType = versions::v9::EditorType;
+pub type GitHubConfig = versions::v9::GitHubConfig;
+pub type UiLanguage = versions::v9::UiLanguage;
+pub type ShowcaseState = versions::v9::ShowcaseState;
 
 /// Will always return config, trying old schemas or eventually returning default
 pub async fn load_config_from_file(config_path: &PathBuf) -> Config {

--- a/crates/services/src/services/config/versions/mod.rs
+++ b/crates/services/src/services/config/versions/mod.rs
@@ -6,3 +6,4 @@ pub(super) mod v5;
 pub(super) mod v6;
 pub(super) mod v7;
 pub(super) mod v8;
+pub(super) mod v9;

--- a/crates/services/src/services/config/versions/v9.rs
+++ b/crates/services/src/services/config/versions/v9.rs
@@ -1,0 +1,126 @@
+use anyhow::Error;
+use executors::{executors::BaseCodingAgent, profile::ExecutorProfileId};
+use serde::{Deserialize, Serialize};
+use ts_rs::TS;
+pub use v8::{
+    EditorConfig, EditorType, GitHubConfig, NotificationConfig, ShowcaseState, SoundFile,
+    ThemeMode, UiLanguage,
+};
+
+use crate::services::config::versions::v8;
+
+fn default_git_branch_prefix() -> String {
+    "vk".to_string()
+}
+
+fn default_pr_auto_description_enabled() -> bool {
+    true
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, TS)]
+pub struct Config {
+    pub config_version: String,
+    pub theme: ThemeMode,
+    pub executor_profile: ExecutorProfileId,
+    pub disclaimer_acknowledged: bool,
+    pub onboarding_acknowledged: bool,
+    pub notifications: NotificationConfig,
+    pub editor: EditorConfig,
+    pub github: GitHubConfig,
+    pub analytics_enabled: bool,
+    pub workspace_dir: Option<String>,
+    pub last_app_version: Option<String>,
+    pub show_release_notes: bool,
+    #[serde(default)]
+    pub language: UiLanguage,
+    #[serde(default = "default_git_branch_prefix")]
+    pub git_branch_prefix: String,
+    #[serde(default)]
+    pub showcases: ShowcaseState,
+    #[serde(default = "default_pr_auto_description_enabled")]
+    pub pr_auto_description_enabled: bool,
+    #[serde(default)]
+    pub pr_auto_description_prompt: Option<String>,
+    #[serde(default)]
+    pub font_family: Option<String>,
+    #[serde(default)]
+    pub font_size: Option<u8>,
+}
+
+impl Config {
+    fn from_v8_config(old_config: v8::Config) -> Self {
+        Self {
+            config_version: "v9".to_string(),
+            theme: old_config.theme,
+            executor_profile: old_config.executor_profile,
+            disclaimer_acknowledged: old_config.disclaimer_acknowledged,
+            onboarding_acknowledged: old_config.onboarding_acknowledged,
+            notifications: old_config.notifications,
+            editor: old_config.editor,
+            github: old_config.github,
+            analytics_enabled: old_config.analytics_enabled,
+            workspace_dir: old_config.workspace_dir,
+            last_app_version: old_config.last_app_version,
+            show_release_notes: old_config.show_release_notes,
+            language: old_config.language,
+            git_branch_prefix: old_config.git_branch_prefix,
+            showcases: old_config.showcases,
+            pr_auto_description_enabled: old_config.pr_auto_description_enabled,
+            pr_auto_description_prompt: old_config.pr_auto_description_prompt,
+            font_family: None,
+            font_size: None,
+        }
+    }
+
+    pub fn from_previous_version(raw_config: &str) -> Result<Self, Error> {
+        let old_config = v8::Config::from(raw_config.to_string());
+        Ok(Self::from_v8_config(old_config))
+    }
+}
+
+impl From<String> for Config {
+    fn from(raw_config: String) -> Self {
+        if let Ok(config) = serde_json::from_str::<Config>(&raw_config)
+            && config.config_version == "v9"
+        {
+            return config;
+        }
+
+        match Self::from_previous_version(&raw_config) {
+            Ok(config) => {
+                tracing::info!("Config upgraded to v9");
+                config
+            }
+            Err(e) => {
+                tracing::warn!("Config migration failed: {}, using default", e);
+                Self::default()
+            }
+        }
+    }
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            config_version: "v9".to_string(),
+            theme: ThemeMode::System,
+            executor_profile: ExecutorProfileId::new(BaseCodingAgent::ClaudeCode),
+            disclaimer_acknowledged: false,
+            onboarding_acknowledged: false,
+            notifications: NotificationConfig::default(),
+            editor: EditorConfig::default(),
+            github: GitHubConfig::default(),
+            analytics_enabled: true,
+            workspace_dir: None,
+            last_app_version: None,
+            show_release_notes: false,
+            language: UiLanguage::default(),
+            git_branch_prefix: default_git_branch_prefix(),
+            showcases: ShowcaseState::default(),
+            pr_auto_description_enabled: true,
+            pr_auto_description_prompt: None,
+            font_family: None,
+            font_size: None,
+        }
+    }
+}

--- a/frontend/src/components/ConfigProvider.tsx
+++ b/frontend/src/components/ConfigProvider.tsx
@@ -17,6 +17,7 @@ import {
 import type { ExecutorConfig } from 'shared/types';
 import { configApi } from '../lib/api';
 import { updateLanguageFromConfig } from '../i18n/config';
+import { loadGoogleFont } from '../hooks/useGoogleFonts';
 
 interface UserSystemState {
   config: Config | null;
@@ -90,6 +91,39 @@ export function UserSystemProvider({ children }: UserSystemProviderProps) {
       updateLanguageFromConfig(config.language);
     }
   }, [config?.language]);
+
+  // Sync font family when config changes
+  useEffect(() => {
+    if (config?.font_family) {
+      // Load custom font from Google Fonts and apply it
+      loadGoogleFont(config.font_family);
+      document.documentElement.style.setProperty(
+        '--font-family',
+        config.font_family
+      );
+      document.body.style.fontFamily = config.font_family;
+    } else {
+      // Reset to default (remove custom font styling)
+      document.documentElement.style.removeProperty('--font-family');
+      document.body.style.fontFamily = '';
+    }
+  }, [config?.font_family]);
+
+  // Sync font size when config changes
+  useEffect(() => {
+    if (config?.font_size) {
+      // Apply custom font size (in pixels)
+      document.documentElement.style.setProperty(
+        '--font-size-base',
+        `${config.font_size}px`
+      );
+      document.documentElement.style.fontSize = `${config.font_size}px`;
+    } else {
+      // Reset to default
+      document.documentElement.style.removeProperty('--font-size-base');
+      document.documentElement.style.fontSize = '';
+    }
+  }, [config?.font_size]);
 
   const updateConfig = useCallback(
     (updates: Partial<Config>) => {

--- a/frontend/src/hooks/useGoogleFonts.ts
+++ b/frontend/src/hooks/useGoogleFonts.ts
@@ -1,0 +1,57 @@
+import { useMemo } from 'react';
+
+export interface GoogleFont {
+  family: string;
+  category: string;
+}
+
+// Curated list of popular Google Fonts
+// No API key needed - we'll load these directly from Google Fonts CDN
+const CURATED_FONTS: GoogleFont[] = [
+  { family: 'Chivo Mono', category: 'monospace' },
+  { family: 'Inter', category: 'sans-serif' },
+  { family: 'Roboto', category: 'sans-serif' },
+  { family: 'Open Sans', category: 'sans-serif' },
+  { family: 'Lato', category: 'sans-serif' },
+  { family: 'Montserrat', category: 'sans-serif' },
+  { family: 'Poppins', category: 'sans-serif' },
+  { family: 'Raleway', category: 'sans-serif' },
+  { family: 'Ubuntu', category: 'sans-serif' },
+  { family: 'Nunito', category: 'sans-serif' },
+  { family: 'Playfair Display', category: 'serif' },
+  { family: 'Merriweather', category: 'serif' },
+  { family: 'Source Sans Pro', category: 'sans-serif' },
+  { family: 'PT Sans', category: 'sans-serif' },
+  { family: 'Noto Sans', category: 'sans-serif' },
+  { family: 'Work Sans', category: 'sans-serif' },
+  { family: 'Oswald', category: 'sans-serif' },
+  { family: 'Roboto Condensed', category: 'sans-serif' },
+  { family: 'Fira Sans', category: 'sans-serif' },
+  { family: 'Titillium Web', category: 'sans-serif' },
+  { family: 'Karla', category: 'sans-serif' },
+];
+
+export function useGoogleFonts() {
+  const fonts = useMemo(() => CURATED_FONTS, []);
+
+  return { fonts, loading: false, error: null };
+}
+
+export function loadGoogleFont(fontFamily: string) {
+  const existingLink = document.querySelector(
+    `link[href*="fonts.googleapis.com"][href*="${fontFamily.replace(
+      / /g,
+      '+'
+    )}"]`
+  );
+
+  if (!existingLink) {
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = `https://fonts.googleapis.com/css2?family=${fontFamily.replace(
+      / /g,
+      '+'
+    )}:wght@400;500;600;700&display=swap`;
+    document.head.appendChild(link);
+  }
+}

--- a/frontend/src/i18n/locales/en/settings.json
+++ b/frontend/src/i18n/locales/en/settings.json
@@ -37,6 +37,18 @@
           "label": "Language",
           "placeholder": "Select language",
           "helper": "Choose your preferred language. Browser Default follows your system language."
+        },
+        "fontFamily": {
+          "label": "Font Family",
+          "placeholder": "Select font",
+          "helper": "Choose your preferred font for the application.",
+          "loading": "Loading fonts...",
+          "resetToDefault": "Reset to Default"
+        },
+        "fontSize": {
+          "label": "Font Size (px)",
+          "placeholder": "14",
+          "helper": "Set custom font size in pixels (10-24). Leave empty for default."
         }
       },
       "taskExecution": {

--- a/frontend/src/pages/settings/GeneralSettings.tsx
+++ b/frontend/src/pages/settings/GeneralSettings.tsx
@@ -36,6 +36,7 @@ import { EditorAvailabilityIndicator } from '@/components/EditorAvailabilityIndi
 import { useTheme } from '@/components/ThemeProvider';
 import { useUserSystem } from '@/components/ConfigProvider';
 import { TagManager } from '@/components/TagManager';
+import { useGoogleFonts } from '@/hooks/useGoogleFonts';
 
 export function GeneralSettings() {
   const { t } = useTranslation(['settings', 'common']);
@@ -52,6 +53,8 @@ export function GeneralSettings() {
     loading,
     updateAndSaveConfig, // Use this on Save
   } = useUserSystem();
+
+  const { fonts, loading: fontsLoading } = useGoogleFonts();
 
   // Draft state management
   const [draft, setDraft] = useState(() => (config ? cloneDeep(config) : null));
@@ -279,6 +282,83 @@ export function GeneralSettings() {
             </Select>
             <p className="text-sm text-muted-foreground">
               {t('settings.general.appearance.language.helper')}
+            </p>
+          </div>
+
+          <div className="space-y-2">
+            <div className="flex items-center justify-between">
+              <Label htmlFor="font-family">
+                {t('settings.general.appearance.fontFamily.label')}
+              </Label>
+              {draft?.font_family && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => updateDraft({ font_family: null })}
+                  className="h-auto py-1 px-2 text-xs"
+                >
+                  {t('settings.general.appearance.fontFamily.resetToDefault')}
+                </Button>
+              )}
+            </div>
+            <Select
+              value={draft?.font_family ?? 'default'}
+              onValueChange={(value: string) =>
+                updateDraft({
+                  font_family: value === 'default' ? null : value,
+                })
+              }
+              disabled={fontsLoading}
+            >
+              <SelectTrigger id="font-family">
+                <SelectValue
+                  placeholder={
+                    fontsLoading
+                      ? t('settings.general.appearance.fontFamily.loading')
+                      : t('settings.general.appearance.fontFamily.placeholder')
+                  }
+                />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="default">
+                  <span className="font-chivo-mono">
+                    Default (Chivo Mono)
+                  </span>
+                </SelectItem>
+                {fonts.map((font) => (
+                  <SelectItem key={font.family} value={font.family}>
+                    <span style={{ fontFamily: font.family }}>
+                      {font.family}
+                    </span>
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <p className="text-sm text-muted-foreground">
+              {t('settings.general.appearance.fontFamily.helper')}
+            </p>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="font-size">
+              {t('settings.general.appearance.fontSize.label')}
+            </Label>
+            <Input
+              id="font-size"
+              type="number"
+              min="10"
+              max="24"
+              placeholder={t('settings.general.appearance.fontSize.placeholder')}
+              value={draft?.font_size ?? ''}
+              onChange={(e) => {
+                const value = e.target.value;
+                updateDraft({
+                  font_size: value === '' ? null : parseInt(value, 10),
+                });
+              }}
+            />
+            <p className="text-sm text-muted-foreground">
+              {t('settings.general.appearance.fontSize.helper')}
             </p>
           </div>
         </CardContent>

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -304,7 +304,7 @@ export type DirectoryEntry = { name: string, path: string, is_directory: boolean
 
 export type DirectoryListResponse = { entries: Array<DirectoryEntry>, current_path: string, };
 
-export type Config = { config_version: string, theme: ThemeMode, executor_profile: ExecutorProfileId, disclaimer_acknowledged: boolean, onboarding_acknowledged: boolean, notifications: NotificationConfig, editor: EditorConfig, github: GitHubConfig, analytics_enabled: boolean, workspace_dir: string | null, last_app_version: string | null, show_release_notes: boolean, language: UiLanguage, git_branch_prefix: string, showcases: ShowcaseState, pr_auto_description_enabled: boolean, pr_auto_description_prompt: string | null, };
+export type Config = { config_version: string, theme: ThemeMode, executor_profile: ExecutorProfileId, disclaimer_acknowledged: boolean, onboarding_acknowledged: boolean, notifications: NotificationConfig, editor: EditorConfig, github: GitHubConfig, analytics_enabled: boolean, workspace_dir: string | null, last_app_version: string | null, show_release_notes: boolean, language: UiLanguage, git_branch_prefix: string, showcases: ShowcaseState, pr_auto_description_enabled: boolean, pr_auto_description_prompt: string | null, font_family: string | null, font_size: number | null, };
 
 export type NotificationConfig = { sound_enabled: boolean, push_enabled: boolean, sound_file: SoundFile, };
 


### PR DESCRIPTION
**Backend Changes:**
- Create config v9 with font_family (Option<String>) and font_size (Option<u8>)
- Support custom fonts from Google Fonts (null = default Chivo Mono)
- Support custom font sizes 10-24px (null = default size)
- Implement migration from config v8 to v9
- Generate TypeScript types via ts-rs

**Frontend Changes:**
- Add useGoogleFonts hook with 20 curated popular fonts (no API key needed)
- Add font family selector dropdown with "Default (Chivo Mono)" option
- Add font size number input with 10-24px range
- Add "Reset to Default" button (shown when custom font selected)
- Apply fonts dynamically via ConfigProvider
- Add i18n strings for font settings

**Implementation Details:**
- Fonts loaded on-demand from Google Fonts CDN
- null values reset to application CSS defaults
- Changes persist across sessions in user config
- Type-safe with full TypeScript support

## Preview
<img width="1455" height="1175" alt="Screenshot 2025-12-23 at 13 09 21" src="https://github.com/user-attachments/assets/3f775c16-56c3-4242-924b-6b51708ec71f" />
