### PR TITLE
feat: add prepend_prompt functionality to executors

### DIFF
--- a/crates/executors/src/executors/cursor.rs
+++ b/crates/executors/src/executors/cursor.rs
@@ -19,7 +19,8 @@ use crate::{
     command::{CmdOverrides, CommandBuilder, apply_overrides},
     env::ExecutionEnv,
     executors::{
-        AppendPrompt, AvailabilityInfo, ExecutorError, SpawnedChild, StandardCodingAgentExecutor,
+        CombineFullPrompt, AppendPrompt, AvailabilityInfo, PrependPrompt, ExecutorError,
+        SpawnedChild, StandardCodingAgentExecutor,
     },
     logs::{
         ActionType, FileChange, NormalizedEntry, NormalizedEntryError, NormalizedEntryType,
@@ -34,6 +35,8 @@ const CURSOR_AUTH_REQUIRED_MSG: &str = "Authentication required. Please run 'cur
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, TS, JsonSchema)]
 pub struct CursorAgent {
+    #[serde(default)]
+    pub prepend_prompt: PrependPrompt,
     #[serde(default)]
     pub append_prompt: AppendPrompt,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -81,7 +84,7 @@ impl StandardCodingAgentExecutor for CursorAgent {
 
         let (executable_path, args) = command_parts.into_resolved().await?;
 
-        let combined_prompt = self.append_prompt.combine_prompt(prompt);
+        let combined_prompt = CombineFullPrompt(&self.prepend_prompt, prompt, &self.append_prompt);
 
         let mut command = Command::new(executable_path);
         command
@@ -120,7 +123,7 @@ impl StandardCodingAgentExecutor for CursorAgent {
             .build_follow_up(&["--resume".to_string(), session_id.to_string()])?;
         let (executable_path, args) = command_parts.into_resolved().await?;
 
-        let combined_prompt = self.append_prompt.combine_prompt(prompt);
+        let combined_prompt = CombineFullPrompt(&self.prepend_prompt, prompt, &self.append_prompt);
 
         let mut command = Command::new(executable_path);
         command
@@ -1221,6 +1224,7 @@ mod tests {
         // Avoid relying on feature flag in tests; construct with a dummy command
         let executor = CursorAgent {
             // No command field needed anymore
+            prepend_prompt: PrependPrompt::default(),
             append_prompt: AppendPrompt::default(),
             force: None,
             model: None,

--- a/crates/server/src/bin/generate_types.rs
+++ b/crates/server/src/bin/generate_types.rs
@@ -186,6 +186,7 @@ fn generate_types_content() -> String {
         executors::executors::droid::Autonomy::decl(),
         executors::executors::droid::ReasoningEffortLevel::decl(),
         executors::executors::AppendPrompt::decl(),
+        executors::executors::PrependPrompt::decl(),
         executors::actions::coding_agent_initial::CodingAgentInitialRequest::decl(),
         executors::actions::coding_agent_follow_up::CodingAgentFollowUpRequest::decl(),
         executors::logs::CommandExitStatus::decl(),

--- a/shared/schemas/amp.json
+++ b/shared/schemas/amp.json
@@ -1,6 +1,16 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "properties": {
+    "prepend_prompt": {
+      "title": "Prepend Prompt",
+      "description": "Extra text prepended to the prompt",
+      "type": [
+        "string",
+        "null"
+      ],
+      "format": "textarea",
+      "default": null
+    },
     "append_prompt": {
       "title": "Append Prompt",
       "description": "Extra text appended to the prompt",

--- a/shared/schemas/claude_code.json
+++ b/shared/schemas/claude_code.json
@@ -1,6 +1,16 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "properties": {
+    "prepend_prompt": {
+      "title": "Prepend Prompt",
+      "description": "Extra text prepended to the prompt",
+      "type": [
+        "string",
+        "null"
+      ],
+      "format": "textarea",
+      "default": null
+    },
     "append_prompt": {
       "title": "Append Prompt",
       "description": "Extra text appended to the prompt",

--- a/shared/schemas/codex.json
+++ b/shared/schemas/codex.json
@@ -1,6 +1,16 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "properties": {
+    "prepend_prompt": {
+      "title": "Prepend Prompt",
+      "description": "Extra text prepended to the prompt",
+      "type": [
+        "string",
+        "null"
+      ],
+      "format": "textarea",
+      "default": null
+    },
     "append_prompt": {
       "title": "Append Prompt",
       "description": "Extra text appended to the prompt",

--- a/shared/schemas/copilot.json
+++ b/shared/schemas/copilot.json
@@ -1,6 +1,16 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "properties": {
+    "prepend_prompt": {
+      "title": "Prepend Prompt",
+      "description": "Extra text prepended to the prompt",
+      "type": [
+        "string",
+        "null"
+      ],
+      "format": "textarea",
+      "default": null
+    },
     "append_prompt": {
       "title": "Append Prompt",
       "description": "Extra text appended to the prompt",

--- a/shared/schemas/cursor_agent.json
+++ b/shared/schemas/cursor_agent.json
@@ -1,6 +1,16 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "properties": {
+    "prepend_prompt": {
+      "title": "Prepend Prompt",
+      "description": "Extra text prepended to the prompt",
+      "type": [
+        "string",
+        "null"
+      ],
+      "format": "textarea",
+      "default": null
+    },
     "append_prompt": {
       "title": "Append Prompt",
       "description": "Extra text appended to the prompt",

--- a/shared/schemas/droid.json
+++ b/shared/schemas/droid.json
@@ -1,6 +1,16 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "properties": {
+    "prepend_prompt": {
+      "title": "Prepend Prompt",
+      "description": "Extra text prepended to the prompt",
+      "type": [
+        "string",
+        "null"
+      ],
+      "format": "textarea",
+      "default": null
+    },
     "append_prompt": {
       "title": "Append Prompt",
       "description": "Extra text appended to the prompt",

--- a/shared/schemas/gemini.json
+++ b/shared/schemas/gemini.json
@@ -1,6 +1,16 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "properties": {
+    "prepend_prompt": {
+      "title": "Prepend Prompt",
+      "description": "Extra text prepended to the prompt",
+      "type": [
+        "string",
+        "null"
+      ],
+      "format": "textarea",
+      "default": null
+    },
     "append_prompt": {
       "title": "Append Prompt",
       "description": "Extra text appended to the prompt",

--- a/shared/schemas/opencode.json
+++ b/shared/schemas/opencode.json
@@ -1,6 +1,16 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "properties": {
+    "prepend_prompt": {
+      "title": "Prepend Prompt",
+      "description": "Extra text prepended to the prompt",
+      "type": [
+        "string",
+        "null"
+      ],
+      "format": "textarea",
+      "default": null
+    },
     "append_prompt": {
       "title": "Append Prompt",
       "description": "Extra text appended to the prompt",

--- a/shared/schemas/qwen_code.json
+++ b/shared/schemas/qwen_code.json
@@ -1,6 +1,16 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "properties": {
+    "prepend_prompt": {
+      "title": "Prepend Prompt",
+      "description": "Extra text prepended to the prompt",
+      "type": [
+        "string",
+        "null"
+      ],
+      "format": "textarea",
+      "default": null
+    },
     "append_prompt": {
       "title": "Append Prompt",
       "description": "Extra text appended to the prompt",


### PR DESCRIPTION
## Summary

Enables users to customize the instructions and commands sent to coding agents by adding `prepend_prompt` configuration support alongside existing `append_prompt`. Users can now prepend custom instructions (e.g., "Follow these coding standards:", "Use TypeScript best practices:") before the main prompt, giving full control over how agents receive and interpret tasks. Also fixes spacing issues in prompt combination - spaces are now properly added between `prepend_prompt`, the main prompt, and `append_prompt` only when each part exists. When `prepend_prompt` is null, there is no leading space before the prompt.

## Changes

### Frontend
- **TypeScript types**: `PrependPrompt` type will be available after running `pnpm run generate-types` (type generation already configured in `generate_types.rs`)

### Backend
- **executors/mod.rs**: 
  - Created `PrependPrompt` struct (mirrors `AppendPrompt` structure)
  - Fixed `AppendPrompt::combine_prompt()` to add space between prompt and append text
  - Added `CombineFullPrompt()` function that combines prepend + prompt + append with proper spacing
  - Removed deprecated `combine_prompt()` methods from both `AppendPrompt` and `PrependPrompt` structs
  - Added comprehensive tests for `CombineFullPrompt()` covering all combinations
- **All executor structs** (claude.rs, cursor.rs, copilot.rs, codex.rs, gemini.rs, amp.rs, droid.rs, opencode.rs, qwen.rs):
  - Added `prepend_prompt: PrependPrompt` field with `#[serde(default)]` attribute
  - Updated all `spawn()` and `spawn_follow_up()` methods to use `CombineFullPrompt()` instead of `append_prompt.combine_prompt()`
  - Updated default value initializations in test code
- **generate_types.rs**: Added `PrependPrompt::decl()` to TypeScript type generation
- **Schema files** (shared/schemas/*.json): Added `prepend_prompt` property to all 9 agent schema files (claude_code.json, cursor_agent.json, copilot.json, amp.json, gemini.json, codex.json, droid.json, opencode.json, qwen_code.json)

## Implementation Details

- **Custom command injection**: Users can now inject custom instructions, guidelines, or commands at the beginning of every prompt sent to agents via `prepend_prompt`, enabling fine-grained control over agent behavior
- **Spacing logic**: `CombineFullPrompt()` only adds spaces between parts that exist. If `prepend_prompt` is null, there's no leading space; if `append_prompt` is null, there's no trailing space
- **Backwards compatibility**: `prepend_prompt` defaults to `None` via `#[serde(default)]`, so existing configurations continue to work without modification
- **Consistent naming**: Function uses PascalCase (`CombineFullPrompt`) to match `PrependPrompt` and `AppendPrompt` struct naming conventions
- **All executors updated**: All 9 coding agent executors (ClaudeCode, CursorAgent, Copilot, Codex, Gemini, Amp, Droid, Opencode, QwenCode) support `prepend_prompt`, allowing custom commands across all supported agents
- **Schema validation**: All JSON schema files updated to include `prepend_prompt` with proper type, format (textarea), and default (null) values
- **Type safety**: `PrependPrompt` and `AppendPrompt` are transparent wrappers around `Option<String>`, ensuring type safety while allowing null values in JSON

This allows users to inject custom instructions, coding standards, or context-specific commands that agents will follow for every task execution.

