### PR TITLE
fix: Opencode ACP missing AvailableCommandsUpdate and CurrentModeUpdate event handlers in session_notification

### DIFF
--- a/crates/executors/src/executors/acp/client.rs
+++ b/crates/executors/src/executors/acp/client.rs
@@ -177,6 +177,12 @@ impl acp::Client for AcpClient {
             acp::SessionUpdate::ToolCall(tc) => Some(AcpEvent::ToolCall(tc)),
             acp::SessionUpdate::ToolCallUpdate(update) => Some(AcpEvent::ToolUpdate(update)),
             acp::SessionUpdate::Plan(plan) => Some(AcpEvent::Plan(plan)),
+            acp::SessionUpdate::AvailableCommandsUpdate(update) => {
+                Some(AcpEvent::AvailableCommands(update.available_commands))
+            }
+            acp::SessionUpdate::CurrentModeUpdate(update) => {
+                Some(AcpEvent::CurrentMode(update.current_mode_id))
+            }
             _ => Some(AcpEvent::Other(args)),
         };
 


### PR DESCRIPTION
Fixes a bug in the ACP (Agent Client Protocol) client where AvailableCommandsUpdate and CurrentModeUpdate events were not being properly converted to their respective AcpEvent types.

Root Cause:
The session_notification method in client.rs was missing case handlers for:
- SessionUpdate::AvailableCommandsUpdate 
- SessionUpdate::CurrentModeUpdate
These events were being caught by the fallback _ match arm and wrapped in Other events instead of being properly converted.

Fixes #1668 
{"Other":{"sessionId":"ses_489ecaedeffe57NdHDvrCt4otX","update":{"sessionUpdate":"available_commands_update","availableCommands":[{"name":"init","description":"create/update AGENTS.md","input":null},{"name":"review","description":"review changes [commit|branch|pr], defaults to uncommitted","input":null},{"name":"compact","description":"compact the session","input":null}]}}}

Fix:
Added explicit case handlers to properly convert:
- AvailableCommandsUpdate → AcpEvent::AvailableCommands
- CurrentModeUpdate → AcpEvent::CurrentMode