### PR TITLE
Fix #1361: keep WebSocket streams alive behind proxies

### DIFF
--- a/crates/server/src/routes/execution_processes.rs
+++ b/crates/server/src/routes/execution_processes.rs
@@ -108,6 +108,7 @@ async fn handle_raw_logs_ws(
 
     // Forward server messages + keepalive ping (for remote proxies that drop idle WS).
     let mut keepalive = tokio::time::interval(Duration::from_secs(20));
+    keepalive.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     // interval ticks immediately; skip the first one so we don't ping on connect.
     keepalive.tick().await;
 
@@ -172,6 +173,7 @@ async fn handle_normalized_logs_ws(
 
     // Forward server messages + keepalive ping (for remote proxies that drop idle WS).
     let mut keepalive = tokio::time::interval(Duration::from_secs(20));
+    keepalive.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     // interval ticks immediately; skip the first one so we don't ping on connect.
     keepalive.tick().await;
 
@@ -255,6 +257,7 @@ async fn handle_execution_processes_ws(
 
     // Forward server messages + keepalive ping (for remote proxies that drop idle WS).
     let mut keepalive = tokio::time::interval(Duration::from_secs(20));
+    keepalive.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     // interval ticks immediately; skip the first one so we don't ping on connect.
     keepalive.tick().await;
 

--- a/crates/server/src/routes/execution_processes.rs
+++ b/crates/server/src/routes/execution_processes.rs
@@ -3,7 +3,7 @@ use axum::{
     Extension, Router,
     extract::{
         Path, Query, State,
-        ws::{WebSocket, WebSocketUpgrade},
+        ws::{Message, WebSocket, WebSocketUpgrade},
     },
     middleware::from_fn_with_state,
     response::{IntoResponse, Json as ResponseJson},
@@ -63,9 +63,12 @@ async fn handle_raw_logs_ws(
     deployment: DeploymentImpl,
     exec_id: Uuid,
 ) -> anyhow::Result<()> {
-    use std::sync::{
-        Arc,
-        atomic::{AtomicUsize, Ordering},
+    use std::{
+        sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+        },
+        time::Duration,
     };
 
     use executors::logs::utils::patch::ConversationPatch;
@@ -103,17 +106,31 @@ async fn handle_raw_logs_ws(
     // Drain (and ignore) any client->server messages so pings/pongs work
     tokio::spawn(async move { while let Some(Ok(_)) = receiver.next().await {} });
 
-    // Forward server messages
-    while let Some(item) = stream.next().await {
-        match item {
-            Ok(msg) => {
-                if sender.send(msg).await.is_err() {
+    // Forward server messages + keepalive ping (for remote proxies that drop idle WS).
+    let mut keepalive = tokio::time::interval(Duration::from_secs(20));
+    // interval ticks immediately; skip the first one so we don't ping on connect.
+    keepalive.tick().await;
+
+    loop {
+        tokio::select! {
+            _ = keepalive.tick() => {
+                if sender.send(Message::Ping(Vec::new())).await.is_err() {
                     break; // client disconnected
                 }
             }
-            Err(e) => {
-                tracing::error!("stream error: {}", e);
-                break;
+            item = stream.next() => {
+                match item {
+                    Some(Ok(msg)) => {
+                        if sender.send(msg).await.is_err() {
+                            break; // client disconnected
+                        }
+                    }
+                    Some(Err(e)) => {
+                        tracing::error!("stream error: {}", e);
+                        break;
+                    }
+                    None => break,
+                }
             }
         }
     }
@@ -147,19 +164,37 @@ async fn handle_normalized_logs_ws(
     socket: WebSocket,
     stream: impl futures_util::Stream<Item = anyhow::Result<LogMsg>> + Unpin + Send + 'static,
 ) -> anyhow::Result<()> {
+    use std::time::Duration;
+
     let mut stream = stream.map_ok(|msg| msg.to_ws_message_unchecked());
     let (mut sender, mut receiver) = socket.split();
     tokio::spawn(async move { while let Some(Ok(_)) = receiver.next().await {} });
-    while let Some(item) = stream.next().await {
-        match item {
-            Ok(msg) => {
-                if sender.send(msg).await.is_err() {
+
+    // Forward server messages + keepalive ping (for remote proxies that drop idle WS).
+    let mut keepalive = tokio::time::interval(Duration::from_secs(20));
+    // interval ticks immediately; skip the first one so we don't ping on connect.
+    keepalive.tick().await;
+
+    loop {
+        tokio::select! {
+            _ = keepalive.tick() => {
+                if sender.send(Message::Ping(Vec::new())).await.is_err() {
                     break;
                 }
             }
-            Err(e) => {
-                tracing::error!("stream error: {}", e);
-                break;
+            item = stream.next() => {
+                match item {
+                    Some(Ok(msg)) => {
+                        if sender.send(msg).await.is_err() {
+                            break;
+                        }
+                    }
+                    Some(Err(e)) => {
+                        tracing::error!("stream error: {}", e);
+                        break;
+                    }
+                    None => break,
+                }
             }
         }
     }
@@ -203,6 +238,8 @@ async fn handle_execution_processes_ws(
     workspace_id: uuid::Uuid,
     show_soft_deleted: bool,
 ) -> anyhow::Result<()> {
+    use std::time::Duration;
+
     // Get the raw stream and convert LogMsg to WebSocket messages
     let mut stream = deployment
         .events()
@@ -216,17 +253,31 @@ async fn handle_execution_processes_ws(
     // Drain (and ignore) any client->server messages so pings/pongs work
     tokio::spawn(async move { while let Some(Ok(_)) = receiver.next().await {} });
 
-    // Forward server messages
-    while let Some(item) = stream.next().await {
-        match item {
-            Ok(msg) => {
-                if sender.send(msg).await.is_err() {
+    // Forward server messages + keepalive ping (for remote proxies that drop idle WS).
+    let mut keepalive = tokio::time::interval(Duration::from_secs(20));
+    // interval ticks immediately; skip the first one so we don't ping on connect.
+    keepalive.tick().await;
+
+    loop {
+        tokio::select! {
+            _ = keepalive.tick() => {
+                if sender.send(Message::Ping(Vec::new())).await.is_err() {
                     break; // client disconnected
                 }
             }
-            Err(e) => {
-                tracing::error!("stream error: {}", e);
-                break;
+            item = stream.next() => {
+                match item {
+                    Some(Ok(msg)) => {
+                        if sender.send(msg).await.is_err() {
+                            break; // client disconnected
+                        }
+                    }
+                    Some(Err(e)) => {
+                        tracing::error!("stream error: {}", e);
+                        break;
+                    }
+                    None => break,
+                }
             }
         }
     }

--- a/crates/server/src/routes/execution_processes.rs
+++ b/crates/server/src/routes/execution_processes.rs
@@ -114,7 +114,7 @@ async fn handle_raw_logs_ws(
     loop {
         tokio::select! {
             _ = keepalive.tick() => {
-                if sender.send(Message::Ping(Vec::new())).await.is_err() {
+                if sender.send(Message::Ping(Vec::new().into())).await.is_err() {
                     break; // client disconnected
                 }
             }
@@ -178,7 +178,7 @@ async fn handle_normalized_logs_ws(
     loop {
         tokio::select! {
             _ = keepalive.tick() => {
-                if sender.send(Message::Ping(Vec::new())).await.is_err() {
+                if sender.send(Message::Ping(Vec::new().into())).await.is_err() {
                     break;
                 }
             }
@@ -261,7 +261,7 @@ async fn handle_execution_processes_ws(
     loop {
         tokio::select! {
             _ = keepalive.tick() => {
-                if sender.send(Message::Ping(Vec::new())).await.is_err() {
+                if sender.send(Message::Ping(Vec::new().into())).await.is_err() {
                     break; // client disconnected
                 }
             }

--- a/crates/server/src/routes/projects.rs
+++ b/crates/server/src/routes/projects.rs
@@ -85,7 +85,7 @@ async fn handle_projects_ws(socket: WebSocket, deployment: DeploymentImpl) -> an
     loop {
         tokio::select! {
             _ = keepalive.tick() => {
-                if sender.send(Message::Ping(Vec::new())).await.is_err() {
+                if sender.send(Message::Ping(Vec::new().into())).await.is_err() {
                     break; // client disconnected
                 }
             }

--- a/crates/server/src/routes/projects.rs
+++ b/crates/server/src/routes/projects.rs
@@ -79,6 +79,7 @@ async fn handle_projects_ws(socket: WebSocket, deployment: DeploymentImpl) -> an
 
     // Forward server messages + keepalive ping (for remote proxies that drop idle WS).
     let mut keepalive = tokio::time::interval(Duration::from_secs(20));
+    keepalive.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     // interval ticks immediately; skip the first one so we don't ping on connect.
     keepalive.tick().await;
 

--- a/crates/server/src/routes/projects.rs
+++ b/crates/server/src/routes/projects.rs
@@ -5,7 +5,7 @@ use axum::{
     Extension, Json, Router,
     extract::{
         Path, Query, State,
-        ws::{WebSocket, WebSocketUpgrade},
+        ws::{Message, WebSocket, WebSocketUpgrade},
     },
     http::StatusCode,
     middleware::from_fn_with_state,
@@ -63,6 +63,8 @@ pub async fn stream_projects_ws(
 }
 
 async fn handle_projects_ws(socket: WebSocket, deployment: DeploymentImpl) -> anyhow::Result<()> {
+    use std::time::Duration;
+
     let mut stream = deployment
         .events()
         .stream_projects_raw()
@@ -75,17 +77,31 @@ async fn handle_projects_ws(socket: WebSocket, deployment: DeploymentImpl) -> an
     // Drain (and ignore) any client->server messages so pings/pongs work
     tokio::spawn(async move { while let Some(Ok(_)) = receiver.next().await {} });
 
-    // Forward server messages
-    while let Some(item) = stream.next().await {
-        match item {
-            Ok(msg) => {
-                if sender.send(msg).await.is_err() {
+    // Forward server messages + keepalive ping (for remote proxies that drop idle WS).
+    let mut keepalive = tokio::time::interval(Duration::from_secs(20));
+    // interval ticks immediately; skip the first one so we don't ping on connect.
+    keepalive.tick().await;
+
+    loop {
+        tokio::select! {
+            _ = keepalive.tick() => {
+                if sender.send(Message::Ping(Vec::new())).await.is_err() {
                     break; // client disconnected
                 }
             }
-            Err(e) => {
-                tracing::error!("stream error: {}", e);
-                break;
+            item = stream.next() => {
+                match item {
+                    Some(Ok(msg)) => {
+                        if sender.send(msg).await.is_err() {
+                            break; // client disconnected
+                        }
+                    }
+                    Some(Err(e)) => {
+                        tracing::error!("stream error: {}", e);
+                        break;
+                    }
+                    None => break,
+                }
             }
         }
     }

--- a/crates/server/src/routes/scratch.rs
+++ b/crates/server/src/routes/scratch.rs
@@ -132,6 +132,7 @@ async fn handle_scratch_ws(
 
     // Forward server messages + keepalive ping (for remote proxies that drop idle WS).
     let mut keepalive = tokio::time::interval(Duration::from_secs(20));
+    keepalive.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     // interval ticks immediately; skip the first one so we don't ping on connect.
     keepalive.tick().await;
 

--- a/crates/server/src/routes/scratch.rs
+++ b/crates/server/src/routes/scratch.rs
@@ -138,7 +138,7 @@ async fn handle_scratch_ws(
     loop {
         tokio::select! {
             _ = keepalive.tick() => {
-                if sender.send(Message::Ping(Vec::new())).await.is_err() {
+                if sender.send(Message::Ping(Vec::new().into())).await.is_err() {
                     break;
                 }
             }

--- a/crates/server/src/routes/scratch.rs
+++ b/crates/server/src/routes/scratch.rs
@@ -2,7 +2,7 @@ use axum::{
     Json, Router,
     extract::{
         Path, State,
-        ws::{WebSocket, WebSocketUpgrade},
+        ws::{Message, WebSocket, WebSocketUpgrade},
     },
     response::{IntoResponse, Json as ResponseJson},
     routing::get,
@@ -118,6 +118,8 @@ async fn handle_scratch_ws(
     id: Uuid,
     scratch_type: ScratchType,
 ) -> anyhow::Result<()> {
+    use std::time::Duration;
+
     let mut stream = deployment
         .events()
         .stream_scratch_raw(id, &scratch_type)
@@ -128,16 +130,31 @@ async fn handle_scratch_ws(
 
     tokio::spawn(async move { while let Some(Ok(_)) = receiver.next().await {} });
 
-    while let Some(item) = stream.next().await {
-        match item {
-            Ok(msg) => {
-                if sender.send(msg).await.is_err() {
+    // Forward server messages + keepalive ping (for remote proxies that drop idle WS).
+    let mut keepalive = tokio::time::interval(Duration::from_secs(20));
+    // interval ticks immediately; skip the first one so we don't ping on connect.
+    keepalive.tick().await;
+
+    loop {
+        tokio::select! {
+            _ = keepalive.tick() => {
+                if sender.send(Message::Ping(Vec::new())).await.is_err() {
                     break;
                 }
             }
-            Err(e) => {
-                tracing::error!("scratch stream error: {}", e);
-                break;
+            item = stream.next() => {
+                match item {
+                    Some(Ok(msg)) => {
+                        if sender.send(msg).await.is_err() {
+                            break;
+                        }
+                    }
+                    Some(Err(e)) => {
+                        tracing::error!("scratch stream error: {}", e);
+                        break;
+                    }
+                    None => break,
+                }
             }
         }
     }

--- a/crates/server/src/routes/task_attempts.rs
+++ b/crates/server/src/routes/task_attempts.rs
@@ -275,6 +275,7 @@ async fn handle_task_attempt_diff_ws(
     let (mut sender, mut receiver) = socket.split();
 
     let mut keepalive = tokio::time::interval(Duration::from_secs(20));
+    keepalive.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     // interval ticks immediately; skip the first one so we don't ping on connect.
     keepalive.tick().await;
 

--- a/crates/server/src/routes/task_attempts.rs
+++ b/crates/server/src/routes/task_attempts.rs
@@ -281,7 +281,7 @@ async fn handle_task_attempt_diff_ws(
     loop {
         tokio::select! {
             _ = keepalive.tick() => {
-                if sender.send(Message::Ping(Vec::new())).await.is_err() {
+                if sender.send(Message::Ping(Vec::new().into())).await.is_err() {
                     break;
                 }
             }

--- a/crates/server/src/routes/task_attempts.rs
+++ b/crates/server/src/routes/task_attempts.rs
@@ -14,7 +14,7 @@ use axum::{
     Extension, Json, Router,
     extract::{
         Query, State,
-        ws::{WebSocket, WebSocketUpgrade},
+        ws::{Message, WebSocket, WebSocketUpgrade},
     },
     http::StatusCode,
     middleware::from_fn_with_state,
@@ -260,6 +260,8 @@ async fn handle_task_attempt_diff_ws(
     workspace: Workspace,
     stats_only: bool,
 ) -> anyhow::Result<()> {
+    use std::time::Duration;
+
     use futures_util::{SinkExt, StreamExt, TryStreamExt};
     use utils::log_msg::LogMsg;
 
@@ -272,8 +274,17 @@ async fn handle_task_attempt_diff_ws(
 
     let (mut sender, mut receiver) = socket.split();
 
+    let mut keepalive = tokio::time::interval(Duration::from_secs(20));
+    // interval ticks immediately; skip the first one so we don't ping on connect.
+    keepalive.tick().await;
+
     loop {
         tokio::select! {
+            _ = keepalive.tick() => {
+                if sender.send(Message::Ping(Vec::new())).await.is_err() {
+                    break;
+                }
+            }
             // Wait for next stream item
             item = stream.next() => {
                 match item {

--- a/crates/server/src/routes/tasks.rs
+++ b/crates/server/src/routes/tasks.rs
@@ -93,7 +93,7 @@ async fn handle_tasks_ws(
     loop {
         tokio::select! {
             _ = keepalive.tick() => {
-                if sender.send(Message::Ping(Vec::new())).await.is_err() {
+                if sender.send(Message::Ping(Vec::new().into())).await.is_err() {
                     break; // client disconnected
                 }
             }

--- a/crates/server/src/routes/tasks.rs
+++ b/crates/server/src/routes/tasks.rs
@@ -87,6 +87,7 @@ async fn handle_tasks_ws(
 
     // Forward server messages + keepalive ping (for remote proxies that drop idle WS).
     let mut keepalive = tokio::time::interval(Duration::from_secs(20));
+    keepalive.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     // interval ticks immediately; skip the first one so we don't ping on connect.
     keepalive.tick().await;
 


### PR DESCRIPTION
Fixes #1361.

Remote deployments appear to drop idle WebSocket connections (~30s). When the frontend reconnects it replays full JsonPatch snapshots (e.g. `/tasks`, `/execution_processes`), interrupting typing and looking like a periodic refresh.

This adds server-side WebSocket keepalive pings (every 20s) to all streaming WS endpoints so connections stay active through proxies/LBs:
- Tasks stream
- Projects stream
- Scratch stream
- Execution process streams + raw/normalized logs
- Task attempt diff stream

Implementation uses `tokio::time::interval` + `tokio::select!` and drains client->server frames (so Pong/Close are handled). Missed ticks are skipped to avoid ping bursts.

Tests: `cargo test -p server`