### PR TITLE
Fix GitHub URL parsing to support non-github.com hosts

### DIFF
--- a/crates/review/Cargo.toml
+++ b/crates/review/Cargo.toml
@@ -27,3 +27,4 @@ tracing-subscriber = { workspace = true }
 dialoguer = "0.11"
 dirs = "5.0"
 toml = "0.8"
+url = "2.5"


### PR DESCRIPTION
Fixes GitHub URL parsing by removing the hardcoded  github.com  assumption.
Uses the url crate to correctly parse repository paths, enabling support
for GitHub Enterprise and custom GitHub hosts.
