### PR TITLE
feat: add auto-create PR on task completion setting

### DIFF
--- a/crates/services/src/services/config/versions/v8.rs
+++ b/crates/services/src/services/config/versions/v8.rs
@@ -17,6 +17,10 @@ fn default_pr_auto_description_enabled() -> bool {
     true
 }
 
+fn default_pr_auto_create_on_completion() -> bool {
+    false
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize, TS)]
 pub struct Config {
     pub config_version: String,
@@ -41,6 +45,8 @@ pub struct Config {
     pub pr_auto_description_enabled: bool,
     #[serde(default)]
     pub pr_auto_description_prompt: Option<String>,
+    #[serde(default = "default_pr_auto_create_on_completion")]
+    pub pr_auto_create_on_completion: bool,
 }
 
 impl Config {
@@ -66,6 +72,7 @@ impl Config {
             showcases: old_config.showcases,
             pr_auto_description_enabled: true,
             pr_auto_description_prompt: None,
+            pr_auto_create_on_completion: false,
         }
     }
 
@@ -116,6 +123,7 @@ impl Default for Config {
             showcases: ShowcaseState::default(),
             pr_auto_description_enabled: true,
             pr_auto_description_prompt: None,
+            pr_auto_create_on_completion: false,
         }
     }
 }

--- a/frontend/src/i18n/locales/en/settings.json
+++ b/frontend/src/i18n/locales/en/settings.json
@@ -138,6 +138,10 @@
       "pullRequests": {
         "title": "Pull Requests",
         "description": "Configure PR creation behavior",
+        "autoCreate": {
+          "label": "Auto-create PR when task completes",
+          "helper": "When enabled, a pull request will be automatically created when the coding agent finishes and goes idle."
+        },
         "autoDescription": {
           "label": "Auto-generate PR description by default",
           "helper": "When enabled, the AI agent will automatically update the PR title and description after creation."

--- a/frontend/src/pages/settings/GeneralSettings.tsx
+++ b/frontend/src/pages/settings/GeneralSettings.tsx
@@ -474,6 +474,23 @@ export function GeneralSettings() {
         <CardContent className="space-y-4">
           <div className="flex items-center space-x-2">
             <Checkbox
+              id="pr-auto-create"
+              checked={draft?.pr_auto_create_on_completion ?? false}
+              onCheckedChange={(checked: boolean) =>
+                updateDraft({ pr_auto_create_on_completion: checked })
+              }
+            />
+            <div className="space-y-0.5">
+              <Label htmlFor="pr-auto-create" className="cursor-pointer">
+                {t('settings.general.pullRequests.autoCreate.label')}
+              </Label>
+              <p className="text-sm text-muted-foreground">
+                {t('settings.general.pullRequests.autoCreate.helper')}
+              </p>
+            </div>
+          </div>
+          <div className="flex items-center space-x-2">
+            <Checkbox
               id="pr-auto-description"
               checked={draft?.pr_auto_description_enabled ?? false}
               onCheckedChange={(checked: boolean) =>

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -304,7 +304,7 @@ export type DirectoryEntry = { name: string, path: string, is_directory: boolean
 
 export type DirectoryListResponse = { entries: Array<DirectoryEntry>, current_path: string, };
 
-export type Config = { config_version: string, theme: ThemeMode, executor_profile: ExecutorProfileId, disclaimer_acknowledged: boolean, onboarding_acknowledged: boolean, notifications: NotificationConfig, editor: EditorConfig, github: GitHubConfig, analytics_enabled: boolean, workspace_dir: string | null, last_app_version: string | null, show_release_notes: boolean, language: UiLanguage, git_branch_prefix: string, showcases: ShowcaseState, pr_auto_description_enabled: boolean, pr_auto_description_prompt: string | null, };
+export type Config = { config_version: string, theme: ThemeMode, executor_profile: ExecutorProfileId, disclaimer_acknowledged: boolean, onboarding_acknowledged: boolean, notifications: NotificationConfig, editor: EditorConfig, github: GitHubConfig, analytics_enabled: boolean, workspace_dir: string | null, last_app_version: string | null, show_release_notes: boolean, language: UiLanguage, git_branch_prefix: string, showcases: ShowcaseState, pr_auto_description_enabled: boolean, pr_auto_description_prompt: string | null, pr_auto_create_on_completion: boolean, };
 
 export type NotificationConfig = { sound_enabled: boolean, push_enabled: boolean, sound_file: SoundFile, };
 


### PR DESCRIPTION
## Summary

- Adds a new global setting to automatically create pull requests when a coding agent finishes execution
- Streamlines workflow by eliminating the manual PR creation step after task completion
- Setting is opt-in (disabled by default) and located in Settings → General → Pull Requests

## Changes

### Backend (`crates/`)
- **config/versions/v8.rs**: Added `pr_auto_create_on_completion: bool` config field with default `false`
- **local-deployment/container.rs**: Added `try_auto_create_pr()` method that:
  - Triggers only on successful coding agent execution
  - Checks if PR already exists (skips if so)
  - Pushes branch to GitHub
  - Creates PR using task title/description
  - Saves PR info to database
  - Opens PR in browser

### Frontend (`frontend/src/`)
- **GeneralSettings.tsx**: Added checkbox toggle in Pull Requests settings card
- **i18n/locales/en/settings.json**: Added localization strings for the new setting

### Shared
- **shared/types.ts**: Regenerated TypeScript types with new config field

## Test plan

- [ ] Enable setting in Settings → General → Pull Requests
- [ ] Create a task and let the coding agent complete successfully
- [ ] Verify PR is automatically created and opens in browser
- [ ] Verify PR is not created if one already exists for the workspace
- [ ] Verify setting disabled by default on fresh install
- [ ] Verify setting persists across app restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)