### PR TITLE
feat: add auto-fix feature for PR CI failures and conflicts

### DIFF
--- a/crates/db/migrations/20260103152237_add_pr_auto_fix_to_projects.sql
+++ b/crates/db/migrations/20260103152237_add_pr_auto_fix_to_projects.sql
@@ -1,0 +1,3 @@
+-- Add pr_auto_fix_enabled to projects (default false)
+-- When enabled, the PR monitor will auto-prompt the agent when CI fails or PR has conflicts
+ALTER TABLE projects ADD COLUMN pr_auto_fix_enabled BOOLEAN NOT NULL DEFAULT FALSE;

--- a/crates/db/src/models/project.rs
+++ b/crates/db/src/models/project.rs
@@ -25,6 +25,8 @@ pub struct Project {
     pub dev_script_working_dir: Option<String>,
     pub default_agent_working_dir: Option<String>,
     pub remote_project_id: Option<Uuid>,
+    /// When enabled, the PR monitor will auto-prompt the agent when CI fails or PR has conflicts
+    pub pr_auto_fix_enabled: bool,
     #[ts(type = "Date")]
     pub created_at: DateTime<Utc>,
     #[ts(type = "Date")]
@@ -43,6 +45,7 @@ pub struct UpdateProject {
     pub dev_script: Option<String>,
     pub dev_script_working_dir: Option<String>,
     pub default_agent_working_dir: Option<String>,
+    pub pr_auto_fix_enabled: Option<bool>,
 }
 
 #[derive(Debug, Serialize, TS)]
@@ -75,6 +78,7 @@ impl Project {
                       dev_script_working_dir,
                       default_agent_working_dir,
                       remote_project_id as "remote_project_id: Uuid",
+                      pr_auto_fix_enabled as "pr_auto_fix_enabled!: bool",
                       created_at as "created_at!: DateTime<Utc>",
                       updated_at as "updated_at!: DateTime<Utc>"
                FROM projects
@@ -92,6 +96,7 @@ impl Project {
             SELECT p.id as "id!: Uuid", p.name, p.dev_script, p.dev_script_working_dir,
                    p.default_agent_working_dir,
                    p.remote_project_id as "remote_project_id: Uuid",
+                   p.pr_auto_fix_enabled as "pr_auto_fix_enabled!: bool",
                    p.created_at as "created_at!: DateTime<Utc>", p.updated_at as "updated_at!: DateTime<Utc>"
             FROM projects p
             WHERE p.id IN (
@@ -117,6 +122,7 @@ impl Project {
                       dev_script_working_dir,
                       default_agent_working_dir,
                       remote_project_id as "remote_project_id: Uuid",
+                      pr_auto_fix_enabled as "pr_auto_fix_enabled!: bool",
                       created_at as "created_at!: DateTime<Utc>",
                       updated_at as "updated_at!: DateTime<Utc>"
                FROM projects
@@ -136,6 +142,7 @@ impl Project {
                       dev_script_working_dir,
                       default_agent_working_dir,
                       remote_project_id as "remote_project_id: Uuid",
+                      pr_auto_fix_enabled as "pr_auto_fix_enabled!: bool",
                       created_at as "created_at!: DateTime<Utc>",
                       updated_at as "updated_at!: DateTime<Utc>"
                FROM projects
@@ -158,6 +165,7 @@ impl Project {
                       dev_script_working_dir,
                       default_agent_working_dir,
                       remote_project_id as "remote_project_id: Uuid",
+                      pr_auto_fix_enabled as "pr_auto_fix_enabled!: bool",
                       created_at as "created_at!: DateTime<Utc>",
                       updated_at as "updated_at!: DateTime<Utc>"
                FROM projects
@@ -188,6 +196,7 @@ impl Project {
                           dev_script_working_dir,
                           default_agent_working_dir,
                           remote_project_id as "remote_project_id: Uuid",
+                          pr_auto_fix_enabled as "pr_auto_fix_enabled!: bool",
                           created_at as "created_at!: DateTime<Utc>",
                           updated_at as "updated_at!: DateTime<Utc>""#,
             project_id,
@@ -210,11 +219,14 @@ impl Project {
         let dev_script = payload.dev_script.clone();
         let dev_script_working_dir = payload.dev_script_working_dir.clone();
         let default_agent_working_dir = payload.default_agent_working_dir.clone();
+        let pr_auto_fix_enabled = payload
+            .pr_auto_fix_enabled
+            .unwrap_or(existing.pr_auto_fix_enabled);
 
         sqlx::query_as!(
             Project,
             r#"UPDATE projects
-               SET name = $2, dev_script = $3, dev_script_working_dir = $4, default_agent_working_dir = $5
+               SET name = $2, dev_script = $3, dev_script_working_dir = $4, default_agent_working_dir = $5, pr_auto_fix_enabled = $6
                WHERE id = $1
                RETURNING id as "id!: Uuid",
                          name,
@@ -222,6 +234,7 @@ impl Project {
                          dev_script_working_dir,
                          default_agent_working_dir,
                          remote_project_id as "remote_project_id: Uuid",
+                         pr_auto_fix_enabled as "pr_auto_fix_enabled!: bool",
                          created_at as "created_at!: DateTime<Utc>",
                          updated_at as "updated_at!: DateTime<Utc>""#,
             id,
@@ -229,6 +242,7 @@ impl Project {
             dev_script,
             dev_script_working_dir,
             default_agent_working_dir,
+            pr_auto_fix_enabled,
         )
         .fetch_one(pool)
         .await

--- a/crates/deployment/src/lib.rs
+++ b/crates/deployment/src/lib.rs
@@ -133,7 +133,8 @@ pub trait Deployment: Clone + Send + Sync + 'static {
                 analytics_service: analytics_service.clone(),
             });
         let publisher = self.share_publisher().ok();
-        PrMonitorService::spawn(db, analytics, publisher).await
+        let queued_message_service = self.queued_message_service().clone();
+        PrMonitorService::spawn(db, analytics, publisher, queued_message_service).await
     }
 
     async fn track_if_analytics_allowed(&self, event_name: &str, properties: Value) {

--- a/crates/services/src/services/pr_monitor.rs
+++ b/crates/services/src/services/pr_monitor.rs
@@ -4,6 +4,9 @@ use db::{
     DBService,
     models::{
         merge::{Merge, MergeStatus, PrMerge},
+        project::Project,
+        scratch::DraftFollowUpData,
+        session::Session,
         task::{Task, TaskStatus},
         workspace::{Workspace, WorkspaceError},
     },
@@ -12,11 +15,15 @@ use serde_json::json;
 use sqlx::error::Error as SqlxError;
 use thiserror::Error;
 use tokio::time::interval;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 
 use crate::services::{
     analytics::AnalyticsContext,
-    github::{GitHubRepoInfo, GitHubService, GitHubServiceError},
+    github::{
+        GitHubRepoInfo, GitHubService, GitHubServiceError, PrCheckStatus, PrMergeableStatus,
+        PrStatusDetails,
+    },
+    queued_message::QueuedMessageService,
     share::SharePublisher,
 };
 
@@ -36,6 +43,7 @@ pub struct PrMonitorService {
     poll_interval: Duration,
     analytics: Option<AnalyticsContext>,
     publisher: Option<SharePublisher>,
+    queued_message_service: QueuedMessageService,
 }
 
 impl PrMonitorService {
@@ -43,12 +51,14 @@ impl PrMonitorService {
         db: DBService,
         analytics: Option<AnalyticsContext>,
         publisher: Option<SharePublisher>,
+        queued_message_service: QueuedMessageService,
     ) -> tokio::task::JoinHandle<()> {
         let service = Self {
             db,
             poll_interval: Duration::from_secs(60), // Check every minute
             analytics,
             publisher,
+            queued_message_service,
         };
         tokio::spawn(async move {
             service.start().await;
@@ -155,8 +165,168 @@ impl PrMonitorService {
                     );
                 }
             }
+        } else {
+            // PR is still open - check if we need to auto-fix issues
+            if let Err(e) = self
+                .check_and_auto_fix_pr_issues(&github_service, &repo_info, pr_merge)
+                .await
+            {
+                warn!(
+                    "Error checking PR #{} for auto-fix issues: {}",
+                    pr_merge.pr_info.number, e
+                );
+            }
         }
 
         Ok(())
+    }
+
+    /// Check if PR has CI failures or conflicts, and queue auto-fix prompt if enabled
+    async fn check_and_auto_fix_pr_issues(
+        &self,
+        github_service: &GitHubService,
+        repo_info: &GitHubRepoInfo,
+        pr_merge: &PrMerge,
+    ) -> Result<(), PrMonitorError> {
+        // Get workspace and task to check if auto-fix is enabled
+        let workspace = match Workspace::find_by_id(&self.db.pool, pr_merge.workspace_id).await? {
+            Some(w) => w,
+            None => return Ok(()), // No workspace found
+        };
+
+        let task = match Task::find_by_id(&self.db.pool, workspace.task_id).await? {
+            Some(t) => t,
+            None => return Ok(()), // No task found
+        };
+
+        let project = match Project::find_by_id(&self.db.pool, task.project_id).await? {
+            Some(p) => p,
+            None => return Ok(()), // No project found
+        };
+
+        // Check if auto-fix is enabled for this project
+        if !project.pr_auto_fix_enabled {
+            return Ok(());
+        }
+
+        // Get detailed PR status
+        let status_details = match github_service
+            .get_pr_status_details(repo_info, pr_merge.pr_info.number)
+            .await
+        {
+            Ok(details) => details,
+            Err(e) => {
+                debug!(
+                    "Could not get PR #{} status details: {}",
+                    pr_merge.pr_info.number, e
+                );
+                return Ok(());
+            }
+        };
+
+        // Build the auto-fix message if there are issues
+        let message = self.build_auto_fix_message(&status_details, pr_merge);
+        if message.is_none() {
+            return Ok(()); // No issues to fix
+        }
+
+        let message = message.unwrap();
+
+        // Find the latest session for this workspace
+        let session = match Session::find_latest_by_workspace_id(&self.db.pool, workspace.id).await?
+        {
+            Some(s) => s,
+            None => {
+                debug!(
+                    "No session found for workspace {}, cannot queue auto-fix message",
+                    workspace.id
+                );
+                return Ok(());
+            }
+        };
+
+        // Check if there's already a queued message for this session
+        if self.queued_message_service.has_queued(session.id) {
+            debug!(
+                "Session {} already has a queued message, skipping auto-fix",
+                session.id
+            );
+            return Ok(());
+        }
+
+        // Queue the auto-fix message
+        info!(
+            "Queueing auto-fix message for PR #{} (workspace {}): CI failures or conflicts detected",
+            pr_merge.pr_info.number, workspace.id
+        );
+
+        self.queued_message_service.queue_message(
+            session.id,
+            DraftFollowUpData {
+                message,
+                variant: None,
+            },
+        );
+
+        // Track analytics event
+        if let Some(analytics) = &self.analytics {
+            analytics.analytics_service.track_event(
+                &analytics.user_id,
+                "pr_auto_fix_queued",
+                Some(json!({
+                    "task_id": task.id.to_string(),
+                    "workspace_id": workspace.id.to_string(),
+                    "project_id": project.id.to_string(),
+                    "pr_number": pr_merge.pr_info.number,
+                    "has_ci_failures": status_details.check_status == PrCheckStatus::Failure,
+                    "has_conflicts": status_details.mergeable_status == PrMergeableStatus::Conflicting,
+                })),
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Build an auto-fix message based on PR issues
+    fn build_auto_fix_message(
+        &self,
+        status_details: &PrStatusDetails,
+        pr_merge: &PrMerge,
+    ) -> Option<String> {
+        let mut issues = Vec::new();
+
+        // Check for CI failures
+        if status_details.check_status == PrCheckStatus::Failure {
+            let failed_checks = if status_details.failed_checks.is_empty() {
+                "some checks".to_string()
+            } else {
+                status_details.failed_checks.join(", ")
+            };
+            issues.push(format!(
+                "CI checks are failing: {}",
+                failed_checks
+            ));
+        }
+
+        // Check for merge conflicts
+        if status_details.mergeable_status == PrMergeableStatus::Conflicting {
+            issues.push("The PR has merge conflicts that need to be resolved".to_string());
+        }
+
+        if issues.is_empty() {
+            return None;
+        }
+
+        let pr_url = &pr_merge.pr_info.url;
+        let issue_list = issues
+            .iter()
+            .map(|i| format!("- {}", i))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        Some(format!(
+            "The PR ({}) has issues that need to be fixed:\n\n{}\n\nPlease investigate and fix these issues.",
+            pr_url, issue_list
+        ))
     }
 }

--- a/frontend/src/pages/settings/ProjectSettings.tsx
+++ b/frontend/src/pages/settings/ProjectSettings.tsx
@@ -38,6 +38,7 @@ interface ProjectFormState {
   dev_script: string;
   dev_script_working_dir: string;
   default_agent_working_dir: string;
+  pr_auto_fix_enabled: boolean;
 }
 
 interface RepoScriptsFormState {
@@ -53,6 +54,7 @@ function projectToFormState(project: Project): ProjectFormState {
     dev_script: project.dev_script ?? '',
     dev_script_working_dir: project.dev_script_working_dir ?? '',
     default_agent_working_dir: project.default_agent_working_dir ?? '',
+    pr_auto_fix_enabled: project.pr_auto_fix_enabled ?? false,
   };
 }
 
@@ -397,6 +399,7 @@ export function ProjectSettings() {
         dev_script_working_dir: draft.dev_script_working_dir.trim() || null,
         default_agent_working_dir:
           draft.default_agent_working_dir.trim() || null,
+        pr_auto_fix_enabled: draft.pr_auto_fix_enabled,
       };
 
       updateProject.mutate({
@@ -627,6 +630,28 @@ export function ProjectSettings() {
                 />
                 <p className="text-sm text-muted-foreground">
                   {t('settings.projects.scripts.agentWorkingDir.helper')}
+                </p>
+              </div>
+
+              <div className="space-y-2 pt-4 border-t">
+                <div className="flex items-center space-x-2">
+                  <Checkbox
+                    id="pr-auto-fix"
+                    checked={draft.pr_auto_fix_enabled}
+                    onCheckedChange={(checked) =>
+                      updateDraft({ pr_auto_fix_enabled: checked === true })
+                    }
+                  />
+                  <Label
+                    htmlFor="pr-auto-fix"
+                    className="text-sm font-medium cursor-pointer"
+                  >
+                    Auto-fix PR issues
+                  </Label>
+                </div>
+                <p className="text-sm text-muted-foreground pl-6">
+                  When enabled, automatically prompt the agent to fix CI
+                  failures or merge conflicts when detected on open PRs.
                 </p>
               </div>
 


### PR DESCRIPTION
## Summary

- Adds a new project setting `pr_auto_fix_enabled` (default off) that monitors open PRs and automatically prompts the agent when CI failures or merge conflicts are detected
- Helps keep PRs green without requiring manual intervention
- Extends the existing PR monitor to check GitHub check status and mergeability

## Changes

- **Database**: New migration adding `pr_auto_fix_enabled` boolean to projects table
- **Backend**: Extended GitHub CLI to fetch PR status details (check runs + mergeability)
- **Backend**: Updated PR monitor service to check for issues and queue auto-fix prompts
- **Frontend**: Added toggle in Project Settings under General settings

## How it works

1. When enabled for a project, the PR monitor (runs every 60 seconds) checks open PRs
2. For each open PR, it fetches the CI check status and merge conflict status from GitHub
3. If tests are failing or there are merge conflicts, it queues a follow-up message to the agent's session
4. The agent receives the message and can investigate/fix the issues

## Test plan

- [ ] Enable `pr_auto_fix_enabled` in Project Settings
- [ ] Create a PR with a failing CI check
- [ ] Wait for the PR monitor to detect the failure
- [ ] Verify a follow-up message is queued for the agent
- [ ] Create a PR with merge conflicts
- [ ] Verify conflicts are detected and prompt is queued

## Notes

After merging, run:
```bash
pnpm run prepare-db
pnpm run generate-types
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)