### PR TITLE
Update opencode-ai version to 1.0.223

### DIFF
--- a/crates/executors/src/executors/opencode.rs
+++ b/crates/executors/src/executors/opencode.rs
@@ -39,7 +39,7 @@ pub struct Opencode {
 
 impl Opencode {
     fn build_command_builder(&self) -> CommandBuilder {
-        let builder = CommandBuilder::new("npx -y opencode-ai@1.0.134").extend_params(["acp"]);
+        let builder = CommandBuilder::new("npx -y opencode-ai@1.0.223").extend_params(["acp"]);
         apply_overrides(builder, &self.cmd)
     }
 


### PR DESCRIPTION
Updates the opencode-ai dependency version from 1.0.134 to 1.0.223 in the opencode executor.

This was necessary for me to use some of the models through opencode zen.