### PR TITLE
feat: make plus sign clickable in empty project state

### DIFF
--- a/frontend/src/components/projects/ProjectList.tsx
+++ b/frontend/src/components/projects/ProjectList.tsx
@@ -77,9 +77,12 @@ export function ProjectList() {
       ) : projects.length === 0 ? (
         <Card>
           <CardContent className="py-12 text-center">
-            <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-lg bg-muted">
+            <button
+              onClick={handleCreateProject}
+              className="mx-auto flex h-12 w-12 items-center justify-center rounded-lg bg-muted hover:bg-muted/80 transition-colors cursor-pointer"
+            >
               <Plus className="h-6 w-6" />
-            </div>
+            </button>
             <h3 className="mt-4 text-lg font-semibold">{t('empty.title')}</h3>
             <p className="mt-2 text-sm text-muted-foreground">
               {t('empty.description')}


### PR DESCRIPTION
## Summary
- Makes the plus sign icon clickable in the empty projects state for better onboarding UX
- Users can now click either the plus icon or the "Create your first project" button

## Changes
- Converted the static `<div>` containing the plus icon to a `<button>`
- Added `onClick={handleCreateProject}` to trigger project creation
- Added hover state and cursor styling for visual feedback

## Test plan
- [ ] Open Vibe Kanban with no projects
- [ ] Click the plus sign icon
- [ ] Verify the "Create Project" dialog opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)