### PR TITLE
fix: add read:org scope to GitHub OAuth

### DIFF
--- a/crates/remote/src/auth/provider.rs
+++ b/crates/remote/src/auth/provider.rs
@@ -164,7 +164,7 @@ impl AuthorizationProvider for GitHubOAuthProvider {
     }
 
     fn scopes(&self) -> &[&str] {
-        &["read:user", "user:email"]
+        &["read:user", "user:email", "read:org"]
     }
 
     fn authorize_url(&self, state: &str, redirect_uri: &str) -> Result<Url> {


### PR DESCRIPTION
## Summary

- Adds the `read:org` scope to GitHub OAuth authorization requests
- Allows users to see and access their GitHub organizations within vibe-kanban

## Details

The GitHub OAuth provider was only requesting `read:user` and `user:email` scopes. This prevented users from seeing their organizations during login, as reported in #1730.

This one-line fix adds `read:org` to the scopes requested during GitHub OAuth authorization.

## Test plan

- [ ] Log out and re-authenticate with GitHub
- [ ] Verify that organizations are now visible during the OAuth flow
- [ ] Confirm organization repositories can be accessed

Fixes #1730

🤖 Generated with [Claude Code](https://claude.com/claude-code)