### PR TITLE
Fix macOS notifications opening Script Editor when clicked

### DIFF
--- a/docs/configuration-customisation/global-settings.mdx
+++ b/docs/configuration-customisation/global-settings.mdx
@@ -100,6 +100,16 @@ Set a prefix for auto-generated branch names (e.g., `vk` results in `vk/task-nam
 
 Toggle sound effects and push notifications to stay informed about task status changes.
 
+### macOS Notifications
+
+For the best notification experience on macOS, we recommend installing `terminal-notifier`:
+
+```bash
+brew install terminal-notifier
+```
+
+Without `terminal-notifier`, notifications are sent via AppleScript, which causes clicking on notifications to open Script Editor. With `terminal-notifier` installed, clicking notifications won't open any unwanted applications.
+
 ## Telemetry
 
 Enable or disable telemetry data collection to help improve Vibe Kanban.


### PR DESCRIPTION
## Summary
- Use `terminal-notifier` as the preferred notification method on macOS
- Fall back to `osascript` if terminal-notifier is not installed
- Fixes the issue where clicking notifications opens Script Editor instead of doing nothing useful

## Problem
When users click on macOS notifications from Vibe Kanban, Script Editor opens instead of the expected behavior. This is because `osascript`'s `display notification` command sends notifications as Script Editor (since osascript is the sending process).

## Solution
Prefer `terminal-notifier` which sends notifications as itself, so clicking them doesn't open any app. Users can install it via:
```bash
brew install terminal-notifier
```

If `terminal-notifier` is not installed, the code falls back to the existing `osascript` behavior.

## Test plan
- [ ] On macOS with `terminal-notifier` installed: notifications should work and clicking should not open Script Editor
- [ ] On macOS without `terminal-notifier`: notifications should still work (via osascript fallback)
- [ ] On Linux/Windows: no change in behavior

Closes #1129

🤖 Generated with [Claude Code](https://claude.com/claude-code)