### PR TITLE
fix: detect and handle iframe load failures in PWA mode

### DIFF
--- a/frontend/src/components/panels/PreviewPanel.tsx
+++ b/frontend/src/components/panels/PreviewPanel.tsx
@@ -7,6 +7,7 @@ import { useDevserverPreview } from '@/hooks/useDevserverPreview';
 import { useDevServer } from '@/hooks/useDevServer';
 import { useLogStream } from '@/hooks/useLogStream';
 import { useDevserverUrlFromLogs } from '@/hooks/useDevserverUrl';
+import { useIsPwa } from '@/hooks/useIsPwa';
 import { ClickToComponentListener } from '@/utils/previewBridge';
 import { useClickedElements } from '@/contexts/ClickedElementsProvider';
 import { Alert } from '@/components/ui/alert';
@@ -15,6 +16,7 @@ import { DevServerLogsView } from '@/components/tasks/TaskDetails/preview/DevSer
 import { PreviewToolbar } from '@/components/tasks/TaskDetails/preview/PreviewToolbar';
 import { NoServerContent } from '@/components/tasks/TaskDetails/preview/NoServerContent';
 import { ReadyContent } from '@/components/tasks/TaskDetails/preview/ReadyContent';
+import { PwaWarningContent } from '@/components/tasks/TaskDetails/preview/PwaWarningContent';
 
 export function PreviewPanel() {
   const [iframeError, setIframeError] = useState(false);
@@ -27,6 +29,7 @@ export function PreviewPanel() {
 
   const { t } = useTranslation('tasks');
   const { project, projectId } = useProject();
+  const isPwa = useIsPwa();
   const { attemptId: rawAttemptId } = useParams<{ attemptId?: string }>();
 
   const attemptId =
@@ -171,11 +174,15 @@ export function PreviewPanel() {
               onStop={stopDevServer}
               isStopping={isStoppingDevServer}
             />
-            <ReadyContent
-              url={previewState.url}
-              iframeKey={`${previewState.url}-${refreshKey}`}
-              onIframeError={handleIframeError}
-            />
+            {isPwa && previewState.url ? (
+              <PwaWarningContent url={previewState.url} />
+            ) : (
+              <ReadyContent
+                url={previewState.url}
+                iframeKey={`${previewState.url}-${refreshKey}`}
+                onIframeError={handleIframeError}
+              />
+            )}
           </>
         ) : (
           <NoServerContent

--- a/frontend/src/components/panels/PreviewPanel.tsx
+++ b/frontend/src/components/panels/PreviewPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { Loader2, X } from 'lucide-react';
@@ -68,14 +68,14 @@ export function PreviewPanel() {
     setIframeError(true);
   };
 
-  const handleIframeLoad = () => {
+  const handleIframeLoad = useCallback(() => {
     iframeLoadedRef.current = true;
     // Clear the PWA timeout since iframe loaded successfully
     if (pwaTimeoutRef.current) {
       clearTimeout(pwaTimeoutRef.current);
       pwaTimeoutRef.current = null;
     }
-  };
+  }, []);
 
   // In PWA mode, detect if iframe is blocked by checking if it loads within a timeout
   useEffect(() => {

--- a/frontend/src/components/tasks/TaskDetails/preview/PwaWarningContent.tsx
+++ b/frontend/src/components/tasks/TaskDetails/preview/PwaWarningContent.tsx
@@ -1,0 +1,40 @@
+import { ExternalLink, AlertTriangle } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { Button } from '@/components/ui/button';
+
+interface PwaWarningContentProps {
+  url: string;
+}
+
+export function PwaWarningContent({ url }: PwaWarningContentProps) {
+  const { t } = useTranslation('tasks');
+
+  return (
+    <div className="flex-1 flex items-center justify-center p-8">
+      <div className="text-center max-w-md space-y-4">
+        <div className="flex justify-center">
+          <div className="rounded-full bg-amber-100 dark:bg-amber-900/30 p-3">
+            <AlertTriangle className="h-8 w-8 text-amber-600 dark:text-amber-500" />
+          </div>
+        </div>
+        <div className="space-y-2">
+          <h3 className="text-lg font-semibold">
+            {t('preview.pwaWarning.title')}
+          </h3>
+          <p className="text-sm text-muted-foreground">
+            {t('preview.pwaWarning.description')}
+          </p>
+        </div>
+        <Button asChild size="lg" className="gap-2">
+          <a href={url} target="_blank" rel="noopener noreferrer">
+            <ExternalLink className="h-4 w-4" />
+            {t('preview.pwaWarning.openInBrowser')}
+          </a>
+        </Button>
+        <p className="text-xs text-muted-foreground">
+          {url}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/tasks/TaskDetails/preview/ReadyContent.tsx
+++ b/frontend/src/components/tasks/TaskDetails/preview/ReadyContent.tsx
@@ -1,26 +1,58 @@
+import { useRef, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 
 interface ReadyContentProps {
   url?: string;
   iframeKey: string;
   onIframeError: () => void;
+  onIframeLoad?: () => void;
 }
 
 export function ReadyContent({
   url,
   iframeKey,
   onIframeError,
+  onIframeLoad,
 }: ReadyContentProps) {
   const { t } = useTranslation('tasks');
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+
+  // Detect if iframe content actually loaded or is blocked
+  useEffect(() => {
+    const iframe = iframeRef.current;
+    if (!iframe) return;
+
+    const handleLoad = () => {
+      // Try to detect if the iframe actually loaded content
+      // In PWA mode, the iframe might "load" but with blocked/empty content
+      try {
+        // This will throw if cross-origin and blocked
+        const hasContent = iframe.contentWindow?.document;
+        if (hasContent) {
+          onIframeLoad?.();
+        }
+      } catch {
+        // Cross-origin access denied is expected for localhost dev servers
+        // If we get here, the iframe loaded something (even if cross-origin)
+        onIframeLoad?.();
+      }
+    };
+
+    iframe.addEventListener('load', handleLoad);
+    return () => iframe.removeEventListener('load', handleLoad);
+  }, [iframeKey, onIframeLoad]);
 
   return (
     <div className="flex-1">
       <iframe
+        ref={iframeRef}
         key={iframeKey}
         src={url}
         title={t('preview.iframe.title')}
         className="w-full h-full border-0"
         sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-modals"
+        // Allow cross-origin features that might help in PWA mode
+        allow="cross-origin-isolated; clipboard-read; clipboard-write"
         referrerPolicy="no-referrer"
         onError={onIframeError}
       />

--- a/frontend/src/components/tasks/TaskDetails/preview/ReadyContent.tsx
+++ b/frontend/src/components/tasks/TaskDetails/preview/ReadyContent.tsx
@@ -16,6 +16,8 @@ export function ReadyContent({
 }: ReadyContentProps) {
   const { t } = useTranslation('tasks');
   const iframeRef = useRef<HTMLIFrameElement>(null);
+  const onIframeLoadRef = useRef(onIframeLoad);
+  onIframeLoadRef.current = onIframeLoad;
 
   // Detect if iframe content actually loaded or is blocked
   useEffect(() => {
@@ -29,18 +31,18 @@ export function ReadyContent({
         // This will throw if cross-origin and blocked
         const hasContent = iframe.contentWindow?.document;
         if (hasContent) {
-          onIframeLoad?.();
+          onIframeLoadRef.current?.();
         }
       } catch {
         // Cross-origin access denied is expected for localhost dev servers
         // If we get here, the iframe loaded something (even if cross-origin)
-        onIframeLoad?.();
+        onIframeLoadRef.current?.();
       }
     };
 
     iframe.addEventListener('load', handleLoad);
     return () => iframe.removeEventListener('load', handleLoad);
-  }, [iframeKey, onIframeLoad]);
+  }, [iframeKey]);
 
   return (
     <div className="flex-1">

--- a/frontend/src/hooks/useIsPwa.ts
+++ b/frontend/src/hooks/useIsPwa.ts
@@ -1,0 +1,18 @@
+import { useMediaQuery } from './useMediaQuery';
+
+/**
+ * Detects if the app is running as a Progressive Web App (PWA) in standalone mode.
+ * This is useful for handling PWA-specific behaviors, such as iframe restrictions
+ * that may occur when the app is installed as a Chrome App.
+ */
+export function useIsPwa(): boolean {
+  const isStandalone = useMediaQuery('(display-mode: standalone)');
+
+  // Also check navigator.standalone for iOS Safari
+  const isIosStandalone =
+    typeof window !== 'undefined' &&
+    (window.navigator as Navigator & { standalone?: boolean }).standalone ===
+      true;
+
+  return isStandalone || isIosStandalone;
+}

--- a/frontend/src/i18n/locales/en/tasks.json
+++ b/frontend/src/i18n/locales/en/tasks.json
@@ -62,6 +62,11 @@
   "preview": {
     "title": "Preview",
     "selectAttempt": "Select an attempt to see preview",
+    "pwaWarning": {
+      "title": "Preview unavailable in app mode",
+      "description": "Previewing localhost content in an iframe doesn't work when Vibe Kanban is installed as an app due to browser security restrictions.",
+      "openInBrowser": "Open preview in browser"
+    },
     "troubleAlert": {
       "title": "We're having trouble previewing your application:",
       "item1": "Did the dev server start successfully? There may be a bug you need to resolve, or perhaps dependencies need to be installed.",


### PR DESCRIPTION
## Summary
When the dev server preview iframe fails to load (which can happen in PWA/Chrome App mode due to browser security restrictions), show a helpful message with a prominent "Open in browser" button instead of leaving users stuck with a broken preview.

## Problem
When Vibe Kanban is installed as a Chrome App (PWA), the dev server preview iframe may fail to load localhost content due to stricter browser security policies. Users see a blank/stuck preview with no explanation or workaround.

## Solution
- **Detect actual failures** - Monitor iframe load events and use a 3-second timeout to detect blocked iframes
- **Show actionable message** - Display a clear explanation and "Open preview in browser" button only when loading actually fails  
- **Try to help the iframe work** - Add `allow` attribute with cross-origin permissions that might help in some scenarios
- **Don't break working setups** - PWA users whose iframes load successfully see the normal preview

## Changes
- `useIsPwa.ts` - New hook to detect PWA/standalone mode via `display-mode: standalone` media query
- `PwaWarningContent.tsx` - Warning component with explanation and "Open in browser" button
- `ReadyContent.tsx` - Added iframe load detection and `allow` attribute
- `PreviewPanel.tsx` - Integrated PWA detection with 3-second timeout before showing warning
- `tasks.json` - Added i18n translations for PWA warning messages

## Test plan
- [ ] In regular browser: verify preview works normally with no changes
- [ ] Install Vibe Kanban as Chrome App (PWA)
- [ ] Start a dev server
- [ ] If iframe loads within 3s: verify preview works normally
- [ ] If iframe doesn't load: verify warning appears with "Open preview in browser" button
- [ ] Click button and verify it opens preview in new browser tab
- [ ] Click refresh in toolbar and verify it retries loading the iframe

🤖 Generated with [Claude Code](https://claude.com/claude-code)