### PR TITLE
feat: Add Goal Flow for decomposing high-level objectives into tasks

### DIFF
--- a/crates/executors/src/actions/coding_agent_initial.rs
+++ b/crates/executors/src/actions/coding_agent_initial.rs
@@ -9,6 +9,7 @@ use crate::{
     approvals::ExecutorApprovalService,
     env::ExecutionEnv,
     executors::{BaseCodingAgent, ExecutorError, SpawnedChild, StandardCodingAgentExecutor},
+    mcp_config::PRECONFIGURED_MCP_SERVERS,
     profile::{ExecutorConfigs, ExecutorProfileId},
 };
 
@@ -23,6 +24,10 @@ pub struct CodingAgentInitialRequest {
     /// If None, uses the container_ref directory directly.
     #[serde(default)]
     pub working_dir: Option<String>,
+    /// If true, inject the vibe_kanban MCP server into the workspace before spawning.
+    /// This allows the agent to use task management tools (create_task, list_tasks, etc.).
+    #[serde(default)]
+    pub include_vibe_kanban_mcp: bool,
 }
 
 impl CodingAgentInitialRequest {
@@ -45,6 +50,13 @@ impl Executable for CodingAgentInitialRequest {
             None => current_dir.to_path_buf(),
         };
 
+        // If requested, inject vibe_kanban MCP server via project-scoped .mcp.json
+        if self.include_vibe_kanban_mcp {
+            if let Err(e) = inject_vibe_kanban_mcp(&effective_dir).await {
+                tracing::warn!("Failed to inject vibe_kanban MCP config: {e}");
+            }
+        }
+
         let executor_profile_id = self.executor_profile_id.clone();
         let mut agent = ExecutorConfigs::get_cached()
             .get_coding_agent(&executor_profile_id)
@@ -56,4 +68,49 @@ impl Executable for CodingAgentInitialRequest {
 
         agent.spawn(&effective_dir, &self.prompt, env).await
     }
+}
+
+/// Inject the vibe_kanban MCP server into the workspace's .mcp.json file.
+/// If the file already exists, merges the vibe_kanban server into the existing config.
+/// This uses project-scoped MCP configuration so Claude Code picks it up automatically.
+async fn inject_vibe_kanban_mcp(workspace_dir: &Path) -> Result<(), ExecutorError> {
+    let mcp_json_path = workspace_dir.join(".mcp.json");
+
+    // Get the vibe_kanban server config from preconfigured servers
+    let vibe_kanban_config = PRECONFIGURED_MCP_SERVERS
+        .get("vibe_kanban")
+        .cloned()
+        .unwrap_or_else(|| {
+            // Fallback in case it's not in preconfigured
+            serde_json::json!({
+                "command": "npx",
+                "args": ["-y", "vibe-kanban@latest", "--mcp"]
+            })
+        });
+
+    // Read existing config or start fresh
+    let mut mcp_config: serde_json::Value = if mcp_json_path.exists() {
+        match tokio::fs::read_to_string(&mcp_json_path).await {
+            Ok(content) => serde_json::from_str(&content).unwrap_or_else(|_| {
+                serde_json::json!({ "mcpServers": {} })
+            }),
+            Err(_) => serde_json::json!({ "mcpServers": {} }),
+        }
+    } else {
+        serde_json::json!({ "mcpServers": {} })
+    };
+
+    // Ensure mcpServers object exists
+    if !mcp_config.get("mcpServers").is_some() {
+        mcp_config["mcpServers"] = serde_json::json!({});
+    }
+
+    // Inject vibe_kanban server (overwrites if already present)
+    mcp_config["mcpServers"]["vibe_kanban"] = vibe_kanban_config;
+
+    let content = serde_json::to_string_pretty(&mcp_config)?;
+    tokio::fs::write(&mcp_json_path, content).await?;
+
+    tracing::info!("Injected vibe_kanban MCP config to {}", mcp_json_path.display());
+    Ok(())
 }

--- a/crates/local-deployment/src/container.rs
+++ b/crates/local-deployment/src/container.rs
@@ -839,6 +839,7 @@ impl LocalContainerService {
                 prompt: queued_data.message.clone(),
                 executor_profile_id: executor_profile_id.clone(),
                 working_dir,
+                include_vibe_kanban_mcp: false,
             })
         };
 

--- a/crates/server/src/routes/task_attempts.rs
+++ b/crates/server/src/routes/task_attempts.rs
@@ -182,7 +182,7 @@ pub async fn create_task_attempt(
     WorkspaceRepo::create_many(pool, workspace.id, &workspace_repos).await?;
     if let Err(err) = deployment
         .container()
-        .start_workspace(&workspace, executor_profile_id.clone())
+        .start_workspace(&workspace, executor_profile_id.clone(), false)
         .await
     {
         tracing::error!("Failed to start task attempt: {}", err);

--- a/crates/server/src/routes/tasks.rs
+++ b/crates/server/src/routes/tasks.rs
@@ -145,6 +145,10 @@ pub struct CreateAndStartTaskRequest {
     pub task: CreateTask,
     pub executor_profile_id: ExecutorProfileId,
     pub repos: Vec<WorkspaceRepoInput>,
+    /// If true, inject the vibe_kanban MCP server into the workspace before spawning.
+    /// This allows the agent to use task management tools (create_task, list_tasks, etc.).
+    #[serde(default)]
+    pub include_vibe_kanban_mcp: bool,
 }
 
 pub async fn create_task_and_start(
@@ -217,7 +221,7 @@ pub async fn create_task_and_start(
 
     let is_attempt_running = deployment
         .container()
-        .start_workspace(&workspace, payload.executor_profile_id.clone())
+        .start_workspace(&workspace, payload.executor_profile_id.clone(), payload.include_vibe_kanban_mcp)
         .await
         .inspect_err(|err| tracing::error!("Failed to start task attempt: {}", err))
         .is_ok();

--- a/crates/services/src/services/container.rs
+++ b/crates/services/src/services/container.rs
@@ -882,6 +882,7 @@ pub trait ContainerService {
         &self,
         workspace: &Workspace,
         executor_profile_id: ExecutorProfileId,
+        include_vibe_kanban_mcp: bool,
     ) -> Result<ExecutionProcess, ContainerError> {
         // Create container
         self.create(workspace).await?;
@@ -938,6 +939,7 @@ pub trait ContainerService {
                 prompt,
                 executor_profile_id: executor_profile_id.clone(),
                 working_dir,
+                include_vibe_kanban_mcp,
             }),
             cleanup_action.map(Box::new),
         );

--- a/frontend/src/components/dialogs/goals/GoalFormDialog.tsx
+++ b/frontend/src/components/dialogs/goals/GoalFormDialog.tsx
@@ -1,0 +1,359 @@
+import { useState, useEffect, useMemo } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import NiceModal, { useModal } from '@ebay/nice-modal-react';
+import { useTaskMutations } from '@/hooks/useTaskMutations';
+import { useProjectRepos, useRepoBranchSelection } from '@/hooks';
+import { useUserSystem } from '@/components/ConfigProvider';
+import { defineModal } from '@/lib/modals';
+import { Bot, User, Check } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import type { Task } from 'shared/types';
+
+export type GoalFormDialogProps = {
+  projectId: string;
+};
+
+export type GoalFormDialogResult = {
+  action: 'created' | 'canceled';
+  task?: Task;
+};
+
+type ExecutionMode = 'regular' | 'auto_managed';
+
+const GOAL_PREFIX = '[Goal] ';
+
+const buildGoalDescription = (
+  userDescription: string,
+  autoManaged: boolean
+): string => {
+  // The prompt structure is critical. Claude reads top-to-bottom and forms
+  // its understanding of the task from the first things it sees.
+  //
+  // Key principles:
+  // 1. Role definition FIRST - before any content that looks like work
+  // 2. Establish what SUCCESS looks like (tasks created, not code written)
+  // 3. Explicit "what not to do" with reasoning Claude can internalize
+  // 4. The user's goal comes LAST, after the framing is established
+  // 5. Use language patterns Claude responds to ("your role", "you are", "success means")
+
+  const executionMode = autoManaged
+    ? `For each task you create, IMMEDIATELY call \`start_workspace_session\` to hand it off to an implementation agent.`
+    : `Create all tasks but do NOT start them. Leave them in "todo" status for user review.`;
+
+  return `You are a **Project Planner Agent**.
+
+Your role is to decompose a goal into actionable tasks. You are NOT an implementation agent. You do not write code, edit files, or make changes to the codebase. Your only tools are the MCP task management tools.
+
+## What Success Looks Like
+
+When you complete this task successfully, the board will have 3-7 new child tasks under this goal. Each task will have:
+- A clear, actionable title starting with a verb (Implement, Add, Create, Update, Fix, Test)
+- A description with enough context for an implementation agent to execute it
+- The \`parent_workspace_id\` set to this task's workspace ID
+
+You will NOT have:
+- Written any code
+- Created or modified any files
+- Made any git commits
+- Used any tools besides \`list_tasks\`, \`create_task\`${autoManaged ? ', and `start_workspace_session`' : ''}
+
+## Your Process
+
+1. **Understand the goal** - Read the objective below carefully
+2. **Identify the work** - What discrete pieces of work need to happen?
+3. **Create tasks** - Use \`create_task\` for each piece of work
+4. ${autoManaged ? '**Start tasks** - Call `start_workspace_session` for each task you create' : '**Stop** - Once tasks are created, you are done'}
+
+${executionMode}
+
+## Task Creation Guidelines
+
+Each task should be:
+- **Atomic**: One clear objective that can be completed in a single session
+- **Specific**: Include file paths, function names, or specific requirements when known
+- **Independent**: Minimize dependencies between tasks where possible
+- **Testable**: The implementer should know when they're done
+
+Bad task: "Work on authentication"
+Good task: "Implement login API endpoint at POST /api/auth/login that accepts email/password and returns a JWT token"
+
+---
+
+## The Goal
+
+${userDescription.trim() || '(No description provided - analyze the codebase to understand what needs to be done)'}
+
+---
+
+Now decompose this goal into tasks. Remember: create tasks, do not implement them.`;
+};
+
+const GoalFormDialogImpl = NiceModal.create<GoalFormDialogProps>(
+  ({ projectId }) => {
+    const modal = useModal();
+    const [title, setTitle] = useState('');
+    const [description, setDescription] = useState('');
+    const [executionMode, setExecutionMode] =
+      useState<ExecutionMode>('regular');
+    const [error, setError] = useState<string | null>(null);
+
+    const { createAndStart } = useTaskMutations(projectId);
+    const { system } = useUserSystem();
+    const { data: projectRepos = [] } = useProjectRepos(projectId, {
+      enabled: modal.visible,
+    });
+    const { configs: repoBranchConfigs } = useRepoBranchSelection({
+      repos: projectRepos,
+      enabled: modal.visible && projectRepos.length > 0,
+    });
+
+    const defaultRepos = useMemo(() => {
+      return repoBranchConfigs
+        .filter((c) => c.targetBranch !== null)
+        .map((c) => ({ repo_id: c.repoId, target_branch: c.targetBranch! }));
+    }, [repoBranchConfigs]);
+
+    useEffect(() => {
+      // Reset form when dialog opens
+      if (modal.visible) {
+        setTitle('');
+        setDescription('');
+        setExecutionMode('regular');
+        setError(null);
+      }
+    }, [modal.visible]);
+
+    const validateTitle = (value: string): string | null => {
+      const trimmedValue = value.trim();
+      if (!trimmedValue) return 'Goal title is required';
+      if (trimmedValue.length < 3)
+        return 'Goal title must be at least 3 characters';
+      if (trimmedValue.length > 200)
+        return 'Goal title must be 200 characters or less';
+      return null;
+    };
+
+    const handleCreate = () => {
+      const titleError = validateTitle(title);
+      if (titleError) {
+        setError(titleError);
+        return;
+      }
+
+      setError(null);
+
+      const goalTitle = `${GOAL_PREFIX}${title.trim()}`;
+      // Use the title as the goal if no description is provided
+      const goalText = description.trim() || title.trim();
+      const goalDescription = buildGoalDescription(
+        goalText,
+        executionMode === 'auto_managed'
+      );
+
+      const executorProfileId = system.config?.executor_profile;
+      if (!executorProfileId) {
+        setError('No executor profile configured. Please set one in settings.');
+        return;
+      }
+
+      createAndStart.mutate(
+        {
+          task: {
+            project_id: projectId,
+            title: goalTitle,
+            description: goalDescription,
+            status: null,
+            parent_workspace_id: null,
+            image_ids: null,
+            shared_task_id: null,
+          },
+          executor_profile_id: executorProfileId,
+          repos: defaultRepos,
+          // Goals need the vibe_kanban MCP server to create/manage tasks
+          include_vibe_kanban_mcp: true,
+        },
+        {
+          onSuccess: (task) => {
+            modal.resolve({
+              action: 'created',
+              task,
+            } as GoalFormDialogResult);
+            modal.hide();
+          },
+          onError: (err) => {
+            setError(
+              err instanceof Error ? err.message : 'Failed to create goal'
+            );
+          },
+        }
+      );
+    };
+
+    const handleCancel = () => {
+      modal.resolve({ action: 'canceled' } as GoalFormDialogResult);
+      modal.hide();
+    };
+
+    const handleOpenChange = (open: boolean) => {
+      if (!open) {
+        handleCancel();
+      }
+    };
+
+    return (
+      <Dialog open={modal.visible} onOpenChange={handleOpenChange}>
+        <DialogContent className="sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle>Add Goal</DialogTitle>
+            <DialogDescription>
+              Create a high-level objective. An agent will break it down into
+              tasks.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="goal-title">Title</Label>
+              <Input
+                id="goal-title"
+                value={title}
+                onChange={(e) => {
+                  setTitle(e.target.value);
+                  setError(null);
+                }}
+                placeholder="e.g., Add user authentication"
+                maxLength={200}
+                autoFocus
+                disabled={createAndStart.isPending}
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="goal-description">Description (optional)</Label>
+              <Textarea
+                id="goal-description"
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder="Describe what you want to achieve..."
+                rows={3}
+                disabled={createAndStart.isPending}
+              />
+            </div>
+
+            <div className="space-y-3">
+              <Label>Execution Mode</Label>
+              <div className="space-y-2">
+                <button
+                  type="button"
+                  onClick={() => setExecutionMode('regular')}
+                  disabled={createAndStart.isPending}
+                  className={cn(
+                    'w-full flex items-start space-x-3 rounded-lg border p-3 text-left transition-colors',
+                    executionMode === 'regular'
+                      ? 'border-primary bg-primary/5'
+                      : 'hover:bg-muted/50'
+                  )}
+                >
+                  <div
+                    className={cn(
+                      'mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded-full border',
+                      executionMode === 'regular'
+                        ? 'border-primary bg-primary text-primary-foreground'
+                        : 'border-muted-foreground'
+                    )}
+                  >
+                    {executionMode === 'regular' && (
+                      <Check className="h-3 w-3" />
+                    )}
+                  </div>
+                  <div className="flex-1 space-y-1">
+                    <div className="flex items-center gap-2">
+                      <User className="h-4 w-4 text-muted-foreground" />
+                      <span className="font-medium">Review first</span>
+                    </div>
+                    <p className="text-sm text-muted-foreground">
+                      Child tasks land in Todo. You start them when ready.
+                    </p>
+                  </div>
+                </button>
+
+                <button
+                  type="button"
+                  onClick={() => setExecutionMode('auto_managed')}
+                  disabled={createAndStart.isPending}
+                  className={cn(
+                    'w-full flex items-start space-x-3 rounded-lg border p-3 text-left transition-colors',
+                    executionMode === 'auto_managed'
+                      ? 'border-primary bg-primary/5'
+                      : 'hover:bg-muted/50'
+                  )}
+                >
+                  <div
+                    className={cn(
+                      'mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded-full border',
+                      executionMode === 'auto_managed'
+                        ? 'border-primary bg-primary text-primary-foreground'
+                        : 'border-muted-foreground'
+                    )}
+                  >
+                    {executionMode === 'auto_managed' && (
+                      <Check className="h-3 w-3" />
+                    )}
+                  </div>
+                  <div className="flex-1 space-y-1">
+                    <div className="flex items-center gap-2">
+                      <Bot className="h-4 w-4 text-muted-foreground" />
+                      <span className="font-medium">Auto-execute</span>
+                    </div>
+                    <p className="text-sm text-muted-foreground">
+                      Agent creates and starts child tasks automatically.
+                    </p>
+                  </div>
+                </button>
+              </div>
+            </div>
+
+            {error && (
+              <Alert variant="destructive">
+                <AlertDescription>{error}</AlertDescription>
+              </Alert>
+            )}
+          </div>
+
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={handleCancel}
+              disabled={createAndStart.isPending}
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={handleCreate}
+              disabled={!title.trim() || createAndStart.isPending}
+            >
+              {createAndStart.isPending ? 'Creating...' : 'Create Goal'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    );
+  }
+);
+
+export const GoalFormDialog = defineModal<
+  GoalFormDialogProps,
+  GoalFormDialogResult
+>(GoalFormDialogImpl);

--- a/frontend/src/components/dialogs/index.ts
+++ b/frontend/src/components/dialogs/index.ts
@@ -37,6 +37,11 @@ export {
   TaskFormDialog,
   type TaskFormDialogProps,
 } from './tasks/TaskFormDialog';
+export {
+  GoalFormDialog,
+  type GoalFormDialogProps,
+  type GoalFormDialogResult,
+} from './goals/GoalFormDialog';
 
 export { CreatePRDialog } from './tasks/CreatePRDialog';
 export {

--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -17,6 +17,7 @@ import {
   MessageCircle,
   Menu,
   Plus,
+  Target,
   LogOut,
   LogIn,
 } from 'lucide-react';
@@ -38,6 +39,7 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip';
 import { OAuthDialog } from '@/components/dialogs/global/OAuthDialog';
+import { GoalFormDialog } from '@/components/dialogs/goals/GoalFormDialog';
 import { useUserSystem } from '@/components/ConfigProvider';
 import { oauthApi } from '@/lib/api';
 
@@ -112,6 +114,12 @@ export function Navbar() {
   const handleCreateTask = () => {
     if (projectId) {
       openTaskForm({ mode: 'create', projectId });
+    }
+  };
+
+  const handleCreateGoal = () => {
+    if (projectId) {
+      GoalFormDialog.show({ projectId });
     }
   };
 
@@ -219,6 +227,15 @@ export function Navbar() {
                       className="h-9 w-9"
                     />
                   )}
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-9 w-9"
+                    onClick={handleCreateGoal}
+                    aria-label="Create new goal"
+                  >
+                    <Target className="h-4 w-4" />
+                  </Button>
                   <Button
                     variant="ghost"
                     size="icon"

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -230,7 +230,12 @@ export type AssignSharedTaskRequest = { new_assignee_user_id: string | null, };
 
 export type ShareTaskResponse = { shared_task_id: string, };
 
-export type CreateAndStartTaskRequest = { task: CreateTask, executor_profile_id: ExecutorProfileId, repos: Array<WorkspaceRepoInput>, };
+export type CreateAndStartTaskRequest = { task: CreateTask, executor_profile_id: ExecutorProfileId, repos: Array<WorkspaceRepoInput>,
+/**
+ * If true, inject the vibe_kanban MCP server into the workspace before spawning.
+ * This allows the agent to use task management tools (create_task, list_tasks, etc.).
+ */
+include_vibe_kanban_mcp?: boolean, };
 
 export type CreateGitHubPrRequest = { title: string, body: string | null, target_branch: string | null, draft: boolean | null, repo_id: string, auto_generate_description: boolean, };
 
@@ -433,16 +438,21 @@ export type DroidReasoningEffort = "none" | "dynamic" | "off" | "low" | "medium"
 
 export type AppendPrompt = string | null;
 
-export type CodingAgentInitialRequest = { prompt: string, 
+export type CodingAgentInitialRequest = { prompt: string,
 /**
  * Executor profile specification
  */
-executor_profile_id: ExecutorProfileId, 
+executor_profile_id: ExecutorProfileId,
 /**
  * Optional relative path to execute the agent in (relative to container_ref).
  * If None, uses the container_ref directory directly.
  */
-working_dir: string | null, };
+working_dir: string | null,
+/**
+ * If true, inject the vibe_kanban MCP server into the workspace before spawning.
+ * This allows the agent to use task management tools (create_task, list_tasks, etc.).
+ */
+include_vibe_kanban_mcp?: boolean, };
 
 export type CodingAgentFollowUpRequest = { prompt: string, session_id: string, 
 /**


### PR DESCRIPTION
## Summary

Adds a **Goal Flow** feature that allows users to create high-level goals that an agent will automatically decompose into actionable tasks.

- **New Goal button** in Navbar alongside existing Task button
- **GoalFormDialog** with title, description, and execution mode selection
- **Two execution modes**: "Review first" (tasks land in Todo) or "Auto-execute" (agent starts child tasks immediately)
- **Runtime MCP injection**: Automatically injects `vibe_kanban` MCP server into the workspace so goal agents can use task management tools

### How it works

1. User clicks "Goal" button and enters a high-level objective
2. System creates a task with `[Goal]` prefix and carefully crafted planner prompt
3. Agent runs with access to `create_task`, `list_tasks`, `start_workspace_session` MCP tools
4. Agent decomposes the goal into 3-7 child tasks (without writing any code itself)

### Key technical details

- `include_vibe_kanban_mcp` flag on `CreateAndStartTaskRequest` triggers MCP injection
- Injection merges into existing `.mcp.json` (doesn't overwrite user's other MCP servers)
- Prompt engineering ensures agent acts as planner, not implementer

## Test plan

- [ ] Create a goal with "Review first" mode - verify child tasks land in Todo
- [ ] Create a goal with "Auto-execute" mode - verify agent starts child tasks
- [ ] Verify goal agent uses MCP tools (not Glob/Grep) to create tasks
- [ ] Verify existing `.mcp.json` configs are preserved when MCP is injected

🤖 Generated with [Claude Code](https://claude.com/claude-code)