### PR TITLE
fix: upgrade git2 to 0.19 for index.skipHash support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2407,9 +2407,9 @@ checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "git2"
-version = "0.18.3"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "232e6a7bfe35766bf715e55a88b39a700596c0ccfd88cd3680b4cdb40d66ef70"
+checksum = "b903b73e45dc0c6c596f2d37eccece7c1c8bb6e4407b001096387c63d0d93724"
 dependencies = [
  "bitflags 2.10.0",
  "libc",
@@ -3299,9 +3299,9 @@ checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.16.2+1.7.2"
+version = "0.17.0+1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee4126d8b4ee5c9d9ea891dd875cfdc1e9d0950437179104b183d7d8a74d24e8"
+checksum = "10472326a8a6477c3c20a64547b0059e4b0d086869eee31e6d7da728a8eb7224"
 dependencies = [
  "cc",
  "libc",

--- a/crates/deployment/Cargo.toml
+++ b/crates/deployment/Cargo.toml
@@ -15,7 +15,7 @@ tokio = { workspace = true }
 sqlx = "0.8.6"
 serde_json = { workspace = true }
 tracing = { workspace = true }
-git2 = "^0.18.1"
+git2 = "0.19"
 futures = "0.3.31"
 axum = { workspace = true }
 

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -40,7 +40,7 @@ thiserror = { workspace = true }
 os_info = "3.12.0"
 futures-util = "0.3"
 ignore = "0.4"
-git2 = "0.18"
+git2 = "0.19"
 mime_guess = "2.0"
 rust-embed = "8.2"
 url = "2.5"

--- a/crates/services/Cargo.toml
+++ b/crates/services/Cargo.toml
@@ -25,7 +25,7 @@ chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1.0", features = ["v4", "serde"] }
 ts-rs = { workspace = true }
 dirs = "5.0"
-git2 = "0.18"
+git2 = "0.19"
 tempfile = "3.21"
 async-trait = { workspace = true } 
 rust-embed = "8.2"

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -30,7 +30,7 @@ tokio-stream = { version = "0.1.17", features = ["sync"] }
 shellexpand = "3.1.1"
 which = "8.0.0"
 similar = "2"
-git2 = "0.18"
+git2 = "0.19"
 dirs = "5.0"
 thiserror = { workspace = true }
 url = "2.5"


### PR DESCRIPTION
## Summary
- Upgrades `git2` from `0.18` to `0.19` across all crates
- This brings in libgit2 1.8.1 which supports Git's `index.skipHash` feature

## Problem
Users with Git 2.40+ who have `index.skipHash=true` (or `feature.manyFiles=true`) configured were seeing:
```
GitServiceError: invalid data in index - calculated checksum does not match expected; class=Index (10)
```

This happened because libgit2 1.7.2 (used by git2 0.18.x) doesn't understand the null checksum that Git writes when `index.skipHash` is enabled.

## Fix
| git2 version | libgit2 | Has fix? |
|--------------|---------|----------|
| 0.18.x       | 1.7.2   | No       |
| **0.19.0**   | **1.8.1** | **Yes** |

Fixes #1710

🤖 Generated with [Claude Code](https://claude.com/claude-code)