### PR TITLE
docs: Remove outdated worktree cleanup statement from merge documentation (Vibe Kanban)

### DIFF
--- a/docs/core-features/completing-a-task.mdx
+++ b/docs/core-features/completing-a-task.mdx
@@ -33,7 +33,7 @@ If conflicts occur, see [Resolving Rebase Conflicts](/core-features/resolving-re
 
 ## Merge
 
-Click **Merge** to integrate your completed work into the target branch. Your task will automatically move to the **Done** column, and the worktree is cleaned up automatically. The branch remains until you manually delete it.
+Click **Merge** to integrate your completed work into the target branch. Your task will automatically move to the **Done** column. The branch remains until you manually delete it.
 
 <Tip>
 If you're working with GitHub, consider creating a pull request instead of merging directly. This allows for team review and CI checks.


### PR DESCRIPTION
## Summary

This PR updates the documentation to remove an outdated statement about worktree behavior during merge operations.

## Changes Made

- Updated `docs/core-features/completing-a-task.mdx` to remove the statement "and the worktree is cleaned up automatically" from the Merge section

## Why This Change Was Made

The previous documentation incorrectly stated that worktrees are automatically deleted when a task is merged. This behavior has been changed, and worktrees are no longer deleted on merge. The documentation now accurately reflects the current behavior: when you merge, the task moves to the Done column and the branch remains until manually deleted.

## Files Changed

- `docs/core-features/completing-a-task.mdx` - Removed outdated worktree cleanup reference

---

This PR was written using [Vibe Kanban](https://vibekanban.com)