### PR TITLE
Fix GitHub Enterprise URL parsing in review crate (Vibe Kanban)

### DIFF
--- a/crates/review/src/error.rs
+++ b/crates/review/src/error.rs
@@ -8,9 +8,6 @@ pub enum ReviewError {
     #[error("GitHub CLI is not authenticated. Run 'gh auth login' first.")]
     GhNotAuthenticated,
 
-    #[error("Invalid GitHub PR URL format. Expected: https://github.com/owner/repo/pull/123")]
-    InvalidPrUrl,
-
     #[error("Failed to get PR information: {0}")]
     PrInfoFailed(String),
 

--- a/crates/review/src/github.rs
+++ b/crates/review/src/github.rs
@@ -170,4 +170,3 @@ pub fn checkout_commit(commit_sha: &str, repo_dir: &Path) -> Result<(), ReviewEr
 
     Ok(())
 }
-

--- a/crates/review/src/github.rs
+++ b/crates/review/src/github.rs
@@ -17,13 +17,11 @@ pub struct PrInfo {
     pub head_ref_name: String,
 }
 
-/// Repository owner info from `gh pr view --json`
 #[derive(Debug, Deserialize)]
 struct GhRepoOwner {
     login: String,
 }
 
-/// Repository info from `gh pr view --json`
 #[derive(Debug, Deserialize)]
 struct GhRepo {
     owner: GhRepoOwner,
@@ -56,10 +54,6 @@ fn ensure_gh_available() -> Result<(), ReviewError> {
     Ok(())
 }
 
-/// Get PR information using `gh pr view` with the raw URL
-///
-/// This accepts any GitHub PR URL (including GitHub Enterprise) and lets `gh`
-/// handle the hostname resolution and authentication.
 pub fn get_pr_info(pr_url: &str) -> Result<PrInfo, ReviewError> {
     ensure_gh_available()?;
 

--- a/crates/review/src/github.rs
+++ b/crates/review/src/github.rs
@@ -24,11 +24,9 @@ struct GhRepoOwner {
 
 #[derive(Debug, Deserialize)]
 struct GhRepo {
-    owner: GhRepoOwner,
     name: String,
 }
 
-/// Response from `gh pr view --json`
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct GhPrView {
@@ -38,6 +36,7 @@ struct GhPrView {
     head_ref_oid: String,
     head_ref_name: String,
     head_repository: GhRepo,
+    head_repository_owner: GhRepoOwner,
 }
 
 /// Check if the GitHub CLI is installed
@@ -65,7 +64,7 @@ pub fn get_pr_info(pr_url: &str) -> Result<PrInfo, ReviewError> {
             "view",
             pr_url,
             "--json",
-            "title,body,baseRefOid,headRefOid,headRefName,headRepository",
+            "title,body,baseRefOid,headRefOid,headRefName,headRepository,headRepositoryOwner",
         ])
         .output()
         .map_err(|e| ReviewError::PrInfoFailed(e.to_string()))?;
@@ -89,7 +88,7 @@ pub fn get_pr_info(pr_url: &str) -> Result<PrInfo, ReviewError> {
         serde_json::from_str(&stdout).map_err(|e| ReviewError::PrInfoFailed(e.to_string()))?;
 
     Ok(PrInfo {
-        owner: pr_view.head_repository.owner.login,
+        owner: pr_view.head_repository_owner.login,
         repo: pr_view.head_repository.name,
         title: pr_view.title,
         description: pr_view.body,

--- a/crates/review/src/github.rs
+++ b/crates/review/src/github.rs
@@ -17,6 +17,19 @@ pub struct PrInfo {
     pub head_ref_name: String,
 }
 
+/// Repository owner info from `gh pr view --json`
+#[derive(Debug, Deserialize)]
+struct GhRepoOwner {
+    login: String,
+}
+
+/// Repository info from `gh pr view --json`
+#[derive(Debug, Deserialize)]
+struct GhRepo {
+    owner: GhRepoOwner,
+    name: String,
+}
+
 /// Response from `gh pr view --json`
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -26,47 +39,7 @@ struct GhPrView {
     base_ref_oid: String,
     head_ref_oid: String,
     head_ref_name: String,
-}
-
-/// Parse a GitHub PR URL to extract owner, repo, and PR number
-///
-/// Expected format: https://github.com/owner/repo/pull/123
-pub fn parse_pr_url(url: &str) -> Result<(String, String, i64), ReviewError> {
-    let url = url.trim();
-
-    // Remove trailing slashes
-    let url = url.trim_end_matches('/');
-
-    // Try to parse as URL
-    let parts: Vec<&str> = url.split('/').collect();
-
-    // Find the index of "github.com" and then extract owner/repo/pull/number
-    let github_idx = parts
-        .iter()
-        .position(|&p| p == "github.com")
-        .ok_or(ReviewError::InvalidPrUrl)?;
-
-    // We need at least: github.com / owner / repo / pull / number
-    if parts.len() < github_idx + 5 {
-        return Err(ReviewError::InvalidPrUrl);
-    }
-
-    let owner = parts[github_idx + 1].to_string();
-    let repo = parts[github_idx + 2].to_string();
-
-    if parts[github_idx + 3] != "pull" {
-        return Err(ReviewError::InvalidPrUrl);
-    }
-
-    let pr_number: i64 = parts[github_idx + 4]
-        .parse()
-        .map_err(|_| ReviewError::InvalidPrUrl)?;
-
-    if owner.is_empty() || repo.is_empty() || pr_number <= 0 {
-        return Err(ReviewError::InvalidPrUrl);
-    }
-
-    Ok((owner, repo, pr_number))
+    head_repository: GhRepo,
 }
 
 /// Check if the GitHub CLI is installed
@@ -83,21 +56,22 @@ fn ensure_gh_available() -> Result<(), ReviewError> {
     Ok(())
 }
 
-/// Get PR information using `gh pr view`
-pub fn get_pr_info(owner: &str, repo: &str, pr_number: i64) -> Result<PrInfo, ReviewError> {
+/// Get PR information using `gh pr view` with the raw URL
+///
+/// This accepts any GitHub PR URL (including GitHub Enterprise) and lets `gh`
+/// handle the hostname resolution and authentication.
+pub fn get_pr_info(pr_url: &str) -> Result<PrInfo, ReviewError> {
     ensure_gh_available()?;
 
-    debug!("Fetching PR info for {owner}/{repo}#{pr_number}");
+    debug!("Fetching PR info for {pr_url}");
 
     let output = Command::new("gh")
         .args([
             "pr",
             "view",
-            &pr_number.to_string(),
-            "--repo",
-            &format!("{owner}/{repo}"),
+            pr_url,
             "--json",
-            "title,body,baseRefOid,headRefOid,headRefName",
+            "title,body,baseRefOid,headRefOid,headRefName,headRepository",
         ])
         .output()
         .map_err(|e| ReviewError::PrInfoFailed(e.to_string()))?;
@@ -121,8 +95,8 @@ pub fn get_pr_info(owner: &str, repo: &str, pr_number: i64) -> Result<PrInfo, Re
         serde_json::from_str(&stdout).map_err(|e| ReviewError::PrInfoFailed(e.to_string()))?;
 
     Ok(PrInfo {
-        owner: owner.to_string(),
-        repo: repo.to_string(),
+        owner: pr_view.head_repository.owner.login,
+        repo: pr_view.head_repository.name,
         title: pr_view.title,
         description: pr_view.body,
         base_commit: pr_view.base_ref_oid,
@@ -197,33 +171,3 @@ pub fn checkout_commit(commit_sha: &str, repo_dir: &Path) -> Result<(), ReviewEr
     Ok(())
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_parse_pr_url_valid() {
-        let (owner, repo, pr) = parse_pr_url("https://github.com/anthropics/claude-code/pull/123")
-            .expect("Should parse valid URL");
-        assert_eq!(owner, "anthropics");
-        assert_eq!(repo, "claude-code");
-        assert_eq!(pr, 123);
-    }
-
-    #[test]
-    fn test_parse_pr_url_with_trailing_slash() {
-        let (owner, repo, pr) =
-            parse_pr_url("https://github.com/owner/repo/pull/456/").expect("Should parse");
-        assert_eq!(owner, "owner");
-        assert_eq!(repo, "repo");
-        assert_eq!(pr, 456);
-    }
-
-    #[test]
-    fn test_parse_pr_url_invalid_format() {
-        assert!(parse_pr_url("https://github.com/owner/repo").is_err());
-        assert!(parse_pr_url("https://github.com/owner/repo/issues/123").is_err());
-        assert!(parse_pr_url("https://gitlab.com/owner/repo/pull/123").is_err());
-        assert!(parse_pr_url("not a url").is_err());
-    }
-}

--- a/crates/review/src/main.rs
+++ b/crates/review/src/main.rs
@@ -133,7 +133,10 @@ async fn run(args: Args) -> Result<(), ReviewError> {
     // 2. Get PR info (also extracts owner/repo from the URL via gh CLI)
     let spinner = create_spinner("Fetching PR information...");
     let pr_info = get_pr_info(&args.pr_url)?;
-    spinner.finish_with_message(format!("PR: {}/{} - {}", pr_info.owner, pr_info.repo, pr_info.title));
+    spinner.finish_with_message(format!(
+        "PR: {}/{} - {}",
+        pr_info.owner, pr_info.repo, pr_info.title
+    ));
 
     // 3. Select Claude Code session (optional)
     let session_files = match session_selector::select_session(&pr_info.head_ref_name) {


### PR DESCRIPTION
## Summary

- Remove hardcoded `github.com` URL parsing in the `review` CLI crate
- Delegate URL parsing to the `gh` CLI which handles GitHub Enterprise hostnames automatically
- Fix JSON response parsing to use separate `headRepository` and `headRepositoryOwner` fields

## What changed

### `crates/review/src/github.rs`
- Removed `parse_pr_url()` function that had hardcoded `github.com` check
- Updated `get_pr_info()` to accept raw PR URL and pass it directly to `gh pr view`
- Added `GhRepoOwner` and `GhRepo` structs to parse the `gh` CLI JSON response correctly
- Extract owner/repo from `headRepositoryOwner.login` and `headRepository.name` fields

### `crates/review/src/main.rs`
- Simplified flow: now calls `get_pr_info(&args.pr_url)` directly instead of parsing URL first
- Uses `pr_info.owner` and `pr_info.repo` from the `gh` response

### `crates/review/src/error.rs`
- Removed unused `InvalidPrUrl` error variant

## Why

GitHub Enterprise instances use different hostnames (e.g., `github.mycompany.com`). The previous implementation rejected any URL that didn't contain `github.com`, breaking GHE support.

By delegating to the `gh` CLI, we get automatic support for:
- GitHub Enterprise hostnames
- SSH hostname aliases from `~/.ssh/config`
- Proper authentication handling per host

## Testing

- [x] tested

---

This PR was written using [Vibe Kanban](https://vibekanban.com)