### PR TITLE
Bump opencode (vibe-kanban)

### DIFF
--- a/crates/executors/src/executors/opencode.rs
+++ b/crates/executors/src/executors/opencode.rs
@@ -39,7 +39,7 @@ pub struct Opencode {
 
 impl Opencode {
     fn build_command_builder(&self) -> CommandBuilder {
-        let builder = CommandBuilder::new("npx -y opencode-ai@1.0.223").extend_params(["acp"]);
+        let builder = CommandBuilder::new("npx -y opencode-ai@1.1.3").extend_params(["acp"]);
         apply_overrides(builder, &self.cmd)
     }
 


### PR DESCRIPTION
Version 1.1.3

`opencode.rs` 

`vibe-kanban/crates/executors/src/executors/opencode.rs`