### PR TITLE
feat: add Bitbucket Server support for PR operations

### DIFF
--- a/crates/services/src/services/bitbucket/api_client.rs
+++ b/crates/services/src/services/bitbucket/api_client.rs
@@ -1,0 +1,413 @@
+//! Bitbucket Server REST API v1.0 client.
+//!
+//! Provides HTTP methods for interacting with Bitbucket Server API endpoints.
+
+use std::time::Duration;
+
+use backon::{ExponentialBuilder, Retryable};
+use reqwest::{Client, Response, StatusCode};
+use tracing::{debug, warn};
+
+use super::models::{
+    BitbucketActivity, BitbucketDiffComment, BitbucketError, BitbucketPullRequest,
+    CreatePullRequestRequest, PagedResponse,
+};
+use crate::services::vcs_provider::VcsProviderError;
+
+/// HTTP client for Bitbucket Server REST API v1.0
+pub struct BitbucketApiClient {
+    http_client: Client,
+}
+
+impl BitbucketApiClient {
+    pub fn new() -> Result<Self, VcsProviderError> {
+        let http_client = Client::builder()
+            .timeout(Duration::from_secs(30))
+            .connect_timeout(Duration::from_secs(10))
+            .build()
+            .map_err(|e| VcsProviderError::Network(format!("Failed to create HTTP client: {}", e)))?;
+
+        Ok(Self { http_client })
+    }
+
+    /// Build the API URL for a given path
+    fn api_url(base_url: &str, path: &str) -> String {
+        format!("{}/rest/api/1.0{}", base_url.trim_end_matches('/'), path)
+    }
+
+    /// Execute a request with retry logic
+    async fn execute_with_retry<F, Fut, T>(
+        &self,
+        operation: F,
+    ) -> Result<T, VcsProviderError>
+    where
+        F: Fn() -> Fut,
+        Fut: std::future::Future<Output = Result<T, VcsProviderError>>,
+    {
+        operation
+            .retry(
+                &ExponentialBuilder::default()
+                    .with_min_delay(Duration::from_secs(1))
+                    .with_max_delay(Duration::from_secs(30))
+                    .with_max_times(3)
+                    .with_jitter(),
+            )
+            .when(|e: &VcsProviderError| e.should_retry())
+            .notify(|err: &VcsProviderError, dur: Duration| {
+                warn!(
+                    "Bitbucket API call failed, retrying after {:.2}s: {}",
+                    dur.as_secs_f64(),
+                    err
+                );
+            })
+            .await
+    }
+
+    /// Handle response errors
+    async fn handle_response(&self, response: Response) -> Result<Response, VcsProviderError> {
+        let status = response.status();
+
+        if status.is_success() {
+            return Ok(response);
+        }
+
+        // Try to parse error response
+        let error_text = response.text().await.unwrap_or_default();
+
+        match status {
+            StatusCode::UNAUTHORIZED => {
+                Err(VcsProviderError::AuthFailed(
+                    "Bitbucket authentication failed. Please check your access token.".into()
+                ))
+            }
+            StatusCode::FORBIDDEN => {
+                let msg = if let Ok(err) = serde_json::from_str::<BitbucketError>(&error_text) {
+                    err.to_string()
+                } else {
+                    error_text
+                };
+                Err(VcsProviderError::PermissionDenied(msg))
+            }
+            StatusCode::NOT_FOUND => {
+                let msg = if let Ok(err) = serde_json::from_str::<BitbucketError>(&error_text) {
+                    err.to_string()
+                } else {
+                    "Resource not found".to_string()
+                };
+                Err(VcsProviderError::NotFound(msg))
+            }
+            StatusCode::CONFLICT => {
+                let msg = if let Ok(err) = serde_json::from_str::<BitbucketError>(&error_text) {
+                    err.to_string()
+                } else {
+                    error_text
+                };
+                Err(VcsProviderError::PullRequest(format!("Conflict: {}", msg)))
+            }
+            _ if status.is_server_error() => {
+                Err(VcsProviderError::Network(format!(
+                    "Bitbucket server error ({}): {}",
+                    status.as_u16(),
+                    error_text
+                )))
+            }
+            _ => {
+                let msg = if let Ok(err) = serde_json::from_str::<BitbucketError>(&error_text) {
+                    err.to_string()
+                } else {
+                    error_text
+                };
+                Err(VcsProviderError::PullRequest(format!(
+                    "Bitbucket API error ({}): {}",
+                    status.as_u16(),
+                    msg
+                )))
+            }
+        }
+    }
+
+    /// Create a pull request
+    pub async fn create_pull_request(
+        &self,
+        base_url: &str,
+        token: &str,
+        project: &str,
+        repo: &str,
+        request: &CreatePullRequestRequest,
+    ) -> Result<BitbucketPullRequest, VcsProviderError> {
+        let url = Self::api_url(
+            base_url,
+            &format!("/projects/{}/repos/{}/pull-requests", project, repo),
+        );
+
+        debug!("Creating PR at {}", url);
+
+        self.execute_with_retry(|| async {
+            let response = self
+                .http_client
+                .post(&url)
+                .bearer_auth(token)
+                .json(request)
+                .send()
+                .await
+                .map_err(|e| VcsProviderError::Network(e.to_string()))?;
+
+            let response = self.handle_response(response).await?;
+
+            response
+                .json::<BitbucketPullRequest>()
+                .await
+                .map_err(|e| VcsProviderError::PullRequest(format!("Failed to parse response: {}", e)))
+        })
+        .await
+    }
+
+    /// Get a pull request by ID
+    pub async fn get_pull_request(
+        &self,
+        base_url: &str,
+        token: &str,
+        project: &str,
+        repo: &str,
+        pr_id: i64,
+    ) -> Result<BitbucketPullRequest, VcsProviderError> {
+        let url = Self::api_url(
+            base_url,
+            &format!("/projects/{}/repos/{}/pull-requests/{}", project, repo, pr_id),
+        );
+
+        debug!("Getting PR from {}", url);
+
+        self.execute_with_retry(|| async {
+            let response = self
+                .http_client
+                .get(&url)
+                .bearer_auth(token)
+                .send()
+                .await
+                .map_err(|e| VcsProviderError::Network(e.to_string()))?;
+
+            let response = self.handle_response(response).await?;
+
+            response
+                .json::<BitbucketPullRequest>()
+                .await
+                .map_err(|e| VcsProviderError::PullRequest(format!("Failed to parse response: {}", e)))
+        })
+        .await
+    }
+
+    /// List pull requests for a repository
+    pub async fn list_pull_requests(
+        &self,
+        base_url: &str,
+        token: &str,
+        project: &str,
+        repo: &str,
+        branch: Option<&str>,
+        state: Option<&str>, // "OPEN", "MERGED", "DECLINED", "ALL"
+    ) -> Result<Vec<BitbucketPullRequest>, VcsProviderError> {
+        let mut all_prs = Vec::new();
+        let mut start = 0;
+        let limit = 25;
+
+        loop {
+            let mut url = Self::api_url(
+                base_url,
+                &format!("/projects/{}/repos/{}/pull-requests", project, repo),
+            );
+
+            // Add query parameters
+            let mut params = vec![
+                format!("start={}", start),
+                format!("limit={}", limit),
+            ];
+
+            if let Some(branch) = branch {
+                // Filter by source branch (at parameter)
+                params.push(format!("at=refs/heads/{}", branch));
+            }
+
+            if let Some(state) = state {
+                params.push(format!("state={}", state));
+            }
+
+            url = format!("{}?{}", url, params.join("&"));
+
+            debug!("Listing PRs from {}", url);
+
+            let page: PagedResponse<BitbucketPullRequest> = self
+                .execute_with_retry(|| async {
+                    let response = self
+                        .http_client
+                        .get(&url)
+                        .bearer_auth(token)
+                        .send()
+                        .await
+                        .map_err(|e| VcsProviderError::Network(e.to_string()))?;
+
+                    let response = self.handle_response(response).await?;
+
+                    response
+                        .json::<PagedResponse<BitbucketPullRequest>>()
+                        .await
+                        .map_err(|e| {
+                            VcsProviderError::PullRequest(format!("Failed to parse response: {}", e))
+                        })
+                })
+                .await?;
+
+            all_prs.extend(page.values);
+
+            if page.is_last_page {
+                break;
+            }
+
+            start = page.next_page_start.unwrap_or(start + limit as i64) as i64;
+        }
+
+        Ok(all_prs)
+    }
+
+    /// Get PR activities (includes comments)
+    pub async fn get_pull_request_activities(
+        &self,
+        base_url: &str,
+        token: &str,
+        project: &str,
+        repo: &str,
+        pr_id: i64,
+    ) -> Result<Vec<BitbucketActivity>, VcsProviderError> {
+        let mut all_activities = Vec::new();
+        let mut start = 0;
+        let limit = 100;
+
+        loop {
+            let url = Self::api_url(
+                base_url,
+                &format!(
+                    "/projects/{}/repos/{}/pull-requests/{}/activities?start={}&limit={}",
+                    project, repo, pr_id, start, limit
+                ),
+            );
+
+            debug!("Getting PR activities from {}", url);
+
+            let page: PagedResponse<BitbucketActivity> = self
+                .execute_with_retry(|| async {
+                    let response = self
+                        .http_client
+                        .get(&url)
+                        .bearer_auth(token)
+                        .send()
+                        .await
+                        .map_err(|e| VcsProviderError::Network(e.to_string()))?;
+
+                    let response = self.handle_response(response).await?;
+
+                    response
+                        .json::<PagedResponse<BitbucketActivity>>()
+                        .await
+                        .map_err(|e| {
+                            VcsProviderError::PullRequest(format!("Failed to parse response: {}", e))
+                        })
+                })
+                .await?;
+
+            all_activities.extend(page.values);
+
+            if page.is_last_page {
+                break;
+            }
+
+            start = page.next_page_start.unwrap_or(start + limit as i64) as i64;
+        }
+
+        Ok(all_activities)
+    }
+
+    /// Get PR diff comments (inline code comments)
+    pub async fn get_pull_request_comments(
+        &self,
+        base_url: &str,
+        token: &str,
+        project: &str,
+        repo: &str,
+        pr_id: i64,
+    ) -> Result<Vec<BitbucketDiffComment>, VcsProviderError> {
+        let mut all_comments = Vec::new();
+        let mut start = 0;
+        let limit = 100;
+
+        loop {
+            let url = Self::api_url(
+                base_url,
+                &format!(
+                    "/projects/{}/repos/{}/pull-requests/{}/comments?start={}&limit={}",
+                    project, repo, pr_id, start, limit
+                ),
+            );
+
+            debug!("Getting PR comments from {}", url);
+
+            let page: PagedResponse<BitbucketDiffComment> = self
+                .execute_with_retry(|| async {
+                    let response = self
+                        .http_client
+                        .get(&url)
+                        .bearer_auth(token)
+                        .send()
+                        .await
+                        .map_err(|e| VcsProviderError::Network(e.to_string()))?;
+
+                    let response = self.handle_response(response).await?;
+
+                    response
+                        .json::<PagedResponse<BitbucketDiffComment>>()
+                        .await
+                        .map_err(|e| {
+                            VcsProviderError::PullRequest(format!("Failed to parse response: {}", e))
+                        })
+                })
+                .await?;
+
+            all_comments.extend(page.values);
+
+            if page.is_last_page {
+                break;
+            }
+
+            start = page.next_page_start.unwrap_or(start + limit as i64) as i64;
+        }
+
+        Ok(all_comments)
+    }
+
+    /// Verify token is valid by calling a simple API endpoint
+    pub async fn verify_token(
+        &self,
+        base_url: &str,
+        token: &str,
+    ) -> Result<(), VcsProviderError> {
+        let url = Self::api_url(base_url, "/application-properties");
+
+        debug!("Verifying Bitbucket token at {}", url);
+
+        let response = self
+            .http_client
+            .get(&url)
+            .bearer_auth(token)
+            .send()
+            .await
+            .map_err(|e| VcsProviderError::Network(e.to_string()))?;
+
+        self.handle_response(response).await?;
+        Ok(())
+    }
+}
+
+impl Default for BitbucketApiClient {
+    fn default() -> Self {
+        Self::new().expect("Failed to create default BitbucketApiClient")
+    }
+}

--- a/crates/services/src/services/bitbucket/credentials.rs
+++ b/crates/services/src/services/bitbucket/credentials.rs
@@ -1,0 +1,254 @@
+//! Bitbucket Server credential management.
+//!
+//! Handles secure storage of Bitbucket Server HTTP access tokens,
+//! with support for both file-based and macOS Keychain storage.
+
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+use tokio::sync::RwLock;
+
+/// Bitbucket Server credentials containing the HTTP access token.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BitbucketCredentials {
+    /// HTTP access token for Bitbucket Server API
+    pub access_token: String,
+    /// Base URL for the Bitbucket Server instance
+    pub base_url: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct StoredCredentials {
+    access_token: String,
+    base_url: String,
+}
+
+impl From<StoredCredentials> for BitbucketCredentials {
+    fn from(value: StoredCredentials) -> Self {
+        Self {
+            access_token: value.access_token,
+            base_url: value.base_url,
+        }
+    }
+}
+
+/// Service for managing Bitbucket Server credentials in memory and persistent storage.
+pub struct BitbucketCredentialStore {
+    backend: Backend,
+    inner: RwLock<Option<BitbucketCredentials>>,
+}
+
+impl BitbucketCredentialStore {
+    pub fn new(path: PathBuf) -> Self {
+        Self {
+            backend: Backend::detect(path),
+            inner: RwLock::new(None),
+        }
+    }
+
+    /// Get the default path for storing Bitbucket credentials
+    pub fn default_path() -> PathBuf {
+        dirs::home_dir()
+            .unwrap_or_else(|| PathBuf::from("."))
+            .join(".vibe-kanban")
+            .join("bitbucket_credentials.json")
+    }
+
+    pub async fn load(&self) -> std::io::Result<()> {
+        let creds = self.backend.load().await?.map(BitbucketCredentials::from);
+        *self.inner.write().await = creds;
+        Ok(())
+    }
+
+    pub async fn save(&self, creds: &BitbucketCredentials) -> std::io::Result<()> {
+        let stored = StoredCredentials {
+            access_token: creds.access_token.clone(),
+            base_url: creds.base_url.clone(),
+        };
+        self.backend.save(&stored).await?;
+        *self.inner.write().await = Some(creds.clone());
+        Ok(())
+    }
+
+    pub async fn clear(&self) -> std::io::Result<()> {
+        self.backend.clear().await?;
+        *self.inner.write().await = None;
+        Ok(())
+    }
+
+    pub async fn get(&self) -> Option<BitbucketCredentials> {
+        self.inner.read().await.clone()
+    }
+
+    /// Check if credentials are configured
+    pub async fn is_configured(&self) -> bool {
+        self.inner.read().await.is_some()
+    }
+}
+
+trait StoreBackend {
+    async fn load(&self) -> std::io::Result<Option<StoredCredentials>>;
+    async fn save(&self, creds: &StoredCredentials) -> std::io::Result<()>;
+    async fn clear(&self) -> std::io::Result<()>;
+}
+
+enum Backend {
+    File(FileBackend),
+    #[cfg(target_os = "macos")]
+    Keychain(KeychainBackend),
+}
+
+impl Backend {
+    fn detect(path: PathBuf) -> Self {
+        #[cfg(target_os = "macos")]
+        {
+            let use_file = match std::env::var("BITBUCKET_CREDENTIALS_BACKEND") {
+                Ok(v) if v.eq_ignore_ascii_case("file") => true,
+                Ok(v) if v.eq_ignore_ascii_case("keychain") => false,
+                _ => cfg!(debug_assertions),
+            };
+            if use_file {
+                tracing::debug!("Bitbucket credentials backend: file");
+                Backend::File(FileBackend { path })
+            } else {
+                tracing::debug!("Bitbucket credentials backend: keychain");
+                Backend::Keychain(KeychainBackend)
+            }
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            tracing::debug!("Bitbucket credentials backend: file");
+            Backend::File(FileBackend { path })
+        }
+    }
+}
+
+impl StoreBackend for Backend {
+    async fn load(&self) -> std::io::Result<Option<StoredCredentials>> {
+        match self {
+            Backend::File(b) => b.load().await,
+            #[cfg(target_os = "macos")]
+            Backend::Keychain(b) => b.load().await,
+        }
+    }
+
+    async fn save(&self, creds: &StoredCredentials) -> std::io::Result<()> {
+        match self {
+            Backend::File(b) => b.save(creds).await,
+            #[cfg(target_os = "macos")]
+            Backend::Keychain(b) => b.save(creds).await,
+        }
+    }
+
+    async fn clear(&self) -> std::io::Result<()> {
+        match self {
+            Backend::File(b) => b.clear().await,
+            #[cfg(target_os = "macos")]
+            Backend::Keychain(b) => b.clear().await,
+        }
+    }
+}
+
+struct FileBackend {
+    path: PathBuf,
+}
+
+impl FileBackend {
+    async fn load(&self) -> std::io::Result<Option<StoredCredentials>> {
+        if !self.path.exists() {
+            return Ok(None);
+        }
+
+        let bytes = std::fs::read(&self.path)?;
+        match serde_json::from_slice::<StoredCredentials>(&bytes) {
+            Ok(creds) => Ok(Some(creds)),
+            Err(e) => {
+                tracing::warn!(?e, "failed to parse Bitbucket credentials file, renaming to .bad");
+                let bad = self.path.with_extension("bad");
+                let _ = std::fs::rename(&self.path, bad);
+                Ok(None)
+            }
+        }
+    }
+
+    async fn save(&self, creds: &StoredCredentials) -> std::io::Result<()> {
+        // Ensure parent directory exists
+        if let Some(parent) = self.path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+
+        let tmp = self.path.with_extension("tmp");
+
+        let file = {
+            let mut opts = std::fs::OpenOptions::new();
+            opts.create(true).truncate(true).write(true);
+
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::OpenOptionsExt;
+                opts.mode(0o600);
+            }
+
+            opts.open(&tmp)?
+        };
+
+        serde_json::to_writer_pretty(&file, creds)?;
+        file.sync_all()?;
+        drop(file);
+
+        std::fs::rename(&tmp, &self.path)?;
+        Ok(())
+    }
+
+    async fn clear(&self) -> std::io::Result<()> {
+        let _ = std::fs::remove_file(&self.path);
+        Ok(())
+    }
+}
+
+#[cfg(target_os = "macos")]
+struct KeychainBackend;
+
+#[cfg(target_os = "macos")]
+impl KeychainBackend {
+    const SERVICE_NAME: &'static str = "vibe-kanban:bitbucket";
+    const ACCOUNT_NAME: &'static str = "default";
+    const ERR_SEC_ITEM_NOT_FOUND: i32 = -25300;
+
+    async fn load(&self) -> std::io::Result<Option<StoredCredentials>> {
+        use security_framework::passwords::get_generic_password;
+
+        match get_generic_password(Self::SERVICE_NAME, Self::ACCOUNT_NAME) {
+            Ok(bytes) => match serde_json::from_slice::<StoredCredentials>(&bytes) {
+                Ok(creds) => Ok(Some(creds)),
+                Err(error) => {
+                    tracing::warn!(
+                        ?error,
+                        "failed to parse Bitbucket keychain credentials; ignoring entry"
+                    );
+                    Ok(None)
+                }
+            },
+            Err(e) if e.code() == Self::ERR_SEC_ITEM_NOT_FOUND => Ok(None),
+            Err(e) => Err(std::io::Error::other(e)),
+        }
+    }
+
+    async fn save(&self, creds: &StoredCredentials) -> std::io::Result<()> {
+        use security_framework::passwords::set_generic_password;
+
+        let bytes = serde_json::to_vec_pretty(creds).map_err(std::io::Error::other)?;
+        set_generic_password(Self::SERVICE_NAME, Self::ACCOUNT_NAME, &bytes)
+            .map_err(std::io::Error::other)
+    }
+
+    async fn clear(&self) -> std::io::Result<()> {
+        use security_framework::passwords::delete_generic_password;
+
+        match delete_generic_password(Self::SERVICE_NAME, Self::ACCOUNT_NAME) {
+            Ok(()) => Ok(()),
+            Err(e) if e.code() == Self::ERR_SEC_ITEM_NOT_FOUND => Ok(()),
+            Err(e) => Err(std::io::Error::other(e)),
+        }
+    }
+}

--- a/crates/services/src/services/bitbucket/mod.rs
+++ b/crates/services/src/services/bitbucket/mod.rs
@@ -1,0 +1,348 @@
+//! Bitbucket Server integration service.
+//!
+//! Provides support for Bitbucket Server REST API v1.0, including:
+//! - Pull request creation
+//! - PR status tracking
+//! - Comment fetching (general and inline review comments)
+//!
+//! Authentication is done via HTTP access tokens (Personal Access Tokens).
+
+mod api_client;
+pub mod credentials;
+pub mod models;
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use db::models::merge::PullRequestInfo;
+use tracing::{debug, info};
+
+use self::api_client::BitbucketApiClient;
+use self::credentials::{BitbucketCredentialStore, BitbucketCredentials};
+use self::models::{CreatePullRequestRequest, ProjectSpec, RefSpec, RepositorySpec};
+use super::github::UnifiedPrComment;
+use super::vcs_provider::{CreatePrRequest, VcsProvider, VcsProviderError, VcsProviderType, VcsRepoInfo};
+
+/// Bitbucket Server service implementing the VcsProvider trait.
+pub struct BitbucketService {
+    client: BitbucketApiClient,
+    credentials: Arc<BitbucketCredentialStore>,
+}
+
+impl BitbucketService {
+    /// Create a new BitbucketService with the default credential store path
+    pub fn new() -> Result<Self, VcsProviderError> {
+        let credentials = Arc::new(BitbucketCredentialStore::new(
+            BitbucketCredentialStore::default_path(),
+        ));
+        let client = BitbucketApiClient::new()?;
+
+        Ok(Self {
+            client,
+            credentials,
+        })
+    }
+
+    /// Create a new BitbucketService with a custom credential store
+    pub fn with_credentials(credentials: Arc<BitbucketCredentialStore>) -> Result<Self, VcsProviderError> {
+        let client = BitbucketApiClient::new()?;
+
+        Ok(Self {
+            client,
+            credentials,
+        })
+    }
+
+    /// Get the credential store for external configuration
+    pub fn credentials(&self) -> &Arc<BitbucketCredentialStore> {
+        &self.credentials
+    }
+
+    /// Load credentials from storage
+    pub async fn load_credentials(&self) -> Result<(), VcsProviderError> {
+        self.credentials
+            .load()
+            .await
+            .map_err(|e| VcsProviderError::Io(e))
+    }
+
+    /// Save credentials to storage
+    pub async fn save_credentials(&self, creds: &BitbucketCredentials) -> Result<(), VcsProviderError> {
+        self.credentials
+            .save(creds)
+            .await
+            .map_err(|e| VcsProviderError::Io(e))
+    }
+
+    /// Get credentials, returning an error if not configured
+    async fn get_credentials(&self) -> Result<BitbucketCredentials, VcsProviderError> {
+        self.credentials.get().await.ok_or_else(|| {
+            VcsProviderError::AuthRequired("Bitbucket Server".to_string())
+        })
+    }
+
+    /// Build the PR URL for display
+    fn build_pr_url(base_url: &str, project: &str, repo: &str, pr_id: i64) -> String {
+        format!(
+            "{}/projects/{}/repos/{}/pull-requests/{}",
+            base_url.trim_end_matches('/'),
+            project,
+            repo,
+            pr_id
+        )
+    }
+}
+
+#[async_trait]
+impl VcsProvider for BitbucketService {
+    fn provider_type(&self) -> VcsProviderType {
+        VcsProviderType::BitbucketServer
+    }
+
+    fn matches_remote_url(&self, url: &str) -> bool {
+        url.contains("git.taboolasyndication.com")
+    }
+
+    async fn check_auth(&self) -> Result<(), VcsProviderError> {
+        let creds = self.get_credentials().await?;
+
+        self.client
+            .verify_token(&creds.base_url, &creds.access_token)
+            .await
+            .map_err(|e| match e {
+                VcsProviderError::AuthFailed(_) => VcsProviderError::AuthFailed(
+                    "Bitbucket access token is invalid or expired".to_string(),
+                ),
+                _ => e,
+            })
+    }
+
+    async fn create_pr(
+        &self,
+        repo_info: &VcsRepoInfo,
+        request: &CreatePrRequest,
+    ) -> Result<PullRequestInfo, VcsProviderError> {
+        let creds = self.get_credentials().await?;
+
+        info!(
+            "Creating Bitbucket PR in {}/{}: {}",
+            repo_info.owner_or_project, repo_info.repo_name, request.title
+        );
+
+        let bb_request = CreatePullRequestRequest {
+            title: request.title.clone(),
+            description: request.body.clone(),
+            from_ref: RefSpec {
+                id: format!("refs/heads/{}", request.head_branch),
+                repository: RepositorySpec {
+                    slug: repo_info.repo_name.clone(),
+                    project: ProjectSpec {
+                        key: repo_info.owner_or_project.clone(),
+                    },
+                },
+            },
+            to_ref: RefSpec {
+                id: format!("refs/heads/{}", request.base_branch),
+                repository: RepositorySpec {
+                    slug: repo_info.repo_name.clone(),
+                    project: ProjectSpec {
+                        key: repo_info.owner_or_project.clone(),
+                    },
+                },
+            },
+        };
+
+        let pr = self
+            .client
+            .create_pull_request(
+                &creds.base_url,
+                &creds.access_token,
+                &repo_info.owner_or_project,
+                &repo_info.repo_name,
+                &bb_request,
+            )
+            .await?;
+
+        let pr_url = Self::build_pr_url(
+            &creds.base_url,
+            &repo_info.owner_or_project,
+            &repo_info.repo_name,
+            pr.id,
+        );
+
+        info!("Created Bitbucket PR #{}: {}", pr.id, pr_url);
+
+        Ok(PullRequestInfo {
+            number: pr.id,
+            url: pr_url,
+            status: db::models::merge::MergeStatus::Open,
+            merged_at: None,
+            merge_commit_sha: None,
+        })
+    }
+
+    async fn get_pr_status(
+        &self,
+        repo_info: &VcsRepoInfo,
+        pr_number: i64,
+    ) -> Result<PullRequestInfo, VcsProviderError> {
+        let creds = self.get_credentials().await?;
+
+        debug!(
+            "Getting Bitbucket PR status for {}/{} #{}",
+            repo_info.owner_or_project, repo_info.repo_name, pr_number
+        );
+
+        let pr = self
+            .client
+            .get_pull_request(
+                &creds.base_url,
+                &creds.access_token,
+                &repo_info.owner_or_project,
+                &repo_info.repo_name,
+                pr_number,
+            )
+            .await?;
+
+        Ok(pr.to_pull_request_info(&creds.base_url))
+    }
+
+    async fn list_prs_for_branch(
+        &self,
+        repo_info: &VcsRepoInfo,
+        branch_name: &str,
+    ) -> Result<Vec<PullRequestInfo>, VcsProviderError> {
+        let creds = self.get_credentials().await?;
+
+        debug!(
+            "Listing Bitbucket PRs for branch {} in {}/{}",
+            branch_name, repo_info.owner_or_project, repo_info.repo_name
+        );
+
+        let prs = self
+            .client
+            .list_pull_requests(
+                &creds.base_url,
+                &creds.access_token,
+                &repo_info.owner_or_project,
+                &repo_info.repo_name,
+                Some(branch_name),
+                Some("ALL"), // Include open, merged, and declined
+            )
+            .await?;
+
+        Ok(prs
+            .into_iter()
+            .map(|pr| pr.to_pull_request_info(&creds.base_url))
+            .collect())
+    }
+
+    async fn get_pr_comments(
+        &self,
+        repo_info: &VcsRepoInfo,
+        pr_number: i64,
+    ) -> Result<Vec<UnifiedPrComment>, VcsProviderError> {
+        let creds = self.get_credentials().await?;
+
+        let pr_url = Self::build_pr_url(
+            &creds.base_url,
+            &repo_info.owner_or_project,
+            &repo_info.repo_name,
+            pr_number,
+        );
+
+        debug!(
+            "Getting Bitbucket PR comments for {}/{} #{}",
+            repo_info.owner_or_project, repo_info.repo_name, pr_number
+        );
+
+        // Fetch both activities (general comments) and diff comments (inline) in parallel
+        let (activities_result, comments_result) = tokio::join!(
+            self.client.get_pull_request_activities(
+                &creds.base_url,
+                &creds.access_token,
+                &repo_info.owner_or_project,
+                &repo_info.repo_name,
+                pr_number,
+            ),
+            self.client.get_pull_request_comments(
+                &creds.base_url,
+                &creds.access_token,
+                &repo_info.owner_or_project,
+                &repo_info.repo_name,
+                pr_number,
+            )
+        );
+
+        let mut unified_comments = Vec::new();
+
+        // Process activities (general comments from activity feed)
+        if let Ok(activities) = activities_result {
+            for activity in activities {
+                if activity.action == "COMMENTED" {
+                    if let Some(comment) = activity.comment {
+                        unified_comments.push(comment.to_unified_comment(&pr_url));
+
+                        // Also include replies
+                        for reply in comment.comments {
+                            unified_comments.push(reply.to_unified_comment(&pr_url));
+                        }
+                    }
+                }
+            }
+        }
+
+        // Process diff comments (inline code comments)
+        if let Ok(diff_comments) = comments_result {
+            for comment in diff_comments {
+                unified_comments.push(comment.to_unified_comment(&pr_url));
+            }
+        }
+
+        // Sort by creation time
+        unified_comments.sort_by_key(|c| match c {
+            UnifiedPrComment::General { created_at, .. } => *created_at,
+            UnifiedPrComment::Review { created_at, .. } => *created_at,
+        });
+
+        // Deduplicate by ID (activities and comments endpoints may overlap)
+        let mut seen_ids = std::collections::HashSet::new();
+        unified_comments.retain(|c| {
+            let id = match c {
+                UnifiedPrComment::General { id, .. } => id.clone(),
+                UnifiedPrComment::Review { id, .. } => id.to_string(),
+            };
+            seen_ids.insert(id)
+        });
+
+        Ok(unified_comments)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_matches_bitbucket_url() {
+        let service = BitbucketService::new().unwrap();
+
+        assert!(service.matches_remote_url("ssh://git@git.taboolasyndication.com:7998/dev/products.git"));
+        assert!(service.matches_remote_url("https://git.taboolasyndication.com/projects/DEV/repos/products"));
+        assert!(!service.matches_remote_url("https://github.com/owner/repo"));
+    }
+
+    #[test]
+    fn test_build_pr_url() {
+        let url = BitbucketService::build_pr_url(
+            "https://git.taboolasyndication.com",
+            "DEV",
+            "products",
+            123,
+        );
+        assert_eq!(
+            url,
+            "https://git.taboolasyndication.com/projects/DEV/repos/products/pull-requests/123"
+        );
+    }
+}

--- a/crates/services/src/services/bitbucket/models.rs
+++ b/crates/services/src/services/bitbucket/models.rs
@@ -1,0 +1,324 @@
+//! Bitbucket Server API response models.
+//!
+//! These types map to the Bitbucket Server REST API v1.0 JSON responses
+//! and provide conversion to the unified data models used by the application.
+
+use chrono::{TimeZone, Utc};
+use db::models::merge::{MergeStatus, PullRequestInfo};
+use serde::{Deserialize, Serialize};
+
+use crate::services::github::UnifiedPrComment;
+
+/// Bitbucket Server paged response wrapper
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PagedResponse<T> {
+    pub values: Vec<T>,
+    pub size: i64,
+    pub is_last_page: bool,
+    #[serde(default)]
+    pub next_page_start: Option<i64>,
+}
+
+/// Bitbucket Server user
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BitbucketUser {
+    pub name: String,
+    pub display_name: String,
+    #[serde(default)]
+    pub email_address: Option<String>,
+}
+
+/// Bitbucket Server ref (branch reference)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BitbucketRef {
+    pub id: String,
+    pub display_id: String,
+    #[serde(default)]
+    pub latest_commit: Option<String>,
+}
+
+/// Bitbucket Server repository
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BitbucketRepository {
+    pub slug: String,
+    pub name: String,
+    pub project: BitbucketProject,
+}
+
+/// Bitbucket Server project
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BitbucketProject {
+    pub key: String,
+    pub name: String,
+}
+
+/// Bitbucket Server pull request participant
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BitbucketParticipant {
+    pub user: BitbucketUser,
+    pub role: String, // "AUTHOR", "REVIEWER", "PARTICIPANT"
+    pub approved: bool,
+    #[serde(default)]
+    pub status: Option<String>, // "UNAPPROVED", "NEEDS_WORK", "APPROVED"
+}
+
+/// Bitbucket Server pull request
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BitbucketPullRequest {
+    pub id: i64,
+    pub title: String,
+    #[serde(default)]
+    pub description: Option<String>,
+    pub state: String, // "OPEN", "MERGED", "DECLINED"
+    pub open: bool,
+    pub closed: bool,
+    pub from_ref: BitbucketRef,
+    pub to_ref: BitbucketRef,
+    pub author: BitbucketParticipant,
+    #[serde(default)]
+    pub reviewers: Vec<BitbucketParticipant>,
+    pub created_date: i64, // milliseconds since epoch
+    pub updated_date: i64,
+    #[serde(default)]
+    pub closed_date: Option<i64>,
+    pub links: BitbucketLinks,
+}
+
+impl BitbucketPullRequest {
+    /// Convert to the unified PullRequestInfo model
+    pub fn to_pull_request_info(&self, base_url: &str) -> PullRequestInfo {
+        let status = match self.state.as_str() {
+            "OPEN" => MergeStatus::Open,
+            "MERGED" => MergeStatus::Merged,
+            "DECLINED" => MergeStatus::Closed,
+            _ => MergeStatus::Unknown,
+        };
+
+        // Extract the self link for the PR URL
+        let url = self
+            .links
+            .self_links
+            .first()
+            .map(|l| l.href.clone())
+            .unwrap_or_else(|| {
+                format!(
+                    "{}/projects/{}/repos/{}/pull-requests/{}",
+                    base_url,
+                    self.to_ref.id.split('/').nth(2).unwrap_or(""),
+                    self.from_ref.display_id,
+                    self.id
+                )
+            });
+
+        let merged_at = if matches!(status, MergeStatus::Merged) {
+            self.closed_date.map(|ms| Utc.timestamp_millis_opt(ms).unwrap())
+        } else {
+            None
+        };
+
+        PullRequestInfo {
+            number: self.id,
+            url,
+            status,
+            merged_at,
+            merge_commit_sha: None, // Bitbucket doesn't return this directly in PR response
+        }
+    }
+}
+
+/// Bitbucket Server links
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BitbucketLinks {
+    #[serde(rename = "self", default)]
+    pub self_links: Vec<BitbucketLink>,
+}
+
+/// Bitbucket Server link
+#[derive(Debug, Clone, Deserialize)]
+pub struct BitbucketLink {
+    pub href: String,
+}
+
+/// Request body for creating a pull request
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CreatePullRequestRequest {
+    pub title: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    pub from_ref: RefSpec,
+    pub to_ref: RefSpec,
+}
+
+/// Reference specification for PR creation
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RefSpec {
+    pub id: String,
+    pub repository: RepositorySpec,
+}
+
+/// Repository specification for PR creation
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RepositorySpec {
+    pub slug: String,
+    pub project: ProjectSpec,
+}
+
+/// Project specification for PR creation
+#[derive(Debug, Clone, Serialize)]
+pub struct ProjectSpec {
+    pub key: String,
+}
+
+/// Bitbucket Server PR activity (includes comments)
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BitbucketActivity {
+    pub id: i64,
+    pub action: String, // "COMMENTED", "APPROVED", "MERGED", etc.
+    pub created_date: i64,
+    pub user: BitbucketUser,
+    #[serde(default)]
+    pub comment: Option<BitbucketComment>,
+    #[serde(default)]
+    pub comment_action: Option<String>, // "ADDED", "EDITED"
+}
+
+/// Bitbucket Server comment
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BitbucketComment {
+    pub id: i64,
+    pub text: String,
+    pub author: BitbucketUser,
+    pub created_date: i64,
+    #[serde(default)]
+    pub updated_date: Option<i64>,
+    #[serde(default)]
+    pub comments: Vec<BitbucketComment>, // nested replies
+    #[serde(default)]
+    pub anchor: Option<CommentAnchor>, // present for inline comments
+}
+
+impl BitbucketComment {
+    /// Convert to unified PR comment
+    pub fn to_unified_comment(&self, pr_url: &str) -> UnifiedPrComment {
+        let created_at = Utc.timestamp_millis_opt(self.created_date).unwrap();
+        let comment_url = format!("{}?commentId={}", pr_url, self.id);
+
+        if let Some(anchor) = &self.anchor {
+            // Inline review comment
+            UnifiedPrComment::Review {
+                id: self.id,
+                author: self.author.display_name.clone(),
+                author_association: "CONTRIBUTOR".to_string(), // Bitbucket doesn't have this concept
+                body: self.text.clone(),
+                created_at,
+                url: comment_url,
+                path: anchor.path.clone(),
+                line: anchor.line,
+                diff_hunk: anchor.diff_type.clone().unwrap_or_default(),
+            }
+        } else {
+            // General comment
+            UnifiedPrComment::General {
+                id: self.id.to_string(),
+                author: self.author.display_name.clone(),
+                author_association: "CONTRIBUTOR".to_string(),
+                body: self.text.clone(),
+                created_at,
+                url: comment_url,
+            }
+        }
+    }
+}
+
+/// Anchor for inline comments
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CommentAnchor {
+    pub path: String,
+    #[serde(default)]
+    pub line: Option<i64>,
+    #[serde(default)]
+    pub line_type: Option<String>, // "CONTEXT", "ADDED", "REMOVED"
+    #[serde(default)]
+    pub file_type: Option<String>, // "FROM", "TO"
+    #[serde(default)]
+    pub diff_type: Option<String>, // diff hunk context
+}
+
+/// Bitbucket Server diff comment (from /comments endpoint)
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BitbucketDiffComment {
+    pub id: i64,
+    pub text: String,
+    pub author: BitbucketUser,
+    pub created_date: i64,
+    #[serde(default)]
+    pub updated_date: Option<i64>,
+    #[serde(default)]
+    pub anchor: Option<CommentAnchor>,
+}
+
+impl BitbucketDiffComment {
+    pub fn to_unified_comment(&self, pr_url: &str) -> UnifiedPrComment {
+        let created_at = Utc.timestamp_millis_opt(self.created_date).unwrap();
+        let comment_url = format!("{}?commentId={}", pr_url, self.id);
+
+        if let Some(anchor) = &self.anchor {
+            UnifiedPrComment::Review {
+                id: self.id,
+                author: self.author.display_name.clone(),
+                author_association: "CONTRIBUTOR".to_string(),
+                body: self.text.clone(),
+                created_at,
+                url: comment_url,
+                path: anchor.path.clone(),
+                line: anchor.line,
+                diff_hunk: anchor.diff_type.clone().unwrap_or_default(),
+            }
+        } else {
+            UnifiedPrComment::General {
+                id: self.id.to_string(),
+                author: self.author.display_name.clone(),
+                author_association: "CONTRIBUTOR".to_string(),
+                body: self.text.clone(),
+                created_at,
+                url: comment_url,
+            }
+        }
+    }
+}
+
+/// Bitbucket Server error response
+#[derive(Debug, Clone, Deserialize)]
+pub struct BitbucketError {
+    pub errors: Vec<BitbucketErrorDetail>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BitbucketErrorDetail {
+    pub context: Option<String>,
+    pub message: String,
+    pub exception_name: Option<String>,
+}
+
+impl std::fmt::Display for BitbucketError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let messages: Vec<_> = self.errors.iter().map(|e| e.message.as_str()).collect();
+        write!(f, "{}", messages.join("; "))
+    }
+}

--- a/crates/services/src/services/git.rs
+++ b/crates/services/src/services/git.rs
@@ -16,6 +16,7 @@ use cli::{ChangeType, StatusDiffEntry, StatusDiffOptions};
 pub use cli::{GitCli, GitCliError};
 
 use super::file_ranker::FileStat;
+use super::github::GitHubRepoInfo;
 
 #[derive(Debug, Error)]
 pub enum GitServiceError {
@@ -1593,6 +1594,50 @@ impl GitService {
             }
         }
     }
+
+    /// Extract GitHub owner and repo name from git repo path
+    pub fn get_github_repo_info(
+        &self,
+        repo_path: &Path,
+    ) -> Result<GitHubRepoInfo, GitServiceError> {
+        // Use VcsRepoInfo parsing which handles GitHub URLs
+        let vcs_info = self.get_vcs_repo_info(repo_path)?;
+        if vcs_info.provider_type != super::vcs_provider::VcsProviderType::GitHub {
+            return Err(GitServiceError::InvalidRepository(
+                "Repository is not hosted on GitHub".to_string(),
+            ));
+        }
+        Ok(GitHubRepoInfo {
+            owner: vcs_info.owner_or_project,
+            repo_name: vcs_info.repo_name,
+        })
+    }
+
+    /// Get the remote URL for a repository
+    pub fn get_remote_url(&self, repo_path: &Path) -> Result<String, GitServiceError> {
+        let repo = self.open_repo(repo_path)?;
+        let remote_name = self.default_remote_name(&repo);
+        let remote = repo.find_remote(&remote_name).map_err(|_| {
+            GitServiceError::InvalidRepository(format!("No '{remote_name}' remote found"))
+        })?;
+
+        remote
+            .url()
+            .map(|s| s.to_string())
+            .ok_or_else(|| GitServiceError::InvalidRepository("Remote has no URL".to_string()))
+    }
+
+    /// Extract VCS provider repo info from git repo path (auto-detects GitHub/Bitbucket)
+    pub fn get_vcs_repo_info(
+        &self,
+        repo_path: &Path,
+    ) -> Result<super::vcs_provider::VcsRepoInfo, GitServiceError> {
+        let url = self.get_remote_url(repo_path)?;
+        super::vcs_provider::VcsRepoInfo::from_remote_url(&url).map_err(|e| {
+            GitServiceError::InvalidRepository(format!("Failed to parse remote URL: {e}"))
+        })
+    }
+
 
     pub fn get_remote_name_from_branch_name(
         &self,

--- a/crates/services/src/services/mod.rs
+++ b/crates/services/src/services/mod.rs
@@ -1,6 +1,7 @@
 pub mod analytics;
 pub mod approvals;
 pub mod auth;
+pub mod bitbucket;
 pub mod config;
 pub mod container;
 pub mod diff_stream;
@@ -20,5 +21,6 @@ pub mod queued_message;
 pub mod remote_client;
 pub mod repo;
 pub mod share;
+pub mod vcs_provider;
 pub mod workspace_manager;
 pub mod worktree_manager;

--- a/crates/services/src/services/vcs_provider.rs
+++ b/crates/services/src/services/vcs_provider.rs
@@ -1,0 +1,549 @@
+//! VCS Provider abstraction for supporting multiple version control hosting services.
+//!
+//! This module provides a trait-based abstraction for VCS providers (GitHub, Bitbucket, etc.)
+//! allowing the application to work with different providers through a unified interface.
+
+use async_trait::async_trait;
+use db::models::merge::PullRequestInfo;
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use ts_rs::TS;
+
+use super::bitbucket::BitbucketService;
+use super::github::{GitHubService, UnifiedPrComment};
+
+/// Supported VCS provider types
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, TS)]
+#[serde(rename_all = "snake_case")]
+pub enum VcsProviderType {
+    GitHub,
+    BitbucketServer,
+}
+
+impl std::fmt::Display for VcsProviderType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            VcsProviderType::GitHub => write!(f, "GitHub"),
+            VcsProviderType::BitbucketServer => write!(f, "Bitbucket Server"),
+        }
+    }
+}
+
+/// Repository information extracted from a git remote URL.
+/// This is provider-agnostic and contains the necessary info to make API calls.
+#[derive(Debug, Clone)]
+pub struct VcsRepoInfo {
+    pub provider_type: VcsProviderType,
+    /// Base URL for API calls (e.g., "https://api.github.com" or "https://git.taboolasyndication.com")
+    pub base_url: String,
+    /// Owner (GitHub) or Project key (Bitbucket)
+    pub owner_or_project: String,
+    /// Repository name
+    pub repo_name: String,
+}
+
+impl VcsRepoInfo {
+    /// Parse a git remote URL and extract repository information.
+    /// Supports both SSH and HTTPS URLs for GitHub and Bitbucket Server.
+    pub fn from_remote_url(url: &str) -> Result<Self, VcsProviderError> {
+        // Try GitHub first
+        if let Ok(info) = Self::parse_github_url(url) {
+            return Ok(info);
+        }
+
+        // Try Bitbucket Server
+        if let Ok(info) = Self::parse_bitbucket_server_url(url) {
+            return Ok(info);
+        }
+
+        Err(VcsProviderError::UnsupportedProvider(format!(
+            "Could not determine VCS provider from URL: {url}"
+        )))
+    }
+
+    fn parse_github_url(url: &str) -> Result<Self, VcsProviderError> {
+        // Supports SSH, HTTPS and PR GitHub URLs
+        // Examples:
+        //   git@github.com:owner/repo.git
+        //   https://github.com/owner/repo.git
+        //   https://github.com/owner/repo/pull/123
+        let re = Regex::new(r"github\.com[:/](?P<owner>[^/]+)/(?P<repo>[^/]+?)(?:\.git)?(?:/|$)")
+            .map_err(|e| VcsProviderError::Repository(format!("Failed to compile regex: {e}")))?;
+
+        let caps = re.captures(url).ok_or_else(|| {
+            VcsProviderError::Repository(format!("Not a GitHub URL: {url}"))
+        })?;
+
+        let owner = caps
+            .name("owner")
+            .ok_or_else(|| VcsProviderError::Repository("Failed to extract owner".into()))?
+            .as_str()
+            .to_string();
+
+        let repo_name = caps
+            .name("repo")
+            .ok_or_else(|| VcsProviderError::Repository("Failed to extract repo name".into()))?
+            .as_str()
+            .to_string();
+
+        Ok(Self {
+            provider_type: VcsProviderType::GitHub,
+            base_url: "https://api.github.com".to_string(),
+            owner_or_project: owner,
+            repo_name,
+        })
+    }
+
+    fn parse_bitbucket_server_url(url: &str) -> Result<Self, VcsProviderError> {
+        // Supports Bitbucket Server URLs:
+        // SSH: ssh://git@git.taboolasyndication.com:7998/dev/products.git
+        // SSH alt: git@git.taboolasyndication.com:7998/dev/products.git
+        // HTTPS browse: https://git.taboolasyndication.com/projects/DEV/repos/products/browse
+        // HTTPS clone: https://git.taboolasyndication.com/scm/DEV/products.git
+
+        // First, check if this looks like our Bitbucket server
+        if !url.contains("git.taboolasyndication.com") {
+            return Err(VcsProviderError::Repository(format!(
+                "Not a Bitbucket Server URL: {url}"
+            )));
+        }
+
+        let base_url = "https://git.taboolasyndication.com".to_string();
+
+        // Try SSH format: ssh://git@host:port/project/repo.git or git@host:port/project/repo.git
+        let ssh_re = Regex::new(
+            r"git\.taboolasyndication\.com(?::\d+)?[/:](?P<project>[^/]+)/(?P<repo>[^/]+?)(?:\.git)?$"
+        ).map_err(|e| VcsProviderError::Repository(format!("Failed to compile regex: {e}")))?;
+
+        if let Some(caps) = ssh_re.captures(url) {
+            let project = caps
+                .name("project")
+                .ok_or_else(|| VcsProviderError::Repository("Failed to extract project".into()))?
+                .as_str()
+                .to_uppercase(); // Bitbucket project keys are typically uppercase
+
+            let repo_name = caps
+                .name("repo")
+                .ok_or_else(|| VcsProviderError::Repository("Failed to extract repo name".into()))?
+                .as_str()
+                .to_string();
+
+            return Ok(Self {
+                provider_type: VcsProviderType::BitbucketServer,
+                base_url,
+                owner_or_project: project,
+                repo_name,
+            });
+        }
+
+        // Try HTTPS browse format: /projects/PROJECT/repos/REPO/browse
+        let browse_re = Regex::new(
+            r"git\.taboolasyndication\.com/projects/(?P<project>[^/]+)/repos/(?P<repo>[^/]+)"
+        ).map_err(|e| VcsProviderError::Repository(format!("Failed to compile regex: {e}")))?;
+
+        if let Some(caps) = browse_re.captures(url) {
+            let project = caps
+                .name("project")
+                .ok_or_else(|| VcsProviderError::Repository("Failed to extract project".into()))?
+                .as_str()
+                .to_string();
+
+            let repo_name = caps
+                .name("repo")
+                .ok_or_else(|| VcsProviderError::Repository("Failed to extract repo name".into()))?
+                .as_str()
+                .to_string();
+
+            return Ok(Self {
+                provider_type: VcsProviderType::BitbucketServer,
+                base_url,
+                owner_or_project: project,
+                repo_name,
+            });
+        }
+
+        // Try HTTPS clone format: /scm/PROJECT/repo.git
+        let scm_re = Regex::new(
+            r"git\.taboolasyndication\.com/scm/(?P<project>[^/]+)/(?P<repo>[^/]+?)(?:\.git)?$"
+        ).map_err(|e| VcsProviderError::Repository(format!("Failed to compile regex: {e}")))?;
+
+        if let Some(caps) = scm_re.captures(url) {
+            let project = caps
+                .name("project")
+                .ok_or_else(|| VcsProviderError::Repository("Failed to extract project".into()))?
+                .as_str()
+                .to_string();
+
+            let repo_name = caps
+                .name("repo")
+                .ok_or_else(|| VcsProviderError::Repository("Failed to extract repo name".into()))?
+                .as_str()
+                .to_string();
+
+            return Ok(Self {
+                provider_type: VcsProviderType::BitbucketServer,
+                base_url,
+                owner_or_project: project,
+                repo_name,
+            });
+        }
+
+        Err(VcsProviderError::Repository(format!(
+            "Could not parse Bitbucket Server URL: {url}"
+        )))
+    }
+}
+
+/// Request to create a pull request
+#[derive(Debug, Clone)]
+pub struct CreatePrRequest {
+    pub title: String,
+    pub body: Option<String>,
+    pub head_branch: String,
+    pub base_branch: String,
+    pub draft: Option<bool>,
+}
+
+/// Errors that can occur when interacting with VCS providers
+#[derive(Debug, Error)]
+pub enum VcsProviderError {
+    #[error("VCS provider not supported: {0}")]
+    UnsupportedProvider(String),
+
+    #[error("Authentication failed: {0}")]
+    AuthFailed(String),
+
+    #[error("Authentication required - please configure your {0} access token")]
+    AuthRequired(String),
+
+    #[error("Repository error: {0}")]
+    Repository(String),
+
+    #[error("Pull request error: {0}")]
+    PullRequest(String),
+
+    #[error("Network error: {0}")]
+    Network(String),
+
+    #[error("Permission denied: {0}")]
+    PermissionDenied(String),
+
+    #[error("Resource not found: {0}")]
+    NotFound(String),
+
+    #[error("GitHub CLI is not installed")]
+    GhCliNotInstalled,
+
+    #[error("HTTP error: {0}")]
+    Http(#[from] reqwest::Error),
+
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+impl VcsProviderError {
+    /// Whether this error is transient and the operation should be retried
+    pub fn should_retry(&self) -> bool {
+        matches!(
+            self,
+            VcsProviderError::Network(_) | VcsProviderError::Http(_)
+        )
+    }
+}
+
+/// Trait defining the interface for VCS providers
+#[async_trait]
+pub trait VcsProvider: Send + Sync {
+    /// Get the provider type
+    fn provider_type(&self) -> VcsProviderType;
+
+    /// Check if this provider can handle the given remote URL
+    fn matches_remote_url(&self, url: &str) -> bool;
+
+    /// Check authentication status
+    async fn check_auth(&self) -> Result<(), VcsProviderError>;
+
+    /// Create a pull request
+    async fn create_pr(
+        &self,
+        repo_info: &VcsRepoInfo,
+        request: &CreatePrRequest,
+    ) -> Result<PullRequestInfo, VcsProviderError>;
+
+    /// Get the status of a pull request
+    async fn get_pr_status(
+        &self,
+        repo_info: &VcsRepoInfo,
+        pr_number: i64,
+    ) -> Result<PullRequestInfo, VcsProviderError>;
+
+    /// List all pull requests for a branch
+    async fn list_prs_for_branch(
+        &self,
+        repo_info: &VcsRepoInfo,
+        branch_name: &str,
+    ) -> Result<Vec<PullRequestInfo>, VcsProviderError>;
+
+    /// Get all comments for a pull request
+    async fn get_pr_comments(
+        &self,
+        repo_info: &VcsRepoInfo,
+        pr_number: i64,
+    ) -> Result<Vec<UnifiedPrComment>, VcsProviderError>;
+}
+
+/// Registry of VCS providers for auto-detection and dispatch
+pub struct VcsProviderRegistry {
+    providers: Vec<Box<dyn VcsProvider>>,
+}
+
+impl VcsProviderRegistry {
+    /// Create a new registry with default providers
+    pub fn new() -> Result<Self, VcsProviderError> {
+        let mut providers: Vec<Box<dyn VcsProvider>> = Vec::new();
+
+        // Register GitHub provider (may fail if gh CLI not installed, but that's ok)
+        match GitHubProviderAdapter::new() {
+            Ok(github) => providers.push(Box::new(github)),
+            Err(e) => {
+                tracing::debug!("GitHub provider not available: {}", e);
+            }
+        }
+
+        // Register Bitbucket provider
+        match BitbucketService::new() {
+            Ok(bitbucket) => providers.push(Box::new(bitbucket)),
+            Err(e) => {
+                tracing::debug!("Bitbucket provider not available: {}", e);
+            }
+        }
+
+        Ok(Self { providers })
+    }
+
+    /// Create a new registry and load Bitbucket credentials
+    pub async fn new_with_loaded_credentials() -> Result<Self, VcsProviderError> {
+        let mut providers: Vec<Box<dyn VcsProvider>> = Vec::new();
+
+        // Register GitHub provider
+        match GitHubProviderAdapter::new() {
+            Ok(github) => providers.push(Box::new(github)),
+            Err(e) => {
+                tracing::debug!("GitHub provider not available: {}", e);
+            }
+        }
+
+        // Register Bitbucket provider with loaded credentials
+        match BitbucketService::new() {
+            Ok(bitbucket) => {
+                if let Err(e) = bitbucket.load_credentials().await {
+                    tracing::debug!("Failed to load Bitbucket credentials: {}", e);
+                }
+                providers.push(Box::new(bitbucket));
+            }
+            Err(e) => {
+                tracing::debug!("Bitbucket provider not available: {}", e);
+            }
+        }
+
+        Ok(Self { providers })
+    }
+
+    /// Register a provider
+    pub fn register(&mut self, provider: Box<dyn VcsProvider>) {
+        self.providers.push(provider);
+    }
+
+    /// Detect the appropriate provider from a remote URL
+    pub fn detect_from_url(&self, url: &str) -> Option<&dyn VcsProvider> {
+        self.providers
+            .iter()
+            .find(|p| p.matches_remote_url(url))
+            .map(|b| b.as_ref())
+    }
+
+    /// Get a provider by type
+    pub fn get_provider(&self, provider_type: VcsProviderType) -> Option<&dyn VcsProvider> {
+        self.providers
+            .iter()
+            .find(|p| p.provider_type() == provider_type)
+            .map(|b| b.as_ref())
+    }
+}
+
+impl Default for VcsProviderRegistry {
+    fn default() -> Self {
+        Self::new().unwrap_or_else(|_| Self {
+            providers: Vec::new(),
+        })
+    }
+}
+
+/// Adapter to make GitHubService implement VcsProvider trait
+pub struct GitHubProviderAdapter {
+    inner: GitHubService,
+}
+
+impl GitHubProviderAdapter {
+    pub fn new() -> Result<Self, VcsProviderError> {
+        let inner = GitHubService::new().map_err(|e| {
+            if matches!(e, super::github::GitHubServiceError::GhCliNotInstalled(_)) {
+                VcsProviderError::GhCliNotInstalled
+            } else {
+                VcsProviderError::AuthFailed(e.to_string())
+            }
+        })?;
+        Ok(Self { inner })
+    }
+}
+
+#[async_trait]
+impl VcsProvider for GitHubProviderAdapter {
+    fn provider_type(&self) -> VcsProviderType {
+        VcsProviderType::GitHub
+    }
+
+    fn matches_remote_url(&self, url: &str) -> bool {
+        url.contains("github.com")
+    }
+
+    async fn check_auth(&self) -> Result<(), VcsProviderError> {
+        self.inner.check_token().await.map_err(|e| {
+            VcsProviderError::AuthFailed(format!("GitHub authentication failed: {}", e))
+        })
+    }
+
+    async fn create_pr(
+        &self,
+        repo_info: &VcsRepoInfo,
+        request: &CreatePrRequest,
+    ) -> Result<PullRequestInfo, VcsProviderError> {
+        let github_repo_info = super::github::GitHubRepoInfo {
+            owner: repo_info.owner_or_project.clone(),
+            repo_name: repo_info.repo_name.clone(),
+        };
+
+        let github_request = super::github::CreatePrRequest {
+            title: request.title.clone(),
+            body: request.body.clone(),
+            head_branch: request.head_branch.clone(),
+            base_branch: request.base_branch.clone(),
+            draft: request.draft,
+        };
+
+        self.inner
+            .create_pr(&github_repo_info, &github_request)
+            .await
+            .map_err(|e| VcsProviderError::PullRequest(e.to_string()))
+    }
+
+    async fn get_pr_status(
+        &self,
+        repo_info: &VcsRepoInfo,
+        pr_number: i64,
+    ) -> Result<PullRequestInfo, VcsProviderError> {
+        // Construct the GitHub PR URL from repo info and PR number
+        let pr_url = format!(
+            "https://github.com/{}/{}/pull/{}",
+            repo_info.owner_or_project, repo_info.repo_name, pr_number
+        );
+
+        self.inner
+            .update_pr_status(&pr_url)
+            .await
+            .map_err(|e| VcsProviderError::PullRequest(e.to_string()))
+    }
+
+    async fn list_prs_for_branch(
+        &self,
+        repo_info: &VcsRepoInfo,
+        branch_name: &str,
+    ) -> Result<Vec<PullRequestInfo>, VcsProviderError> {
+        let github_repo_info = super::github::GitHubRepoInfo {
+            owner: repo_info.owner_or_project.clone(),
+            repo_name: repo_info.repo_name.clone(),
+        };
+
+        self.inner
+            .list_all_prs_for_branch(&github_repo_info, branch_name)
+            .await
+            .map_err(|e| VcsProviderError::PullRequest(e.to_string()))
+    }
+
+    async fn get_pr_comments(
+        &self,
+        repo_info: &VcsRepoInfo,
+        pr_number: i64,
+    ) -> Result<Vec<UnifiedPrComment>, VcsProviderError> {
+        let github_repo_info = super::github::GitHubRepoInfo {
+            owner: repo_info.owner_or_project.clone(),
+            repo_name: repo_info.repo_name.clone(),
+        };
+
+        self.inner
+            .get_pr_comments(&github_repo_info, pr_number)
+            .await
+            .map_err(|e| VcsProviderError::PullRequest(e.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_github_ssh_url() {
+        let info = VcsRepoInfo::from_remote_url("git@github.com:owner/repo.git").unwrap();
+        assert_eq!(info.provider_type, VcsProviderType::GitHub);
+        assert_eq!(info.owner_or_project, "owner");
+        assert_eq!(info.repo_name, "repo");
+    }
+
+    #[test]
+    fn test_parse_github_https_url() {
+        let info = VcsRepoInfo::from_remote_url("https://github.com/owner/repo.git").unwrap();
+        assert_eq!(info.provider_type, VcsProviderType::GitHub);
+        assert_eq!(info.owner_or_project, "owner");
+        assert_eq!(info.repo_name, "repo");
+    }
+
+    #[test]
+    fn test_parse_bitbucket_ssh_url() {
+        let info = VcsRepoInfo::from_remote_url(
+            "ssh://git@git.taboolasyndication.com:7998/dev/products.git",
+        )
+        .unwrap();
+        assert_eq!(info.provider_type, VcsProviderType::BitbucketServer);
+        assert_eq!(info.owner_or_project, "DEV"); // uppercase
+        assert_eq!(info.repo_name, "products");
+    }
+
+    #[test]
+    fn test_parse_bitbucket_browse_url() {
+        let info = VcsRepoInfo::from_remote_url(
+            "https://git.taboolasyndication.com/projects/DEV/repos/products/browse",
+        )
+        .unwrap();
+        assert_eq!(info.provider_type, VcsProviderType::BitbucketServer);
+        assert_eq!(info.owner_or_project, "DEV");
+        assert_eq!(info.repo_name, "products");
+    }
+
+    #[test]
+    fn test_parse_bitbucket_scm_url() {
+        let info = VcsRepoInfo::from_remote_url(
+            "https://git.taboolasyndication.com/scm/DEV/products.git",
+        )
+        .unwrap();
+        assert_eq!(info.provider_type, VcsProviderType::BitbucketServer);
+        assert_eq!(info.owner_or_project, "DEV");
+        assert_eq!(info.repo_name, "products");
+    }
+
+    #[test]
+    fn test_unsupported_provider() {
+        let result = VcsRepoInfo::from_remote_url("https://gitlab.com/owner/repo.git");
+        assert!(result.is_err());
+    }
+}


### PR DESCRIPTION
Add support for Bitbucket Server (on-premise) alongside existing GitHub integration using a VCS provider abstraction layer.

New features:
- VcsProvider trait for unified VCS operations
- VcsProviderRegistry for auto-detection from remote URL
- BitbucketService implementing create PR, get status, list PRs, fetch comments
- Secure credential storage (file-based with macOS Keychain integration)
- Bitbucket REST API v1.0 client with retry logic

The system auto-detects whether a repository uses GitHub or Bitbucket based on the remote URL and routes operations accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)