### PR TITLE
feat(executors): add model_provider field to Droid executor

### DIFF
--- a/crates/executors/src/executors/droid.rs
+++ b/crates/executors/src/executors/droid.rs
@@ -78,6 +78,13 @@ pub struct Droid {
     )]
     pub reasoning_effort: Option<ReasoningEffortLevel>,
 
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(
+        title = "Model Provider",
+        description = "Model provider to use (e.g., openai, anthropic, google)"
+    )]
+    pub model_provider: Option<String>,
+
     #[serde(flatten)]
     pub cmd: crate::command::CmdOverrides,
 }

--- a/npx-cli/package-lock.json
+++ b/npx-cli/package-lock.json
@@ -1,0 +1,27 @@
+{
+  "name": "vibe-kanban",
+  "version": "0.0.144",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "vibe-kanban",
+      "version": "0.0.144",
+      "dependencies": {
+        "adm-zip": "^0.5.16"
+      },
+      "bin": {
+        "vibe-kanban": "bin/cli.js"
+      }
+    },
+    "node_modules/adm-zip": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
+      "integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
+      }
+    }
+  }
+}

--- a/shared/schemas/droid.json
+++ b/shared/schemas/droid.json
@@ -49,6 +49,14 @@
         null
       ]
     },
+    "model_provider": {
+      "title": "Model Provider",
+      "description": "Model provider to use (e.g., openai, anthropic, google)",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "base_command_override": {
       "title": "Base Command Override",
       "description": "Override the base command with a custom command",

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -425,7 +425,7 @@ auto_approve: boolean, base_command_override?: string | null, additional_params?
 
 export type QwenCode = { append_prompt: AppendPrompt, yolo?: boolean | null, base_command_override?: string | null, additional_params?: Array<string> | null, env?: { [key in string]?: string } | null, };
 
-export type Droid = { append_prompt: AppendPrompt, autonomy: Autonomy, model?: string | null, reasoning_effort?: DroidReasoningEffort | null, base_command_override?: string | null, additional_params?: Array<string> | null, env?: { [key in string]?: string } | null, };
+export type Droid = { append_prompt: AppendPrompt, autonomy: Autonomy, model?: string | null, reasoning_effort?: DroidReasoningEffort | null, model_provider?: string | null, base_command_override?: string | null, additional_params?: Array<string> | null, env?: { [key in string]?: string } | null, };
 
 export type Autonomy = "normal" | "low" | "medium" | "high" | "skip-permissions-unsafe";
 


### PR DESCRIPTION
Add support for specifying model provider in Droid executor configuration.

Changes:
- Add model_provider field to Droid struct (for UI display purposes)
- Update TypeScript types and JSON schema
- Note: model_provider is not passed to droid CLI as it doesn't support --model-provider flag
- The model ID itself contains all necessary information

This allows users to configure custom models like GLM-4.7 in the UI.