### PR TITLE
Fix hash render in diff file names

### DIFF
--- a/frontend/tailwind.new.config.js
+++ b/frontend/tailwind.new.config.js
@@ -130,8 +130,8 @@ module.exports = {
         half: getSize('base', 0.5),
       },
       fontFamily: {
-        'ibm-plex-sans': ['IBM Plex Sans', 'Noto Emoji', 'sans-serif'],
-        'ibm-plex-mono': ['IBM Plex Mono', 'Noto Emoji', 'monospace'],
+        'ibm-plex-sans': ['"IBM Plex Sans"', '"Noto Emoji"', 'sans-serif'],
+        'ibm-plex-mono': ['"IBM Plex Mono"', 'monospace'],
       },
       keyframes: {
         "accordion-down": {


### PR DESCRIPTION
The font-family had typos and produced weirdly rendered file names if they contain both letters and numbers.