### PR TITLE
Fix file tree click to scroll diff to top instead of nearest visible position (Vibe Kanban)

### DIFF
--- a/frontend/src/components/ui-new/containers/ChangesPanelContainer.tsx
+++ b/frontend/src/components/ui-new/containers/ChangesPanelContainer.tsx
@@ -165,7 +165,7 @@ export function ChangesPanelContainer({
     const timeoutId = setTimeout(() => {
       diffRefs.current.get(selectedFilePath)?.scrollIntoView({
         behavior: 'smooth',
-        block: 'nearest',
+        block: 'start',
       });
     }, 0);
 


### PR DESCRIPTION
## Summary

Fixed an issue where clicking on a file in the FileTreeContainer did not properly scroll the corresponding diff to the top of the ChangesPanelContainer. Users would often end up scrolled only halfway through the file instead of seeing it from the beginning.

## Changes Made

Changed `scrollIntoView` block parameter from `'nearest'` to `'start'` in `ChangesPanelContainer.tsx`.

**Before:**
```typescript
diffRefs.current.get(selectedFilePath)?.scrollIntoView({
  behavior: 'smooth',
  block: 'nearest',  // Scrolls minimum distance to make element visible
});
```

**After:**
```typescript
diffRefs.current.get(selectedFilePath)?.scrollIntoView({
  behavior: 'smooth',
  block: 'start',  // Aligns top of element with top of scroll container
});
```

## Why This Fix Works

- `block: 'nearest'` only scrolls the minimum distance needed to bring an element into view. If the diff header was already partially visible, no additional scrolling occurred - leaving users "halfway" through the file.
- `block: 'start'` aligns the top of the selected diff with the top of the scrollable container, ensuring the file header is always visible at the top when a file is clicked in the tree.

## Files Modified

- `frontend/src/components/ui-new/containers/ChangesPanelContainer.tsx`

---

This PR was written using [Vibe Kanban](https://vibekanban.com)