### PR TITLE
Fix new sessions to inherit last used variant from previous session (Vibe Kanban)

### DIFF
--- a/frontend/src/components/ui-new/containers/SessionChatBoxContainer.tsx
+++ b/frontend/src/components/ui-new/containers/SessionChatBoxContainer.tsx
@@ -177,37 +177,23 @@ export function SessionChatBoxContainer({
   // User profiles, config preference, and latest executor from processes
   const { profiles, config } = useUserSystem();
 
-  // Get last used executor from the most recently used session in this workspace
-  const lastSessionExecutor = useMemo(() => {
-    if (!sessions?.length) return null;
-    // Sessions are sorted by most recently used (first is most recent)
-    const mostRecentSession = sessions[0];
-    return mostRecentSession?.executor ?? null;
-  }, [sessions]);
-
-  // Get last session's ID for fetching its processes (only in new session mode)
+  // Fetch processes from last session to get full profile (only in new session mode)
   const lastSessionId = isNewSessionMode ? sessions?.[0]?.id : undefined;
-
-  // Fetch processes from last session to get the full profile (executor + variant)
   const { executionProcesses: lastSessionProcesses } =
     useExecutionProcesses(lastSessionId);
 
-  // Extract full profile from last session's processes
-  const lastSessionProfile = useMemo(() => {
-    if (!lastSessionProcesses?.length) return null;
-    return getLatestProfileFromProcesses(lastSessionProcesses);
-  }, [lastSessionProcesses]);
-
-  // Compute latestProfileId: from processes, or fall back to last session's profile/executor
+  // Compute latestProfileId: current processes > last session processes > session metadata
   const latestProfileId = useMemo(() => {
-    // If we have processes (existing session), use them
+    // Current session's processes take priority
     const fromProcesses = getLatestProfileFromProcesses(processes);
     if (fromProcesses) return fromProcesses;
 
-    // Use full profile from last session (includes variant)
-    if (lastSessionProfile) return lastSessionProfile;
+    // Try full profile from last session's processes (includes variant)
+    const fromLastSession = getLatestProfileFromProcesses(lastSessionProcesses);
+    if (fromLastSession) return fromLastSession;
 
     // Fallback: just executor from session metadata, no variant
+    const lastSessionExecutor = sessions?.[0]?.executor;
     if (lastSessionExecutor) {
       return {
         executor: lastSessionExecutor as BaseCodingAgent,
@@ -216,7 +202,7 @@ export function SessionChatBoxContainer({
     }
 
     return null;
-  }, [processes, lastSessionProfile, lastSessionExecutor]);
+  }, [processes, lastSessionProcesses, sessions]);
 
   // Message editor state
   const {


### PR DESCRIPTION
## Summary

New sessions now correctly inherit the **variant** (in addition to the executor) from the most recently used session in a workspace.

## Problem

When creating a new session, the executor profile was correctly inherited from the last session via `sessions[0].executor`, but the variant was always hardcoded to `null`:

```tsx
if (lastSessionExecutor) {
  return {
    executor: lastSessionExecutor as BaseCodingAgent,
    variant: null,  // <-- Always null
  };
}
```

This meant users had to manually re-select their preferred variant (e.g., "PLAN", "ROUTER") every time they started a new session.

## Solution

Fetch execution processes from the most recent session when in new session mode using `useExecutionProcesses`, then extract the full executor profile (executor + variant) from those processes.

### Changes

- Added `useExecutionProcesses` hook to fetch processes from the last session (only when `isNewSessionMode` is true)
- Updated `latestProfileId` computation to use a 3-tier fallback:
  1. Current session's processes (highest priority)
  2. Last session's processes (includes variant)
  3. Session metadata executor only (fallback, variant = null)

### Code Improvements

- Removed redundant `lastSessionExecutor` memo (inlined into the main computation)
- Consolidated logic from 4 separate declarations down to 3
- Cleaner, more readable implementation with same behavior

## Test Plan

- [ ] Create a session with a non-default variant selected
- [ ] Start a new session in the same workspace
- [ ] Verify the variant dropdown shows the previously used variant

---

This PR was written using [Vibe Kanban](https://vibekanban.com)