### PR TITLE
Show GitHub PR status icon on workspace sidebar (Vibe Kanban)

### DIFF
--- a/frontend/src/components/ui-new/hooks/useWorkspaces.ts
+++ b/frontend/src/components/ui-new/hooks/useWorkspaces.ts
@@ -25,6 +25,7 @@ export interface SidebarWorkspace {
   hasUnseenActivity?: boolean;
   latestProcessCompletedAt?: string;
   latestProcessStatus?: 'running' | 'completed' | 'failed' | 'killed';
+  prStatus?: 'open' | 'merged' | 'closed' | 'unknown';
 }
 
 // Keep the old export name for backwards compatibility
@@ -67,6 +68,7 @@ function toSidebarWorkspace(
     hasUnseenActivity: summary?.has_unseen_turns,
     latestProcessCompletedAt: summary?.latest_process_completed_at ?? undefined,
     latestProcessStatus: summary?.latest_process_status ?? undefined,
+    prStatus: summary?.pr_status ?? undefined,
   };
 }
 

--- a/frontend/src/components/ui-new/primitives/WorkspaceSummary.tsx
+++ b/frontend/src/components/ui-new/primitives/WorkspaceSummary.tsx
@@ -6,6 +6,7 @@ import {
   PlayIcon,
   FileIcon,
   CircleIcon,
+  GitPullRequestIcon,
 } from '@phosphor-icons/react';
 import { useTranslation } from 'react-i18next';
 import { cn } from '@/lib/utils';
@@ -27,6 +28,7 @@ interface WorkspaceSummaryProps {
   hasUnseenActivity?: boolean;
   latestProcessCompletedAt?: string;
   latestProcessStatus?: 'running' | 'completed' | 'failed' | 'killed';
+  prStatus?: 'open' | 'merged' | 'closed' | 'unknown';
   onClick?: () => void;
   className?: string;
   summary?: boolean;
@@ -48,6 +50,7 @@ export function WorkspaceSummary({
   hasUnseenActivity = false,
   latestProcessCompletedAt,
   latestProcessStatus,
+  prStatus,
   onClick,
   className,
   summary = false,
@@ -116,6 +119,20 @@ export function WorkspaceSummary({
             {hasUnseenActivity && !isRunning && !isFailed && (
               <CircleIcon
                 className="size-icon-xs text-brand shrink-0"
+                weight="fill"
+              />
+            )}
+
+            {/* PR status icon */}
+            {prStatus === 'open' && (
+              <GitPullRequestIcon
+                className="size-icon-xs text-brand shrink-0"
+                weight="fill"
+              />
+            )}
+            {prStatus === 'merged' && (
+              <GitPullRequestIcon
+                className="size-icon-xs text-success shrink-0"
                 weight="fill"
               />
             )}

--- a/frontend/src/components/ui-new/views/WorkspacesSidebar.tsx
+++ b/frontend/src/components/ui-new/views/WorkspacesSidebar.tsx
@@ -97,6 +97,7 @@ export function WorkspacesSidebar({
               hasUnseenActivity={workspace.hasUnseenActivity}
               latestProcessCompletedAt={workspace.latestProcessCompletedAt}
               latestProcessStatus={workspace.latestProcessStatus}
+              prStatus={workspace.prStatus}
               onClick={() => onSelectWorkspace(workspace.id)}
             />
           ))}
@@ -124,6 +125,7 @@ export function WorkspacesSidebar({
               hasUnseenActivity={workspace.hasUnseenActivity}
               latestProcessCompletedAt={workspace.latestProcessCompletedAt}
               latestProcessStatus={workspace.latestProcessStatus}
+              prStatus={workspace.prStatus}
               onClick={() => onSelectWorkspace(workspace.id)}
             />
           ))}

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -352,7 +352,11 @@ has_running_dev_server: boolean,
 /**
  * Does this workspace have unseen coding agent turns?
  */
-has_unseen_turns: boolean, };
+has_unseen_turns: boolean, 
+/**
+ * PR status for this workspace (if any PR exists)
+ */
+pr_status: MergeStatus | null, };
 
 export type WorkspaceSummaryResponse = { summaries: Array<WorkspaceSummary>, };
 


### PR DESCRIPTION
## Summary

Adds a visual indicator for GitHub Pull Request status in the workspace sidebar. Workspaces now display a PR icon showing:

- **Open PR**: Git pull request icon in brand color (orange)
- **Merged PR**: Git pull request icon in success color (green)
- **No PR/Closed/Unknown**: No icon displayed

## Changes Made

### Backend
- **`crates/db/src/models/merge.rs`**: Added `get_latest_pr_status_for_workspaces()` method to efficiently batch-query the latest PR status for all workspaces, grouped by archived status
- **`crates/server/src/routes/task_attempts/workspace_summary.rs`**: Added `pr_status` field to `WorkspaceSummary` struct and integrated PR status fetching into the summary endpoint

### Frontend
- **`frontend/src/components/ui-new/hooks/useWorkspaces.ts`**: Extended `SidebarWorkspace` interface with `prStatus` field and updated the data mapping
- **`frontend/src/components/ui-new/primitives/WorkspaceSummary.tsx`**: Added `GitPullRequestIcon` display logic for open/merged PR states
- **`frontend/src/components/ui-new/views/WorkspacesSidebar.tsx`**: Passed `prStatus` prop to workspace summary components

### Generated Types
- **`shared/types.ts`**: Auto-generated to include the new `pr_status` field

## Implementation Details

The PR status is fetched as part of the existing workspace summary API endpoint, which already aggregates data from multiple sources. This approach:
- Minimizes additional API calls
- Uses an efficient SQL query with a subquery to get the latest PR per workspace
- Follows existing patterns in the codebase for status indicators

---

This PR was written using [Vibe Kanban](https://vibekanban.com)