### PR TITLE
Fix GitHub PR button display and refactor RepoCard styling (Vibe Kanban)

### DIFF
--- a/frontend/src/components/ui-new/primitives/RepoCard.tsx
+++ b/frontend/src/components/ui-new/primitives/RepoCard.tsx
@@ -94,7 +94,7 @@ export function RepoCard({
         <div className="flex items-center justify-center">
           <CrosshairIcon className="size-icon-sm text-low" weight="bold" />
         </div>
-        <div className="flex-1 min-w-0">
+        <div className="flex-1 min-w-0 flex">
           <DropdownMenu>
             <DropdownMenuTriggerButton
               label={targetBranch}
@@ -117,6 +117,24 @@ export function RepoCard({
                   </DropdownMenuItem>
                 </>
               )}
+            </DropdownMenuContent>
+          </DropdownMenu>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <button
+                className="flex items-center justify-center p-1.5 rounded hover:bg-tertiary text-low hover:text-base transition-colors"
+                title="Repo actions"
+              >
+                <ArrowSquareOutIcon className="size-icon-base" weight="bold" />
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent>
+              <DropdownMenuItem icon={CopyIcon} onClick={onCopyPath}>
+                {tCommon('actions.copyPath')}
+              </DropdownMenuItem>
+              <DropdownMenuItem icon={CodeIcon} onClick={onOpenInEditor}>
+                {tCommon('actions.openInIde')}
+              </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
         </div>
@@ -155,7 +173,7 @@ export function RepoCard({
 
       {/* PR status row */}
       {prNumber && (
-        <div className="flex items-center gap-half mt-half">
+        <div className="flex items-center gap-half my-base">
           {prStatus === 'merged' ? (
             prUrl ? (
               <button
@@ -191,31 +209,13 @@ export function RepoCard({
       )}
 
       {/* Actions row */}
-      <div className="flex items-center gap-half">
+      <div className="my-base">
         <SplitButton
           options={repoActionOptions}
           selectedValue={selectedAction}
           onSelectionChange={setSelectedAction}
           onAction={(action) => onActionsClick?.(action)}
         />
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <button
-              className="flex items-center justify-center p-1.5 rounded hover:bg-tertiary text-low hover:text-base transition-colors"
-              title="Repo actions"
-            >
-              <ArrowSquareOutIcon className="size-icon-base" weight="bold" />
-            </button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent>
-            <DropdownMenuItem icon={CopyIcon} onClick={onCopyPath}>
-              {tCommon('actions.copyPath')}
-            </DropdownMenuItem>
-            <DropdownMenuItem icon={CodeIcon} onClick={onOpenInEditor}>
-              {tCommon('actions.openInIde')}
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
       </div>
     </CollapsibleSection>
   );


### PR DESCRIPTION
## Summary

This PR fixes the GitHub PR button in the Git panel and refactors the RepoCard component for better consistency with the design system.

### Changes Made

**PR Button Fix:**
- Fixed translation parameter mismatch where `Open PR #{{number}}` was showing literally instead of the actual PR number
- Changed `{ prNumber }` to `{ number: prNumber }` to match the translation key expectations

**Styling Improvements:**
- Refactored PR badge styling to use design system tokens (`bg-panel`, `text-success`, `text-normal`, `hover:bg-tertiary`) instead of hardcoded Tailwind colors
- Updated spacing to use consistent tokens (`gap-half`, `px-base`, `py-half`, `my-base`)
- Changed border radius from `rounded-full` to `rounded-sm` to match other UI elements

**UX Improvements:**
- Made merged PRs clickable - users can now open merged PRs on GitHub (previously only open PRs were clickable)
- Added external link icon to merged PR badges when URL is available
- Improved visual separation between PR status row and action buttons

**Code Cleanup:**
- Removed unused RenameWorkspaceDialog component and related code
- Removed `pr_status` from workspace summaries (moved to RepoCard level)
- Cleaned up unused imports and translations across multiple locale files
- Moved repo actions dropdown to be inline with branch selector

### Files Modified

- `frontend/src/components/ui-new/primitives/RepoCard.tsx` - Main PR button and styling fixes
- `frontend/src/components/ui-new/primitives/WorkspaceSummary.tsx` - Removed PR status icon
- `frontend/src/components/ui-new/dialogs/RenameWorkspaceDialog.tsx` - Deleted
- `frontend/src/components/ui-new/actions/index.ts` - Removed rename action
- `frontend/src/components/ui-new/hooks/useWorkspaces.ts` - Removed prStatus field
- `crates/server/src/routes/task_attempts/workspace_summary.rs` - Removed PR status from API
- `crates/db/src/models/merge.rs` - Removed unused query method
- `shared/types.ts` - Updated generated types
- `frontend/src/i18n/locales/*/common.json` - Removed unused rename translations (en, es, ja, ko, zh-Hans, zh-Hant)

---

This PR was written using [Vibe Kanban](https://vibekanban.com)