### PR TITLE
Fix PR comment button labels showing raw translation keys (Vibe Kanban)

### DIFF
--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -169,7 +169,15 @@
     "viewInChangesPanel": "View in changes panel",
     "copyPath": "Copy path",
     "copyWorktreePath": "Copy worktree path",
-    "openInIde": "Open in IDE"
+    "openInIde": "Open in IDE",
+    "cancel": "Cancel",
+    "saveChanges": "Save Changes",
+    "copied": "Copied"
+  },
+  "comments": {
+    "addReviewComment": "Add Review Comment",
+    "addPlaceholder": "Add a comment...",
+    "editPlaceholder": "Edit comment..."
   },
   "confirm": {
     "defaultConfirm": "Confirm",

--- a/frontend/src/i18n/locales/es/common.json
+++ b/frontend/src/i18n/locales/es/common.json
@@ -169,7 +169,15 @@
     "viewInChangesPanel": "Ver en panel de cambios",
     "copyPath": "Copiar ruta",
     "copyWorktreePath": "Copiar ruta del worktree",
-    "openInIde": "Abrir en IDE"
+    "openInIde": "Abrir en IDE",
+    "cancel": "Cancelar",
+    "saveChanges": "Guardar cambios",
+    "copied": "Copiado"
+  },
+  "comments": {
+    "addReviewComment": "Agregar comentario de revisión",
+    "addPlaceholder": "Agregar un comentario...",
+    "editPlaceholder": "Editar comentario..."
   },
   "confirm": {
     "defaultConfirm": "Confirmar",

--- a/frontend/src/i18n/locales/ja/common.json
+++ b/frontend/src/i18n/locales/ja/common.json
@@ -169,7 +169,15 @@
     "viewInChangesPanel": "変更パネルで表示",
     "copyPath": "パスをコピー",
     "copyWorktreePath": "ワークツリーパスをコピー",
-    "openInIde": "IDEで開く"
+    "openInIde": "IDEで開く",
+    "cancel": "キャンセル",
+    "saveChanges": "変更を保存",
+    "copied": "コピーしました"
+  },
+  "comments": {
+    "addReviewComment": "レビューコメントを追加",
+    "addPlaceholder": "コメントを追加...",
+    "editPlaceholder": "コメントを編集..."
   },
   "confirm": {
     "defaultConfirm": "確認",

--- a/frontend/src/i18n/locales/ko/common.json
+++ b/frontend/src/i18n/locales/ko/common.json
@@ -169,7 +169,15 @@
     "viewInChangesPanel": "변경사항 패널에서 보기",
     "copyPath": "워크트리 경로 복사",
     "copyWorktreePath": "워크트리 경로 복사",
-    "openInIde": "IDE에서 열기"
+    "openInIde": "IDE에서 열기",
+    "cancel": "취소",
+    "saveChanges": "변경사항 저장",
+    "copied": "복사됨"
+  },
+  "comments": {
+    "addReviewComment": "리뷰 코멘트 추가",
+    "addPlaceholder": "코멘트 추가...",
+    "editPlaceholder": "코멘트 편집..."
   },
   "confirm": {
     "defaultConfirm": "확인",

--- a/frontend/src/i18n/locales/zh-Hans/common.json
+++ b/frontend/src/i18n/locales/zh-Hans/common.json
@@ -169,7 +169,15 @@
     "viewInChangesPanel": "在更改面板中查看",
     "copyPath": "复制路径",
     "copyWorktreePath": "复制工作树路径",
-    "openInIde": "在IDE中打开"
+    "openInIde": "在IDE中打开",
+    "cancel": "取消",
+    "saveChanges": "保存更改",
+    "copied": "已复制"
+  },
+  "comments": {
+    "addReviewComment": "添加审查评论",
+    "addPlaceholder": "添加评论...",
+    "editPlaceholder": "编辑评论..."
   },
   "confirm": {
     "defaultConfirm": "确认",

--- a/frontend/src/i18n/locales/zh-Hant/common.json
+++ b/frontend/src/i18n/locales/zh-Hant/common.json
@@ -169,7 +169,15 @@
     "viewInChangesPanel": "在變更面板中檢視",
     "copyPath": "複製路徑",
     "copyWorktreePath": "複製工作樹路徑",
-    "openInIde": "在IDE中開啟"
+    "openInIde": "在IDE中開啟",
+    "cancel": "取消",
+    "saveChanges": "儲存變更",
+    "copied": "已複製"
+  },
+  "comments": {
+    "addReviewComment": "新增審查評論",
+    "addPlaceholder": "新增評論...",
+    "editPlaceholder": "編輯評論..."
   },
   "confirm": {
     "defaultConfirm": "確認",


### PR DESCRIPTION
## Summary

Fixed an issue where PR review comment buttons displayed raw translation keys (e.g., `comments.addReviewComment`, `actions.cancel`) instead of properly translated text.

## Changes

Added missing translation keys to `common.json` across all 6 supported locales:

| Key | English Text |
|-----|-------------|
| `comments.addReviewComment` | Add Review Comment |
| `comments.addPlaceholder` | Add a comment... |
| `comments.editPlaceholder` | Edit comment... |
| `actions.cancel` | Cancel |
| `actions.saveChanges` | Save Changes |
| `actions.copied` | Copied |

### Locales Updated
- English (en)
- Spanish (es)
- Japanese (ja)
- Korean (ko)
- Simplified Chinese (zh-Hans)
- Traditional Chinese (zh-Hant)

## Why

The `CommentWidgetLine.tsx` and `ReviewCommentRenderer.tsx` components were using translation keys that didn't exist in the translation files. When i18next can't find a translation key, it falls back to displaying the raw key string, which is what users were seeing.

## Verification

- [x] `pnpm run check` passes
- [x] i18n check script confirms translation keys are consistent across all locales
- [x] tested

---

This PR was written using [Vibe Kanban](https://vibekanban.com)