### PR TITLE
feat: add bulk delete tasks by status

### DIFF
--- a/crates/server/src/bin/generate_types.rs
+++ b/crates/server/src/bin/generate_types.rs
@@ -120,6 +120,8 @@ fn generate_types_content() -> String {
         server::routes::tasks::ShareTaskResponse::decl(),
         server::routes::tasks::CreateAndStartTaskRequest::decl(),
         server::routes::task_attempts::pr::CreatePrApiRequest::decl(),
+        server::routes::tasks::BulkDeleteTasksRequest::decl(),
+        server::routes::tasks::BulkDeleteTasksResponse::decl(),
         server::routes::images::ImageResponse::decl(),
         server::routes::images::ImageMetadata::decl(),
         server::routes::task_attempts::CreateTaskAttemptBody::decl(),

--- a/frontend/src/components/dialogs/tasks/BulkDeleteTasksDialog.tsx
+++ b/frontend/src/components/dialogs/tasks/BulkDeleteTasksDialog.tsx
@@ -1,0 +1,109 @@
+import { useState } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Alert } from '@/components/ui/alert';
+import { tasksApi } from '@/lib/api';
+import type { TaskStatus } from 'shared/types';
+import NiceModal, { useModal } from '@ebay/nice-modal-react';
+import { defineModal } from '@/lib/modals';
+import { statusLabels } from '@/utils/statusLabels';
+
+export interface BulkDeleteTasksDialogProps {
+  projectId: string;
+  status: TaskStatus;
+  count: number;
+}
+
+const BulkDeleteTasksDialogImpl =
+  NiceModal.create<BulkDeleteTasksDialogProps>(
+    ({ projectId, status, count }) => {
+      const modal = useModal();
+      const [isDeleting, setIsDeleting] = useState(false);
+      const [error, setError] = useState<string | null>(null);
+
+      const statusLabel = statusLabels[status];
+
+      const handleConfirmDelete = async () => {
+        setIsDeleting(true);
+        setError(null);
+
+        try {
+          await tasksApi.bulkDelete({ project_id: projectId, status });
+          modal.resolve();
+          modal.hide();
+        } catch (err: unknown) {
+          const errorMessage =
+            err instanceof Error ? err.message : 'Failed to delete tasks';
+          setError(errorMessage);
+        } finally {
+          setIsDeleting(false);
+        }
+      };
+
+      const handleCancelDelete = () => {
+        modal.reject();
+        modal.hide();
+      };
+
+      return (
+        <Dialog
+          open={modal.visible}
+          onOpenChange={(open) => !open && handleCancelDelete()}
+        >
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Clear {statusLabel} Tasks</DialogTitle>
+              <DialogDescription>
+                Are you sure you want to delete{' '}
+                <span className="font-semibold">
+                  {count} {count === 1 ? 'task' : 'tasks'}
+                </span>{' '}
+                from {statusLabel}?
+              </DialogDescription>
+            </DialogHeader>
+
+            <Alert variant="destructive" className="mb-4">
+              <strong>Warning:</strong> This action will permanently delete all{' '}
+              {statusLabel.toLowerCase()} tasks and cannot be undone.
+            </Alert>
+
+            {error && (
+              <Alert variant="destructive" className="mb-4">
+                {error}
+              </Alert>
+            )}
+
+            <DialogFooter>
+              <Button
+                variant="outline"
+                onClick={handleCancelDelete}
+                disabled={isDeleting}
+                autoFocus
+              >
+                Cancel
+              </Button>
+              <Button
+                variant="destructive"
+                onClick={handleConfirmDelete}
+                disabled={isDeleting}
+              >
+                {isDeleting ? 'Deleting...' : `Delete ${count} Tasks`}
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      );
+    }
+  );
+
+export const BulkDeleteTasksDialog = defineModal<
+  BulkDeleteTasksDialogProps,
+  void
+>(BulkDeleteTasksDialogImpl);

--- a/frontend/src/components/ui/shadcn-io/kanban/index.tsx
+++ b/frontend/src/components/ui/shadcn-io/kanban/index.tsx
@@ -21,7 +21,7 @@ import {
 import { type ReactNode, type Ref, type KeyboardEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { Plus } from 'lucide-react';
+import { Plus, Trash2 } from 'lucide-react';
 import type { ClientRect } from '@dnd-kit/core';
 import type { Transform } from '@dnd-kit/utilities';
 import { Button } from '../../button';
@@ -153,6 +153,7 @@ export type KanbanHeaderProps =
       color: Status['color'];
       className?: string;
       onAddTask?: () => void;
+      onClearColumn?: () => void;
     };
 
 export const KanbanHeader = (props: KanbanHeaderProps) => {
@@ -181,6 +182,25 @@ export const KanbanHeader = (props: KanbanHeaderProps) => {
 
         <p className="m-0 text-sm">{props.name}</p>
       </span>
+      {props.onClearColumn && (
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                className="m-0 p-0 h-0 text-foreground/50 hover:text-destructive"
+                onClick={props.onClearColumn}
+                aria-label={t('actions.clearColumnName', { name: props.name })}
+              >
+                <Trash2 className="h-4 w-4" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="top">
+              {t('actions.clearColumnName', { name: props.name })}
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      )}
       <TooltipProvider>
         <Tooltip>
           <TooltipTrigger asChild>

--- a/frontend/src/hooks/useTaskMutations.ts
+++ b/frontend/src/hooks/useTaskMutations.ts
@@ -5,6 +5,8 @@ import { paths } from '@/lib/paths';
 import { taskRelationshipsKeys } from '@/hooks/useTaskRelationships';
 import { workspaceSummaryKeys } from '@/components/ui-new/hooks/useWorkspaces';
 import type {
+  BulkDeleteTasksRequest,
+  BulkDeleteTasksResponse,
   CreateTask,
   CreateAndStartTaskRequest,
   Task,
@@ -95,6 +97,17 @@ export function useTaskMutations(projectId?: string) {
     },
   });
 
+  const bulkDeleteTasks = useMutation({
+    mutationFn: (data: BulkDeleteTasksRequest) => tasksApi.bulkDelete(data),
+    onSuccess: (_: BulkDeleteTasksResponse) => {
+      invalidateQueries();
+      queryClient.invalidateQueries({ queryKey: taskRelationshipsKeys.all });
+    },
+    onError: (err) => {
+      console.error('Failed to bulk delete tasks:', err);
+    },
+  });
+
   const shareTask = useMutation({
     mutationFn: (taskId: string) => tasksApi.share(taskId),
     onError: (err) => {
@@ -130,6 +143,7 @@ export function useTaskMutations(projectId?: string) {
     createAndStart,
     updateTask,
     deleteTask,
+    bulkDeleteTasks,
     shareTask,
     stopShareTask: unshareSharedTask,
     linkSharedTaskToLocal,

--- a/frontend/src/i18n/locales/en/tasks.json
+++ b/frontend/src/i18n/locales/en/tasks.json
@@ -17,7 +17,9 @@
     "noSearchResults": "No tasks match your search."
   },
   "actions": {
-    "addTask": "Add task"
+    "addTask": "Add task",
+    "clearColumn": "Clear done tasks",
+    "clearColumnName": "Clear {{name}} tasks"
   },
   "filters": {
     "sharedToggleAria": "Toggle shared tasks",

--- a/frontend/src/i18n/locales/es/tasks.json
+++ b/frontend/src/i18n/locales/es/tasks.json
@@ -11,7 +11,8 @@
     }
   },
   "actions": {
-    "addTask": "Agregar tarea"
+    "addTask": "Agregar tarea",
+    "clearColumn": "Limpiar tareas completadas"
   },
   "filters": {
     "sharedToggleAria": "Alternar tareas compartidas",

--- a/frontend/src/i18n/locales/ja/tasks.json
+++ b/frontend/src/i18n/locales/ja/tasks.json
@@ -11,7 +11,8 @@
     }
   },
   "actions": {
-    "addTask": "タスクを追加"
+    "addTask": "タスクを追加",
+    "clearColumn": "完了タスクをクリア"
   },
   "filters": {
     "sharedToggleAria": "共有タスクを切り替える",

--- a/frontend/src/i18n/locales/ko/tasks.json
+++ b/frontend/src/i18n/locales/ko/tasks.json
@@ -11,7 +11,8 @@
     }
   },
   "actions": {
-    "addTask": "작업 추가"
+    "addTask": "작업 추가",
+    "clearColumn": "완료된 작업 삭제"
   },
   "filters": {
     "sharedToggleAria": "공유 작업 전환",

--- a/frontend/src/i18n/locales/zh-Hans/tasks.json
+++ b/frontend/src/i18n/locales/zh-Hans/tasks.json
@@ -17,7 +17,8 @@
     "noSearchResults": "没有任务匹配您的搜索。"
   },
   "actions": {
-    "addTask": "添加任务"
+    "addTask": "添加任务",
+    "clearColumn": "清除已完成任务"
   },
   "filters": {
     "sharedToggleAria": "切换共享任务",

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -3,6 +3,8 @@
 import {
   ApprovalStatus,
   ApiResponse,
+  BulkDeleteTasksRequest,
+  BulkDeleteTasksResponse,
   Config,
   CreateFollowUpAttempt,
   EditorType,
@@ -423,6 +425,16 @@ export const tasksApi = {
       method: 'DELETE',
     });
     return handleApiResponse<void>(response);
+  },
+
+  bulkDelete: async (
+    data: BulkDeleteTasksRequest
+  ): Promise<BulkDeleteTasksResponse> => {
+    const response = await makeRequest(`/api/tasks/bulk-delete`, {
+      method: 'POST',
+      body: JSON.stringify(data),
+    });
+    return handleApiResponse<BulkDeleteTasksResponse>(response);
   },
 
   share: async (taskId: string): Promise<ShareTaskResponse> => {

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -244,6 +244,10 @@ export type CreateAndStartTaskRequest = { task: CreateTask, executor_profile_id:
 
 export type CreatePrApiRequest = { title: string, body: string | null, target_branch: string | null, draft: boolean | null, repo_id: string, auto_generate_description: boolean, };
 
+export type BulkDeleteTasksRequest = { project_id: string, status: TaskStatus, };
+
+export type BulkDeleteTasksResponse = { deleted_count: bigint, };
+
 export type ImageResponse = { id: string, file_path: string, original_name: string, mime_type: string | null, size_bytes: bigint, hash: string, created_at: string, updated_at: string, };
 
 export type ImageMetadata = { exists: boolean, file_name: string | null, path: string | null, size_bytes: bigint | null, format: string | null, proxy_url: string | null, };


### PR DESCRIPTION
Related to #1670

<img width="563" height="134" alt="Screenshot 2026-01-09 at 11 58 45 AM" src="https://github.com/user-attachments/assets/a92035cd-b59e-4535-a976-19f7620be000" />
<img width="597" height="271" alt="Screenshot 2026-01-09 at 11 58 55 AM" src="https://github.com/user-attachments/assets/8fc3ec35-e607-460f-ad24-d358eaf51239" />


## Summary
- Adds trash icon to kanban column headers for bulk delete
- New `POST /api/tasks/bulk-delete` endpoint to delete all tasks by status
- Confirmation dialog with warning before deletion
- Checks for running processes before allowing delete
- Uses transaction for DB writes with background workspace cleanup
- Includes i18n translations for EN, ES, JA, KO, ZH-Hans

## Test plan
- [x] Verified bulk delete dialog appears on trash icon click
- [x] Verified tasks are deleted after confirmation
- [x] Verified running tasks block deletion
- [x] Verified workspace cleanup runs in background

🤖 Generated with [Claude Code](https://claude.com/claude-code)