### PR TITLE
Fix URL text overflow in Dev Server preview controls (Vibe Kanban)

### DIFF
--- a/frontend/src/components/ui-new/views/PreviewControls.tsx
+++ b/frontend/src/components/ui-new/views/PreviewControls.tsx
@@ -65,7 +65,7 @@ export function PreviewControls({
         {/* Controls row: URL bar + Start/Stop button */}
         <div className="flex items-center gap-half p-base">
           {url && (
-            <div className="flex items-center gap-half bg-panel rounded-sm px-base py-half flex-1">
+            <div className="flex items-center gap-half bg-panel rounded-sm px-base py-half flex-1 min-w-0">
               <span className="flex-1 font-mono text-sm text-low truncate">
                 {url}
               </span>


### PR DESCRIPTION
## Summary

Fixes an issue where long URLs in the Dev Server preview controls would overflow their container instead of truncating properly.

## Changes

Added `min-w-0` to the URL bar container in `PreviewControls.tsx`.

## Why

In CSS flexbox, flex items have `min-width: auto` by default, which prevents them from shrinking below their content's intrinsic width. Even though the URL text element had the `truncate` class (which sets `overflow: hidden` and `text-overflow: ellipsis`), the parent flex container couldn't shrink to trigger truncation.

Adding `min-w-0` overrides this default behavior, allowing the flex item to shrink below its content size and enabling proper text truncation.

## Implementation Details

- **File**: `frontend/src/components/ui-new/views/PreviewControls.tsx`
- **Change**: Added `min-w-0` class to the URL bar container div
- This follows the established pattern used elsewhere in the codebase (e.g., `BranchSelector.tsx`, `InputField.tsx`, `WorkspaceSummary.tsx`, `FolderPickerDialog.tsx`)

---

This PR was written using [Vibe Kanban](https://vibekanban.com)