### PR TITLE
Add PostHog analytics event for new UI access (Vibe Kanban)

### DIFF
--- a/frontend/src/components/ui-new/scope/NewDesignScope.tsx
+++ b/frontend/src/components/ui-new/scope/NewDesignScope.tsx
@@ -6,8 +6,6 @@ import { ActionsProvider } from '@/contexts/ActionsContext';
 import NiceModal from '@ebay/nice-modal-react';
 import '@/styles/new/index.css';
 
-const UI_NEW_ACCESSED_KEY = 'ui_new_accessed';
-
 interface NewDesignScopeProps {
   children: ReactNode;
 }
@@ -15,11 +13,12 @@ interface NewDesignScopeProps {
 export function NewDesignScope({ children }: NewDesignScopeProps) {
   const ref = useRef<HTMLDivElement>(null);
   const posthog = usePostHog();
+  const hasTracked = useRef(false);
 
   useEffect(() => {
-    if (!sessionStorage.getItem(UI_NEW_ACCESSED_KEY)) {
+    if (!hasTracked.current) {
       posthog?.capture('ui_new_accessed');
-      sessionStorage.setItem(UI_NEW_ACCESSED_KEY, 'true');
+      hasTracked.current = true;
     }
   }, [posthog]);
 


### PR DESCRIPTION
## Summary

Adds PostHog analytics tracking to capture when users access the new UI (`/workspaces` routes).

## Changes

- Added `ui_new_accessed` event tracking in `NewDesignScope.tsx`
- Event fires once per component mount when users visit any `/workspaces` route
- Uses a `useRef` to prevent duplicate events from re-renders

## Implementation Details

The tracking is implemented in `NewDesignScope`, which wraps all new UI routes. This ensures the event is captured regardless of which specific `/workspaces` route the user lands on.

Key behaviors:
- **Once per mount**: The event fires once when the component mounts
- **Respects opt-out**: PostHog SDK automatically respects the user's analytics preferences
- **Minimal overhead**: Uses existing PostHog infrastructure already configured in the app

---

This PR was written using [Vibe Kanban](https://vibekanban.com)