### PR TITLE
Add debounce to ConversationList for improved rendering performance (Vibe Kanban)

### DIFF
--- a/frontend/src/components/ui-new/ConversationList.tsx
+++ b/frontend/src/components/ui-new/ConversationList.tsx
@@ -91,6 +91,12 @@ export function ConversationList({ attempt, task }: ConversationListProps) {
     useState<DataWithScrollModifier<PatchTypeWithKey> | null>(null);
   const [loading, setLoading] = useState(true);
   const { setEntries, reset } = useEntries();
+  const pendingUpdateRef = useRef<{
+    entries: PatchTypeWithKey[];
+    addType: AddEntryType;
+    loading: boolean;
+  } | null>(null);
+  const debounceTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     setLoading(true);
@@ -98,25 +104,48 @@ export function ConversationList({ attempt, task }: ConversationListProps) {
     reset();
   }, [attempt.id, reset]);
 
+  useEffect(() => {
+    return () => {
+      if (debounceTimeoutRef.current) {
+        clearTimeout(debounceTimeoutRef.current);
+      }
+    };
+  }, []);
+
   const onEntriesUpdated = (
     newEntries: PatchTypeWithKey[],
     addType: AddEntryType,
     newLoading: boolean
   ) => {
-    let scrollModifier: ScrollModifier = InitialDataScrollModifier;
+    pendingUpdateRef.current = {
+      entries: newEntries,
+      addType,
+      loading: newLoading,
+    };
 
-    if (addType === 'plan' && !loading) {
-      scrollModifier = ScrollToTopOfLastItem;
-    } else if (addType === 'running' && !loading) {
-      scrollModifier = AutoScrollToBottom;
+    if (debounceTimeoutRef.current) {
+      clearTimeout(debounceTimeoutRef.current);
     }
 
-    setChannelData({ data: newEntries, scrollModifier });
-    setEntries(newEntries);
+    debounceTimeoutRef.current = setTimeout(() => {
+      const pending = pendingUpdateRef.current;
+      if (!pending) return;
 
-    if (loading) {
-      setLoading(newLoading);
-    }
+      let scrollModifier: ScrollModifier = InitialDataScrollModifier;
+
+      if (pending.addType === 'plan' && !loading) {
+        scrollModifier = ScrollToTopOfLastItem;
+      } else if (pending.addType === 'running' && !loading) {
+        scrollModifier = AutoScrollToBottom;
+      }
+
+      setChannelData({ data: pending.entries, scrollModifier });
+      setEntries(pending.entries);
+
+      if (loading) {
+        setLoading(pending.loading);
+      }
+    }, 100);
   };
 
   useConversationHistory({ attempt, onEntriesUpdated });


### PR DESCRIPTION
## Summary

Adds a 100ms debounce to the `ConversationList` component's entry update handler, matching the existing pattern in `VirtualizedProcessLogs.tsx`.

## Changes

- Added `pendingUpdateRef` to store the latest pending update data (entries, addType, loading state)
- Added `debounceTimeoutRef` to track the debounce timeout for cleanup
- Wrapped the `onEntriesUpdated` callback logic in a debounced `setTimeout` with 100ms delay
- Added a cleanup effect to clear pending timeouts on component unmount

## Why

The `ConversationList` component receives rapid updates during streaming conversations from the `useConversationHistory` hook. Without debouncing, each update triggers an immediate state change and re-render, which can cause performance issues with the virtualized list.

By batching these updates with a 100ms debounce (the same delay used in `VirtualizedProcessLogs.tsx`), we ensure only the latest update is applied, reducing unnecessary re-renders while maintaining a responsive UI.

## Implementation Details

The debounce pattern stores pending updates in a ref and only applies the most recent one after the delay expires. This ensures:
- Rapid consecutive updates are coalesced into a single render
- The correct scroll modifier is applied based on the final update type
- Cleanup on unmount prevents memory leaks and stale state updates

---

This PR was written using [Vibe Kanban](https://vibekanban.com)