### PR TITLE
Show sidebar by default when no panel is open (Vibe Kanban)

### DIFF
--- a/frontend/src/components/ui-new/containers/WorkspacesLayout.tsx
+++ b/frontend/src/components/ui-new/containers/WorkspacesLayout.tsx
@@ -158,6 +158,7 @@ export function WorkspacesLayout() {
     setChangesMode,
     setLogsMode,
     resetForCreateMode,
+    setSidebarVisible,
   } = useLayoutStore();
 
   // Read persisted draft for sidebar placeholder (works outside of CreateModeProvider)
@@ -328,6 +329,13 @@ export function WorkspacesLayout() {
       resetForCreateMode();
     }
   }, [isCreateMode, resetForCreateMode]);
+
+  // Show sidebar when no panel is open
+  useEffect(() => {
+    if (!isChangesMode && !isLogsMode && !isPreviewMode) {
+      setSidebarVisible(true);
+    }
+  }, [isChangesMode, isLogsMode, isPreviewMode, setSidebarVisible]);
 
   // Command bar keyboard shortcut (CMD+K)
   const handleOpenCommandBar = useCallback(() => {


### PR DESCRIPTION
## Summary

Automatically show the left sidebar when entering the WorkspacesLayout and no side panel (changes/preview/logs) is open.

## Changes Made

- Added `setSidebarVisible` to the destructured values from `useLayoutStore()`
- Added a new `useEffect` hook that sets `isSidebarVisible` to `true` whenever no panel mode is active (`!isChangesMode && !isLogsMode && !isPreviewMode`)

## Why

Previously, the sidebar visibility state was persisted in localStorage. If a user hid the sidebar while a panel was open, that state would persist even after the panel closed. This led to a confusing UX where users would enter the workspace with no panel open but also no sidebar visible.

Now, whenever no panel is active, the sidebar automatically becomes visible, ensuring users always have access to workspace navigation when there's screen space available.

## Implementation Details

The fix adds a `useEffect` in `WorkspacesLayout.tsx` that triggers whenever any of the panel mode states change. When all three modes are inactive, the sidebar is set to visible. This happens:
- On component mount (if no panel is open)
- When closing any panel (changes/logs/preview)

---

This PR was written using [Vibe Kanban](https://vibekanban.com)