### PR TITLE
Fix CreatePRDialog using wrong base branch in workspaces layout (Vibe Kanban)

### DIFF
--- a/frontend/src/components/ui-new/actions/index.ts
+++ b/frontend/src/components/ui-new/actions/index.ts
@@ -605,6 +605,9 @@ export const Actions = {
       const workspace = getWorkspaceFromCache(ctx.queryClient, workspaceId);
       const task = await tasksApi.getById(workspace.task_id);
 
+      const repos = await attemptsApi.getRepos(workspaceId);
+      const repo = repos.find((r) => r.id === repoId);
+
       const result = await CreatePRDialog.show({
         attempt: workspace,
         task: {
@@ -614,6 +617,7 @@ export const Actions = {
           executor: '',
         },
         repoId,
+        targetBranch: repo?.target_branch,
       });
 
       if (!result.success && result.error) {


### PR DESCRIPTION
## Summary

Fixes an issue where the Create PR dialog would show the wrong default base branch when opened from the workspaces (ui-new) layout. Previously, it would display the currently checked-out branch in the main repository instead of the workspace's configured target branch.

## Changes

Updated the `GitCreatePR` action in `frontend/src/components/ui-new/actions/index.ts` to:

1. Fetch the workspace's repos via `attemptsApi.getRepos(workspaceId)`
2. Find the specific repo and pass its `target_branch` to `CreatePRDialog.show()`

This matches the pattern already used by the `GitRebase` action in the same file, which correctly passes the target branch.

## Root Cause

The `CreatePRDialog` component has fallback logic (lines 91-104) that:
1. First priority: uses the `targetBranch` prop if provided
2. Fallback: uses the branch marked as `is_current` from the repo

The `GitCreatePR` action was not passing the `targetBranch` prop, causing the dialog to fall back to using the current branch of the main repo rather than the workspace's target branch.

## Testing

1. Open a workspace in the ui-new layout
2. Click "Create Pull Request" from the git actions menu
3. Verify the base branch defaults to the workspace's target branch (not the main repo's current branch)

---

This PR was written using [Vibe Kanban](https://vibekanban.com)