### PR TITLE
Fix STDERR logs not displaying in red in new design (Vibe Kanban)

### DIFF
--- a/frontend/src/components/common/RawLogText.tsx
+++ b/frontend/src/components/common/RawLogText.tsx
@@ -86,7 +86,7 @@ const RawLogText = memo(
       <Component
         className={clsx(
           'font-mono text-xs break-all whitespace-pre-wrap',
-          shouldApplyStderrFallback && 'text-destructive',
+          shouldApplyStderrFallback && 'text-error',
           className
         )}
       >


### PR DESCRIPTION
## Summary

Fixed STDERR logs not appearing in red color in the new design system.

## Changes

- Changed `text-destructive` to `text-error` in `RawLogText.tsx`

## Why

The new design system (`tailwind.new.config.js`) uses `error` as the color name for error/destructive styling instead of `destructive`. The `RawLogText` component was using `text-destructive` for STDERR log styling, which doesn't exist in the new Tailwind config, causing STDERR logs to not display in red.

## Implementation Details

- The fix is in `frontend/src/components/common/RawLogText.tsx`
- STDERR logs will now correctly display in red when they don't contain ANSI escape codes (ANSI formatting takes precedence when present)
- The `text-error` class maps to `hsl(var(--error))` which is defined as a red color (`0 59% 57%`)

---

This PR was written using [Vibe Kanban](https://vibekanban.com)