### PR TITLE
Auto-archive workspace when PR is merged via polling (Vibe Kanban)

### DIFF
--- a/crates/services/src/services/pr_monitor.rs
+++ b/crates/services/src/services/pr_monitor.rs
@@ -120,10 +120,15 @@ impl PrMonitorService {
                     Workspace::find_by_id(&self.db.pool, pr_merge.workspace_id).await?
             {
                 info!(
-                    "PR #{} was merged, updating task {} to done",
+                    "PR #{} was merged, updating task {} to done and archiving workspace",
                     pr_merge.pr_info.number, workspace.task_id
                 );
                 Task::update_status(&self.db.pool, workspace.task_id, TaskStatus::Done).await?;
+
+                // Archive workspace unless pinned
+                if !workspace.pinned {
+                    Workspace::set_archived(&self.db.pool, workspace.id, true).await?;
+                }
 
                 // Track analytics event
                 if let Some(analytics) = &self.analytics


### PR DESCRIPTION
## Summary

This PR adds automatic workspace archival when the PR monitor service detects that a PR has been merged.

## What changed

Added workspace archival logic to the `PrMonitorService` in `crates/services/src/services/pr_monitor.rs`. When the background polling service (which runs every 60 seconds) detects that a PR status changed to "merged", it now:

1. Marks the task as Done (existing behavior)
2. **Archives the workspace** (new behavior) - unless the workspace is pinned

## Why

Previously, there was an inconsistency in how workspaces were archived across different merge paths:

| Merge Path | Task → Done | Workspace Archived |
|------------|-------------|-------------------|
| Direct merge (no PR) | ✅ | ✅ |
| Attach already-merged PR | ✅ | ✅ |
| PR monitor detects merge | ✅ | ❌ **was missing** |

This meant that if a user created a PR and then merged it externally (via GitHub UI), the workspace would remain in the active list instead of being automatically moved to the archived section.

## Implementation details

- Respects the `pinned` flag: pinned workspaces are not auto-archived
- Uses the existing `Workspace::set_archived()` method
- No database migrations or frontend changes required - the workspace automatically moves to the archived list via existing WebSocket streaming

---

This PR was written using [Vibe Kanban](https://vibekanban.com)