### PR TITLE
Increase workspace name length from 35 to 60 characters (Vibe Kanban)

### DIFF
--- a/crates/db/src/models/workspace.rs
+++ b/crates/db/src/models/workspace.rs
@@ -5,6 +5,9 @@ use thiserror::Error;
 use ts_rs::TS;
 use uuid::Uuid;
 
+/// Maximum length for auto-generated workspace names (derived from first user prompt)
+const WORKSPACE_NAME_MAX_LEN: usize = 60;
+
 use super::{
     project::Project,
     task::Task,
@@ -580,7 +583,7 @@ impl Workspace {
             if ws.workspace.name.is_none()
                 && let Some(prompt) = Self::get_first_user_message(pool, ws.workspace.id).await?
             {
-                let name = Self::truncate_to_name(&prompt, 35);
+                let name = Self::truncate_to_name(&prompt, WORKSPACE_NAME_MAX_LEN);
                 Self::update(pool, ws.workspace.id, None, None, Some(&name)).await?;
                 ws.workspace.name = Some(name);
             }
@@ -667,7 +670,7 @@ impl Workspace {
         if ws.workspace.name.is_none()
             && let Some(prompt) = Self::get_first_user_message(pool, ws.workspace.id).await?
         {
-            let name = Self::truncate_to_name(&prompt, 35);
+            let name = Self::truncate_to_name(&prompt, WORKSPACE_NAME_MAX_LEN);
             Self::update(pool, ws.workspace.id, None, None, Some(&name)).await?;
             ws.workspace.name = Some(name);
         }


### PR DESCRIPTION
## Summary

Increases the maximum length for auto-generated workspace names from 35 to 60 characters, allowing more context from the user's prompt to be visible in workspace listings.

## Changes

- Added a `WORKSPACE_NAME_MAX_LEN` constant (set to 60) in `crates/db/src/models/workspace.rs`
- Updated both `find_all_with_status` and `find_by_id_with_status` methods to use this constant instead of the hardcoded value of 35

## Why

Workspace names are derived from the first user message/prompt and were being truncated too aggressively at 35 characters. This made it difficult to distinguish between workspaces when viewing the list, as too few words from the prompt were visible. Increasing to 60 characters provides better context while still keeping names reasonably concise.

## Implementation Details

- The `truncate_to_name` function already handles smart truncation (breaking at word boundaries and adding "..." suffix)
- Extracting the value into a named constant improves maintainability for future adjustments
- The change affects both the workspace list view and individual workspace status queries

---

This PR was written using [Vibe Kanban](https://vibekanban.com)