### PR TITLE
Display project name in Navbar when available

### DIFF
--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -171,6 +171,14 @@ export function Navbar() {
                   : 'online'}
               </span>
             </a>
+            {project && (
+              <>
+                <NavDivider />
+                <span className="text-base text-muted-foreground truncate max-w-[200px]">
+                  {project.name}
+                </span>
+              </>
+            )}
           </div>
 
           <div className="hidden sm:flex items-center gap-2">


### PR DESCRIPTION
Added for clarity in what project you are in, the project name ( if available ) to the header.