### PR TITLE
Fix gh CLI PR creation for older versions by running from repo directory (Vibe Kanban)

### DIFF
--- a/crates/services/src/services/git_host/github/cli.rs
+++ b/crates/services/src/services/git_host/github/cli.rs
@@ -180,11 +180,16 @@ impl GhCli {
     }
 
     /// Run `gh pr create` and parse the response.
+    ///
+    /// The `repo_path` parameter specifies the working directory for the command.
+    /// This is required for compatibility with older `gh` CLI versions (e.g., v2.4.0)
+    /// that require running from within a git repository.
     pub fn create_pr(
         &self,
         request: &CreatePrRequest,
         owner: &str,
         repo_name: &str,
+        repo_path: &Path,
     ) -> Result<PullRequestInfo, GhCliError> {
         // Write body to temp file to avoid shell escaping and length issues
         let body = request.body.as_deref().unwrap_or("");
@@ -212,7 +217,7 @@ impl GhCli {
             args.push(OsString::from("--draft"));
         }
 
-        let raw = self.run(args, None)?;
+        let raw = self.run(args, Some(repo_path))?;
         Self::parse_pr_create_text(&raw)
     }
 


### PR DESCRIPTION
## Summary

Fixes PR creation failing on older GitHub CLI versions (e.g., v2.4.0 on Ubuntu 22.04) that require running `gh pr create` from within a git repository directory.

Related: https://github.com/BloopAI/vibe-kanban/pull/1754

## Changes

- **`crates/services/src/services/git_host/github/cli.rs`**: Added `repo_path` parameter to the `create_pr()` method and pass it to `self.run()` as the working directory
- **`crates/services/src/services/git_host/github/mod.rs`**: Thread the `repo_path` through the async closure to the CLI call

## Why

Older `gh` CLI versions fail when running `gh pr create --repo owner/repo` from outside a git repository, even when the `--repo` flag is explicitly provided. This is a known limitation in older versions. By executing the command from within the repository directory (which is already available in the provider), we ensure compatibility with all `gh` CLI versions.

## Implementation Details

The `repo_path` was already available in `GitHostProvider::create_pr()` but wasn't being passed down to the CLI layer. The fix:
1. Adds `repo_path: &Path` parameter to `GhCli::create_pr()`
2. Passes `Some(repo_path)` to `self.run()` instead of `None`
3. Converts the path reference to an owned `PathBuf` for the `spawn_blocking` task

This is a safe, backwards-compatible change - running the `gh` command from within the repo directory can only help compatibility, not hurt it.

---

- [x] tested

---

This PR was written using [Vibe Kanban](https://vibekanban.com)