### PR TITLE
Fix infinite loop in extractProfile causing browser crash (Vibe Kanban)

### DIFF
--- a/frontend/src/components/NormalizedConversation/RetryEditorInline.tsx
+++ b/frontend/src/components/NormalizedConversation/RetryEditorInline.tsx
@@ -14,7 +14,7 @@ import { useUserSystem } from '@/components/ConfigProvider';
 import { useBranchStatus } from '@/hooks/useBranchStatus';
 import { useVariant } from '@/hooks/useVariant';
 import { useRetryProcess } from '@/hooks/useRetryProcess';
-import type { ExecutorAction, ExecutorProfileId } from 'shared/types';
+import { extractProfileFromAction } from '@/utils/executor';
 
 export function RetryEditorInline({
   attempt,
@@ -46,26 +46,7 @@ export function RetryEditorInline({
       (p) => p.id === executionProcessId
     );
     if (!process?.executor_action) return null;
-
-    const extractProfile = (
-      action: ExecutorAction | null
-    ): ExecutorProfileId | null => {
-      let curr: ExecutorAction | null = action;
-      while (curr) {
-        const typ = curr.typ;
-        switch (typ.type) {
-          case 'CodingAgentInitialRequest':
-          case 'CodingAgentFollowUpRequest':
-            return typ.executor_profile_id;
-          case 'ScriptRequest':
-            curr = curr.next_action;
-            continue;
-        }
-      }
-      return null;
-    };
-
-    return extractProfile(process.executor_action)?.variant ?? null;
+    return extractProfileFromAction(process.executor_action)?.variant ?? null;
   }, [attemptData.processes, executionProcessId]);
 
   const { selectedVariant, setSelectedVariant } = useVariant({

--- a/frontend/src/components/tasks/TaskFollowUpSection.tsx
+++ b/frontend/src/components/tasks/TaskFollowUpSection.tsx
@@ -47,11 +47,8 @@ import WYSIWYGEditor from '@/components/ui/wysiwyg';
 import { useRetryUi } from '@/contexts/RetryUiContext';
 import { useFollowUpSend } from '@/hooks/useFollowUpSend';
 import { useVariant } from '@/hooks/useVariant';
-import type {
-  DraftFollowUpData,
-  ExecutorAction,
-  ExecutorProfileId,
-} from 'shared/types';
+import type { DraftFollowUpData, ExecutorProfileId } from 'shared/types';
+import { extractProfileFromAction } from '@/utils/executor';
 import { buildResolveConflictsInstructions } from '@/lib/conflicts';
 import { useTranslation } from 'react-i18next';
 import { useScratch } from '@/hooks/useScratch';
@@ -152,29 +149,11 @@ export function TaskFollowUpSection({
   // Variant selection - derive default from latest process
   const latestProfileId = useMemo<ExecutorProfileId | null>(() => {
     if (!processes?.length) return null;
-
-    const extractProfile = (
-      action: ExecutorAction | null
-    ): ExecutorProfileId | null => {
-      let curr: ExecutorAction | null = action;
-      while (curr) {
-        const typ = curr.typ;
-        switch (typ.type) {
-          case 'CodingAgentInitialRequest':
-          case 'CodingAgentFollowUpRequest':
-            return typ.executor_profile_id;
-          case 'ScriptRequest':
-            curr = curr.next_action;
-            continue;
-        }
-      }
-      return null;
-    };
     return (
       processes
         .slice()
         .reverse()
-        .map((p) => extractProfile(p.executor_action ?? null))
+        .map((p) => extractProfileFromAction(p.executor_action ?? null))
         .find((pid) => pid !== null) ?? null
     );
   }, [processes]);

--- a/frontend/src/utils/executor.ts
+++ b/frontend/src/utils/executor.ts
@@ -57,6 +57,7 @@ export function extractProfileFromAction(
       case 'CodingAgentFollowUpRequest':
         return typ.executor_profile_id;
       case 'ScriptRequest':
+      default:
         curr = curr.next_action;
         continue;
     }


### PR DESCRIPTION
## Summary

Fixes a critical bug where the `extractProfile` function could cause an infinite loop, freezing the browser.

## Changes

- Added `default` case to switch statement in `extractProfileFromAction` (`frontend/src/utils/executor.ts`)
- Removed duplicate local `extractProfile` implementations from:
  - `TaskFollowUpSection.tsx`
  - `RetryEditorInline.tsx`
- Both components now use the shared `extractProfileFromAction` utility

## Root Cause

The switch statement in `extractProfile` was missing a `default` case. When iterating through an `ExecutorAction` linked list, if an action had an unhandled `typ.type` value, the loop would continue forever because `curr` was never updated to `curr.next_action`.

```typescript
// Before (bug)
switch (typ.type) {
  case 'CodingAgentInitialRequest':
  case 'CodingAgentFollowUpRequest':
    return typ.executor_profile_id;
  case 'ScriptRequest':
    curr = curr.next_action;
    continue;
  // Missing default - unhandled types cause infinite loop
}

// After (fixed)
switch (typ.type) {
  case 'CodingAgentInitialRequest':
  case 'CodingAgentFollowUpRequest':
    return typ.executor_profile_id;
  case 'ScriptRequest':
  default:
    curr = curr.next_action;
    continue;
}
```

## Impact

- **3 files changed**: 6 insertions, 45 deletions
- Consolidated duplicate code into single shared utility
- Prevents browser crashes when processing executor actions with unexpected types

---

This PR was written using [Vibe Kanban](https://vibekanban.com)