### PR TITLE
Increase chatbox max height from 20vh to 50vh (Vibe Kanban)

### DIFF
--- a/frontend/src/components/ui-new/primitives/ChatBoxBase.tsx
+++ b/frontend/src/components/ui-new/primitives/ChatBoxBase.tsx
@@ -141,7 +141,7 @@ export function ChatBoxBase({
           onChange={editor.onChange}
           onCmdEnter={onCmdEnter}
           disabled={disabled}
-          className="min-h-0 max-h-[min(15rem,20vh)] overflow-y-auto"
+          className="min-h-0 max-h-[50vh] overflow-y-auto"
           projectId={projectId}
           autoFocus={autoFocus}
           onPasteFiles={onPasteFiles}


### PR DESCRIPTION
## Summary

Increases the maximum vertical height of the chat input box from 20% to 50% of the viewport height, allowing users more room to compose longer messages.

## Changes

- Updated `ChatBoxBase.tsx` to change the editor's `max-h` constraint from `min(15rem, 20vh)` to `50vh`

## Why

The previous constraint of `max-h-[min(15rem,20vh)]` was quite restrictive, limiting the editor to whichever was smaller: 15rem or 20% of viewport height. This made it difficult for users to:
- Compose longer, detailed task descriptions
- Paste and review code snippets
- Write multi-step instructions without excessive scrolling

The new `50vh` limit provides a much more comfortable editing experience while still ensuring the chatbox doesn't overwhelm the conversation history above it.

## Implementation Details

- The `min-h-0` class is preserved to ensure the editor starts compact and only grows as content is added
- The `overflow-y-auto` class ensures proper scrolling when content exceeds the maximum height
- This change affects both `CreateChatBox` and `SessionChatBox` components since they both use `ChatBoxBase`

---

This PR was written using [Vibe Kanban](https://vibekanban.com)