### PR TITLE
Soften agent availability status messaging from 'Not Found' to 'Unknown' (Vibe Kanban)

### DIFF
--- a/frontend/src/i18n/locales/en/settings.json
+++ b/frontend/src/i18n/locales/en/settings.json
@@ -248,8 +248,8 @@
         "loginDetectedTooltip": "Recent authentication credentials found for this agent",
         "installationFound": "Previous Usage Detected",
         "installationFoundTooltip": "Agent configuration found. You may need to log in to use it.",
-        "notFound": "Not Found",
-        "notFoundTooltip": "No previous usage detected. Agent may require installation and/or login."
+        "notFound": "Unknown",
+        "notFoundTooltip": "We couldn't verify this agent is set up, but go ahead and try it."
       },
       "editor": {
         "formLabel": "Edit JSON",

--- a/frontend/src/i18n/locales/es/settings.json
+++ b/frontend/src/i18n/locales/es/settings.json
@@ -248,8 +248,8 @@
         "loginDetectedTooltip": "Se encontraron credenciales de autenticación recientes para este agente",
         "installationFound": "Uso previo detectado",
         "installationFoundTooltip": "Se encontró la configuración del agente. Es posible que debas iniciar sesión para usarlo.",
-        "notFound": "No encontrado",
-        "notFoundTooltip": "No se detectó uso previo. El agente puede requerir instalación y/o inicio de sesión."
+        "notFound": "Desconocido",
+        "notFoundTooltip": "No pudimos verificar que este agente esté configurado, pero pruébalo."
       },
       "editor": {
         "formLabel": "Editar JSON",

--- a/frontend/src/i18n/locales/ja/settings.json
+++ b/frontend/src/i18n/locales/ja/settings.json
@@ -248,8 +248,8 @@
         "loginDetectedTooltip": "このエージェントの最近の認証情報が見つかりました",
         "installationFound": "以前の使用を検出",
         "installationFoundTooltip": "エージェント設定が見つかりました。使用するにはログインが必要な場合があります。",
-        "notFound": "見つかりません",
-        "notFoundTooltip": "以前の使用が検出されませんでした。エージェントにはインストールやログインが必要な場合があります。"
+        "notFound": "不明",
+        "notFoundTooltip": "このエージェントが設定されているか確認できませんでしたが、試してみてください。"
       },
       "editor": {
         "formLabel": "JSONを編集",

--- a/frontend/src/i18n/locales/ko/settings.json
+++ b/frontend/src/i18n/locales/ko/settings.json
@@ -248,8 +248,8 @@
         "loginDetectedTooltip": "이 에이전트에 대한 최근 인증 자격 증명이 발견되었습니다",
         "installationFound": "이전 사용 감지됨",
         "installationFoundTooltip": "에이전트 구성이 발견되었습니다. 사용하려면 로그인해야 할 수 있습니다.",
-        "notFound": "찾을 수 없음",
-        "notFoundTooltip": "이전 사용이 감지되지 않았습니다. 에이전트에 설치 및/또는 로그인이 필요할 수 있습니다."
+        "notFound": "알 수 없음",
+        "notFoundTooltip": "이 에이전트가 설정되어 있는지 확인할 수 없지만, 시도해 보세요."
       },
       "editor": {
         "formLabel": "JSON 편집",

--- a/frontend/src/i18n/locales/zh-Hans/settings.json
+++ b/frontend/src/i18n/locales/zh-Hans/settings.json
@@ -248,8 +248,8 @@
         "loginDetectedTooltip": "找到此代理的最近身份验证凭据",
         "installationFound": "检测到以前使用",
         "installationFoundTooltip": "找到代理配置。您可能需要登录才能使用它。",
-        "notFound": "未找到",
-        "notFoundTooltip": "未检测到以前的使用。代理可能需要安装和/或登录。"
+        "notFound": "未知",
+        "notFoundTooltip": "我们无法验证此代理是否已设置，但请继续尝试。"
       },
       "editor": {
         "formLabel": "编辑 JSON",

--- a/frontend/src/i18n/locales/zh-Hant/settings.json
+++ b/frontend/src/i18n/locales/zh-Hant/settings.json
@@ -248,8 +248,8 @@
         "loginDetectedTooltip": "找到此代理的最近驗證憑證",
         "installationFound": "偵測到曾使用",
         "installationFoundTooltip": "找到代理設定。您可能需要登入才能使用。",
-        "notFound": "未找到",
-        "notFoundTooltip": "未偵測到曾使用。代理可能需要安裝和/或登入。"
+        "notFound": "未知",
+        "notFoundTooltip": "我們無法驗證此代理是否已設定，但請繼續嘗試。"
       },
       "editor": {
         "formLabel": "編輯 JSON",


### PR DESCRIPTION
## Summary

Updates the agent availability indicator copy to use softer, more encouraging language when the system cannot verify an agent's installation status.

## Changes

- Changed status label from "Not Found" to "Unknown" across all 6 supported locales
- Updated tooltip from "No previous usage detected. Agent may require installation and/or login." to "We couldn't verify this agent is set up, but go ahead and try it."

### Locales Updated
- English (en)
- Spanish (es)
- Japanese (ja)
- Korean (ko)
- Simplified Chinese (zh-Hans)
- Traditional Chinese (zh-Hant)

## Why

The previous wording "Not Found" was too definitive - users may have the agent installed, but the system simply couldn't detect it. The new "Unknown" status with encouraging tooltip copy makes it clear that:
1. The system just doesn't know the agent's status (not that it's definitely missing)
2. Users should go ahead and try using the agent anyway

This reduces unnecessary confusion and friction for users who may have agents properly installed but not detected.

- [x] tested

---

This PR was written using [Vibe Kanban](https://vibekanban.com)