### PR TITLE
chore: Reorder Repository Settings to prioritize Dev Server Script (Vibe Kanban)

### DIFF
--- a/frontend/src/i18n/locales/en/settings.json
+++ b/frontend/src/i18n/locales/en/settings.json
@@ -367,7 +367,7 @@
       },
       "scripts": {
         "title": "Scripts & Configuration",
-        "description": "Configure setup, cleanup, and copy files for this repository. These scripts run whenever the repository is used in any workspace.",
+        "description": "Configure dev server, setup, cleanup, and copy files for this repository. These scripts run whenever the repository is used in any workspace.",
         "setup": {
           "label": "Setup Script",
           "helper": "This script runs from within the worktree after it's created and before the coding agent starts. Use it for setup tasks like installing dependencies or preparing the environment.",

--- a/frontend/src/pages/settings/ReposSettings.tsx
+++ b/frontend/src/pages/settings/ReposSettings.tsx
@@ -336,6 +336,27 @@ export function ReposSettings() {
             </CardHeader>
             <CardContent className="space-y-4">
               <div className="space-y-2">
+                <Label htmlFor="dev-server-script">
+                  {t('settings.repos.scripts.devServer.label')}
+                </Label>
+                <AutoExpandingTextarea
+                  id="dev-server-script"
+                  value={draft.dev_server_script}
+                  onChange={(e) =>
+                    updateDraft({
+                      dev_server_script: e.target.value,
+                    })
+                  }
+                  placeholder={placeholders.dev}
+                  maxRows={12}
+                  className="w-full px-3 py-2 border border-input bg-background text-foreground rounded-md focus:outline-none focus:ring-2 focus:ring-ring font-mono"
+                />
+                <p className="text-sm text-muted-foreground">
+                  {t('settings.repos.scripts.devServer.helper')}
+                </p>
+              </div>
+
+              <div className="space-y-2">
                 <Label htmlFor="setup-script">
                   {t('settings.repos.scripts.setup.label')}
                 </Label>
@@ -411,27 +432,6 @@ export function ReposSettings() {
                 />
                 <p className="text-sm text-muted-foreground">
                   {t('settings.repos.scripts.copyFiles.helper')}
-                </p>
-              </div>
-
-              <div className="space-y-2">
-                <Label htmlFor="dev-server-script">
-                  {t('settings.repos.scripts.devServer.label')}
-                </Label>
-                <AutoExpandingTextarea
-                  id="dev-server-script"
-                  value={draft.dev_server_script}
-                  onChange={(e) =>
-                    updateDraft({
-                      dev_server_script: e.target.value,
-                    })
-                  }
-                  placeholder={placeholders.dev}
-                  maxRows={12}
-                  className="w-full px-3 py-2 border border-input bg-background text-foreground rounded-md focus:outline-none focus:ring-2 focus:ring-ring font-mono"
-                />
-                <p className="text-sm text-muted-foreground">
-                  {t('settings.repos.scripts.devServer.helper')}
                 </p>
               </div>
 


### PR DESCRIPTION
## Summary

This PR improves the Repository Settings page by reordering the "Scripts & Configuration" section to make the Dev Server Script input more prominent.

## Changes

- **Moved Dev Server Script to the top**: The Dev Server Script input field is now the first item in the Scripts & Configuration section, making it easier to find and configure
- **Updated section description**: The subheading now explicitly mentions "dev server" in the list of configurable items: "Configure dev server, setup, cleanup, and copy files for this repository"

## Why

The dev server script is a commonly used configuration option that users frequently need to access. Moving it to the top of the section improves discoverability and workflow efficiency.

## Files Changed

- `frontend/src/pages/settings/ReposSettings.tsx` - Reordered the form fields
- `frontend/src/i18n/locales/en/settings.json` - Updated the section description text

---

This PR was written using [Vibe Kanban](https://vibekanban.com)