### PR TITLE
Add agent parameter support for OpenCode executor

### DIFF
--- a/shared/schemas/opencode.json
+++ b/shared/schemas/opencode.json
@@ -11,6 +11,12 @@
       "format": "textarea",
       "default": null
     },
+    "agent": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "model": {
       "type": [
         "string",

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -477,7 +477,7 @@ export type CursorAgent = { append_prompt: AppendPrompt, force?: boolean | null,
 
 export type Copilot = { append_prompt: AppendPrompt, model?: string | null, allow_all_tools?: boolean | null, allow_tool?: string | null, deny_tool?: string | null, add_dir?: Array<string> | null, disable_mcp_server?: Array<string> | null, base_command_override?: string | null, additional_params?: Array<string> | null, env?: { [key in string]?: string } | null, };
 
-export type Opencode = { append_prompt: AppendPrompt, model?: string | null, mode?: string | null, 
+export type Opencode = { append_prompt: AppendPrompt, agent?: string | null, model?: string | null, mode?: string | null,
 /**
  * Auto-approve agent actions
  */


### PR DESCRIPTION
- Add agent field to Opencode struct with automatic model resolution
- Implement agent API integration to fetch default models
- Update types and schemas for frontend compatibility
- Add proper documentation and error handling

I posted this proposal in Discussions https://github.com/BloopAI/vibe-kanban/discussions/1921 and wanted to share a concrete implementation here—happy to close this if it doesn't align with your roadmap or discuss and iterate based on your feedback.