### PR TITLE
Add missing i18n translation keys for logs and search UI (Vibe Kanban)

### DIFF
--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -261,5 +261,16 @@
       "title": "Return to Classic UI",
       "content": "Click the exit icon on the left side of the navbar to return to the classic kanban board. To disable the new UI entirely, update the \"Enable Workspaces Beta\" option under \"Beta Features\" in settings."
     }
+  },
+  "logs": {
+    "searchLogs": "Search logs",
+    "selectProcessToView": "Select a process to view logs"
+  },
+  "processes": {
+    "noProcesses": "No processes"
+  },
+  "search": {
+    "matchCount": "{{current}} of {{total}}",
+    "noMatches": "No matches"
   }
 }

--- a/frontend/src/i18n/locales/es/common.json
+++ b/frontend/src/i18n/locales/es/common.json
@@ -261,5 +261,16 @@
       "title": "Volver a la interfaz clásica",
       "content": "Haz clic en el icono de salida en el lado izquierdo de la barra de navegación para volver al tablero kanban clásico. Para desactivar la nueva interfaz por completo, actualiza la opción \"Habilitar Beta de Workspaces\" en \"Funciones Beta\" en la configuración."
     }
+  },
+  "logs": {
+    "searchLogs": "Buscar registros",
+    "selectProcessToView": "Seleccione un proceso para ver los registros"
+  },
+  "processes": {
+    "noProcesses": "Sin procesos"
+  },
+  "search": {
+    "matchCount": "{{current}} de {{total}}",
+    "noMatches": "Sin coincidencias"
   }
 }

--- a/frontend/src/i18n/locales/ja/common.json
+++ b/frontend/src/i18n/locales/ja/common.json
@@ -261,5 +261,16 @@
       "title": "クラシックUIに戻る",
       "content": "ナビバー左側の終了アイコンをクリックすると、クラシックカンバンボードに戻ります。新しいUIを完全に無効にするには、設定の「ベータ機能」にある「Workspacesベータを有効にする」オプションを更新してください。"
     }
+  },
+  "logs": {
+    "searchLogs": "ログを検索",
+    "selectProcessToView": "プロセスを選択してログを表示"
+  },
+  "processes": {
+    "noProcesses": "プロセスがありません"
+  },
+  "search": {
+    "matchCount": "{{current}} / {{total}}",
+    "noMatches": "一致なし"
   }
 }

--- a/frontend/src/i18n/locales/ko/common.json
+++ b/frontend/src/i18n/locales/ko/common.json
@@ -261,5 +261,16 @@
       "title": "클래식 UI로 돌아가기",
       "content": "네비게이션 바 왼쪽의 나가기 아이콘을 클릭하면 클래식 칸반 보드로 돌아갑니다. 새 UI를 완전히 비활성화하려면 설정의 \"베타 기능\"에서 \"Workspaces 베타 활성화\" 옵션을 업데이트하세요."
     }
+  },
+  "logs": {
+    "searchLogs": "로그 검색",
+    "selectProcessToView": "로그를 보려면 프로세스를 선택하세요"
+  },
+  "processes": {
+    "noProcesses": "프로세스 없음"
+  },
+  "search": {
+    "matchCount": "{{current}} / {{total}}",
+    "noMatches": "일치 항목 없음"
   }
 }

--- a/frontend/src/i18n/locales/zh-Hans/common.json
+++ b/frontend/src/i18n/locales/zh-Hans/common.json
@@ -261,5 +261,16 @@
       "title": "返回经典界面",
       "content": "点击导航栏左侧的退出图标可返回经典看板。要完全禁用新界面，请在设置中的「测试版功能」下更新「启用 Workspaces 测试版」选项。"
     }
+  },
+  "logs": {
+    "searchLogs": "搜索日志",
+    "selectProcessToView": "选择一个进程以查看日志"
+  },
+  "processes": {
+    "noProcesses": "无进程"
+  },
+  "search": {
+    "matchCount": "{{current}} / {{total}}",
+    "noMatches": "无匹配项"
   }
 }

--- a/frontend/src/i18n/locales/zh-Hant/common.json
+++ b/frontend/src/i18n/locales/zh-Hant/common.json
@@ -261,5 +261,16 @@
       "title": "返回經典介面",
       "content": "點擊導覽列左側的退出圖示可返回經典看板。要完全停用新介面，請在設定中的「測試版功能」下更新「啟用 Workspaces 測試版」選項。"
     }
+  },
+  "logs": {
+    "searchLogs": "搜尋日誌",
+    "selectProcessToView": "選擇一個程序以查看日誌"
+  },
+  "processes": {
+    "noProcesses": "無程序"
+  },
+  "search": {
+    "matchCount": "{{current}} / {{total}}",
+    "noMatches": "無匹配項"
   }
 }


### PR DESCRIPTION
## Summary

Adds missing i18n translation keys to all 6 locale files (`en`, `es`, `ja`, `ko`, `zh-Hans`, `zh-Hant`) that were referenced in the code but not defined in the translation files.

## Changes

Added the following keys to each `common.json`:

- **`logs.searchLogs`** - Placeholder text for the search input in the process logs panel
- **`logs.selectProcessToView`** - Empty state message when no process is selected
- **`processes.noProcesses`** - Empty state message when no processes exist
- **`search.matchCount`** - Shows current match position (e.g., "1 of 5")
- **`search.noMatches`** - Shown when search has no results

## Why

These keys were being used in `ProcessListContainer.tsx` and `LogsContentContainer.tsx` but were missing from all locale files, causing the raw translation keys to display instead of localized strings.

## Files Modified

- `frontend/src/i18n/locales/en/common.json`
- `frontend/src/i18n/locales/es/common.json`
- `frontend/src/i18n/locales/ja/common.json`
- `frontend/src/i18n/locales/ko/common.json`
- `frontend/src/i18n/locales/zh-Hans/common.json`
- `frontend/src/i18n/locales/zh-Hant/common.json`

## Verification

- [x] `pnpm run check` passes

---

This PR was written using [Vibe Kanban](https://vibekanban.com)