### PR TITLE
Enable click-to-view output for MCP tools in conversation list (Vibe Kanban)

### DIFF
--- a/frontend/src/components/ui-new/NewDisplayConversationEntry.tsx
+++ b/frontend/src/components/ui-new/NewDisplayConversationEntry.tsx
@@ -572,9 +572,8 @@ function ToolSummaryEntry({
     }
   }, [summary, expanded]);
 
-  // Only Bash tools with output should open the logs panel
-  const isBash = toolName === 'Bash';
-  const hasOutput = isBash && content && content.trim().length > 0;
+  // Any tool with output can open the logs panel
+  const hasOutput = content && content.trim().length > 0;
 
   const handleViewContent = useCallback(() => {
     viewToolContentInPanel(toolName, content, command);


### PR DESCRIPTION
## Summary
Enable MCP tool entries (and all other tools with output) to be clickable in the conversation list, allowing users to view their results in the logs panel.

## Changes Made
- Removed the Bash-only restriction for the click-to-view functionality in `ToolSummaryEntry`
- Any tool with output can now be clicked to view results in the logs panel

## Why
Previously, only Bash tool entries were clickable to view their output. MCP tools (e.g., `mcp:dev-manager:start`, `mcp:dev-manager:stop`) have JSON results that users couldn't easily view. This change makes all tools with output clickable, providing a consistent experience across tool types.

## Implementation Details
The change is minimal - simplified `hasOutput` from:
```typescript
const isBash = toolName === 'Bash';
const hasOutput = isBash && content && content.trim().length > 0;
```
to:
```typescript
const hasOutput = content && content.trim().length > 0;
```

The `getToolOutput` function already handles JSON result parsing for MCP tools (via the `tool` action type), so no additional changes were needed.

---

This PR was written using [Vibe Kanban](https://vibekanban.com)