### PR TITLE
Add Run Setup/Cleanup Script actions to new UI command bar (Vibe Kanban)

### DIFF
--- a/frontend/src/components/ui-new/actions/pages.ts
+++ b/frontend/src/components/ui-new/actions/pages.ts
@@ -110,6 +110,14 @@ export const Pages: Record<StaticPageId, CommandBarPage> = {
           { type: 'action', action: Actions.DeleteWorkspace },
         ],
       },
+      {
+        type: 'group',
+        label: 'Scripts',
+        items: [
+          { type: 'action', action: Actions.RunSetupScript },
+          { type: 'action', action: Actions.RunCleanupScript },
+        ],
+      },
     ],
   },
 

--- a/frontend/src/components/ui-new/actions/useActionVisibility.ts
+++ b/frontend/src/components/ui-new/actions/useActionVisibility.ts
@@ -6,6 +6,7 @@ import { useWorkspaceContext } from '@/contexts/WorkspaceContext';
 import { useUserSystem } from '@/components/ConfigProvider';
 import { useDevServer } from '@/hooks/useDevServer';
 import { useBranchStatus } from '@/hooks/useBranchStatus';
+import { useExecutionProcessesContext } from '@/contexts/ExecutionProcessesContext';
 import type { Workspace, Merge } from 'shared/types';
 import type {
   ActionVisibilityContext,
@@ -31,6 +32,7 @@ export function useActionVisibilityContext(): ActionVisibilityContext {
   const { isStarting, isStopping, runningDevServers } =
     useDevServer(workspaceId);
   const { data: branchStatus } = useBranchStatus(workspaceId);
+  const { isAttemptRunningVisible } = useExecutionProcessesContext();
 
   return useMemo(() => {
     // Compute isAllDiffsExpanded
@@ -79,6 +81,7 @@ export function useActionVisibilityContext(): ActionVisibilityContext {
       hasMultipleRepos: repos.length > 1,
       hasOpenPR,
       hasUnpushedCommits,
+      isAttemptRunning: isAttemptRunningVisible,
     };
   }, [
     layout.isChangesMode,
@@ -98,6 +101,7 @@ export function useActionVisibilityContext(): ActionVisibilityContext {
     isStopping,
     runningDevServers,
     branchStatus,
+    isAttemptRunningVisible,
   ]);
 }
 


### PR DESCRIPTION
## Summary

This PR adds the ability to run setup and cleanup scripts from the new UI command bar, bringing feature parity with the old UI's `TaskFollowUpSection.tsx` implementation.

## Changes

### New Actions
- **Run Setup Script**: Executes the project's configured setup script
- **Run Cleanup Script**: Executes the project's configured cleanup script

### Files Modified

1. **`frontend/src/components/ui-new/actions/index.ts`**
   - Added `isAttemptRunning` field to `ActionVisibilityContext` interface to track execution state
   - Added `RunSetupScript` and `RunCleanupScript` workspace action definitions
   - Both actions use the existing `attemptsApi.runSetupScript/runCleanupScript` API methods
   - Actions are automatically disabled when another process is running

2. **`frontend/src/components/ui-new/actions/pages.ts`**
   - Added a new "Scripts" group to the Workspace Actions page containing both script actions

3. **`frontend/src/components/ui-new/actions/useActionVisibility.ts`**
   - Imported `useExecutionProcessesContext` to access execution state
   - Added `isAttemptRunningVisible` to the visibility context

### Error Handling
- Displays user-friendly error messages for:
  - `no_script_configured`: "No setup/cleanup script configured for this project"
  - `process_already_running`: "Cannot run script while another process is running"

## How to Test

1. Navigate to the new UI (`/workspaces`)
2. Select a workspace
3. Open the command bar (CMD+K)
4. Navigate to "Workspace Actions"
5. Look for the "Scripts" group with "Run Setup Script" and "Run Cleanup Script" options
6. Verify actions are disabled while an agent or script is running

---

This PR was written using [Vibe Kanban](https://vibekanban.com)