### PR TITLE
Navigate away when deleting the currently selected workspace (Vibe Kanban)

### DIFF
--- a/frontend/src/components/ui-new/actions/index.ts
+++ b/frontend/src/components/ui-new/actions/index.ts
@@ -191,8 +191,7 @@ function getNextWorkspaceId(
   );
   if (currentIndex >= 0 && activeWorkspaces.length > 1) {
     const nextWorkspace =
-      activeWorkspaces[currentIndex + 1] ||
-      activeWorkspaces[currentIndex - 1];
+      activeWorkspaces[currentIndex + 1] || activeWorkspaces[currentIndex - 1];
     return nextWorkspace?.id ?? null;
   }
   return null;


### PR DESCRIPTION
## Summary

When deleting a workspace that is currently selected/viewed, the app now automatically navigates to an adjacent workspace instead of staying on the deleted workspace's URL (which would leave the UI in an invalid state).

## Changes

- Added `getNextWorkspaceId` helper function to find the next workspace to navigate to when removing the current workspace from the active list
- Updated `DeleteWorkspace` action to:
  - Check if the workspace being deleted is the currently viewed workspace
  - Calculate the next workspace (next sibling, or previous if at end of list) before deletion
  - Navigate to the next workspace after successful deletion
  - Fall back to `/workspaces/create` if no other workspaces exist
- Refactored `ArchiveWorkspace` to use the same helper function for consistency and reduced code duplication

## Implementation Details

The navigation logic only triggers when deleting the **current** workspace (identified via `ctx.currentWorkspaceId`). Deleting a workspace from the sidebar that isn't currently selected does not trigger navigation.

The helper function `getNextWorkspaceId` prefers the next workspace in the list, falling back to the previous one if the deleted workspace was at the end.

---

This PR was written using [Vibe Kanban](https://vibekanban.com)