### PR TITLE
Prevent WYSIWYG editor focus loss when clicking sidebar '+' button (Vibe Kanban)

### DIFF
--- a/frontend/src/components/ui-new/primitives/SectionHeader.tsx
+++ b/frontend/src/components/ui-new/primitives/SectionHeader.tsx
@@ -26,6 +26,7 @@ export function SectionHeader({
         <button
           type="button"
           onClick={onIconClick}
+          onMouseDown={(e) => e.preventDefault()}
           className="text-low hover:text-normal"
         >
           <IconComponent className="size-icon-xs" weight="bold" />


### PR DESCRIPTION
## Summary

- Added `onMouseDown={(e) => e.preventDefault()}` to the button in `SectionHeader.tsx` to prevent the browser's default focus behavior

## Why

When the WYSIWYG editor in the Create Workspace view is focused and the user clicks the '+' button in the sidebar header, the editor would lose focus. This is because clicking a button element naturally moves browser focus to that button.

## Implementation Details

The fix uses `e.preventDefault()` on the `mousedown` event, which prevents the default focus change while still allowing the `onClick` handler to fire normally. This is a common pattern already used elsewhere in the codebase (e.g., in the WYSIWYG toolbar buttons) for the same purpose.

**File changed:** `frontend/src/components/ui-new/primitives/SectionHeader.tsx`

---

This PR was written using [Vibe Kanban](https://vibekanban.com)