### PR TITLE
Fix worktree recreation when directory exists without git metadata

### DIFF
--- a/crates/services/src/services/worktree_manager.rs
+++ b/crates/services/src/services/worktree_manager.rs
@@ -170,8 +170,12 @@ impl WorktreeManager {
 
             // Check 2: Worktree must be registered in git metadata using find_worktree
             let repo = Repository::open(&repo_path).map_err(WorktreeError::Git)?;
-            let worktree_name = Self::find_worktree_git_internal_name(&repo_path, &worktree_path)?
-                .ok_or_else(|| WorktreeError::InvalidPath("Invalid worktree path".to_string()))?;
+            let Some(worktree_name) =
+                Self::find_worktree_git_internal_name(&repo_path, &worktree_path)?
+            else {
+                // Directory exists but not registered in git metadata - needs recreation
+                return Ok(false);
+            };
 
             // Try to find the worktree - if it exists and is valid, we're good
             match repo.find_worktree(&worktree_name) {


### PR DESCRIPTION
## Summary
- Fix `is_worktree_properly_set_up` to return `Ok(false)` instead of throwing `InvalidPath` error when a worktree directory exists but has no corresponding `.git/worktrees/` metadata entry
- This allows the recreation flow to clean up and reinitialize the worktree properly

## Problem
When a workspace directory exists on disk but lacks git worktree metadata (no `.git` file, no entry in the repo's `.git/worktrees/`), the function was throwing an error:
```
Failed to recreate worktree before log normalization for workspace X: Invalid path: Invalid worktree path
```

This prevented recovery and blocked operations like log normalization.

## Solution
Changed the logic from:
```rust
let worktree_name = Self::find_worktree_git_internal_name(&repo_path, &worktree_path)?
    .ok_or_else(|| WorktreeError::InvalidPath("Invalid worktree path".to_string()))?;
```

To:
```rust
let Some(worktree_name) = Self::find_worktree_git_internal_name(&repo_path, &worktree_path)? else {
    // Directory exists but not registered in git metadata - needs recreation
    return Ok(false);
};
```

Now when a directory exists without git metadata, the function returns `Ok(false)` which triggers the recreation flow to clean up and create a fresh worktree.

## Test plan
- [x] `cargo check -p services` passes
- [ ] Verify worktree recreation works for workspaces with orphaned directories

🤖 Generated with [Claude Code](https://claude.com/claude-code)