### PR TITLE
Translate README.md to French (Vibe Kanban)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,40 +3,40 @@
     <picture>
       <source srcset="frontend/public/vibe-kanban-logo-dark.svg" media="(prefers-color-scheme: dark)">
       <source srcset="frontend/public/vibe-kanban-logo.svg" media="(prefers-color-scheme: light)">
-      <img src="frontend/public/vibe-kanban-logo.svg" alt="Vibe Kanban Logo">
+      <img src="frontend/public/vibe-kanban-logo.svg" alt="Logo Vibe Kanban">
     </picture>
   </a>
 </p>
 
-<p align="center">Get 10X more out of Claude Code, Gemini CLI, Codex, Amp and other coding agents...</p>
+<p align="center">Tirez 10X plus de Claude Code, Gemini CLI, Codex, Amp et d'autres agents de codage...</p>
 <p align="center">
   <a href="https://www.npmjs.com/package/vibe-kanban"><img alt="npm" src="https://img.shields.io/npm/v/vibe-kanban?style=flat-square" /></a>
-  <a href="https://github.com/BloopAI/vibe-kanban/blob/main/.github/workflows/publish.yml"><img alt="Build status" src="https://img.shields.io/github/actions/workflow/status/BloopAI/vibe-kanban/.github%2Fworkflows%2Fpublish.yml" /></a>
-  <a href="https://deepwiki.com/BloopAI/vibe-kanban"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki"></a>
+  <a href="https://github.com/BloopAI/vibe-kanban/blob/main/.github/workflows/publish.yml"><img alt="Statut de build" src="https://img.shields.io/github/actions/workflow/status/BloopAI/vibe-kanban/.github%2Fworkflows%2Fpublish.yml" /></a>
+  <a href="https://deepwiki.com/BloopAI/vibe-kanban"><img src="https://deepwiki.com/badge.svg" alt="Demander à DeepWiki"></a>
 </p>
 
 <h1 align="center">
-  <a href="https://jobs.polymer.co/vibe-kanban?source=github"><strong>We're hiring!</strong></a>
+  <a href="https://jobs.polymer.co/vibe-kanban?source=github"><strong>Nous recrutons !</strong></a>
 </h1>
 
 ![](frontend/public/vibe-kanban-screenshot-overview.png)
 
-## Overview
+## Aperçu
 
-AI coding agents are increasingly writing the world's code and human engineers now spend the majority of their time planning, reviewing, and orchestrating tasks. Vibe Kanban streamlines this process, enabling you to:
+Les agents de codage IA écrivent de plus en plus le code du monde et les ingénieurs humains passent désormais la majorité de leur temps à planifier, réviser et orchestrer des tâches. Vibe Kanban simplifie ce processus, vous permettant de :
 
-- Easily switch between different coding agents
-- Orchestrate the execution of multiple coding agents in parallel or in sequence
-- Quickly review work and start dev servers
-- Track the status of tasks that your coding agents are working on
-- Centralise configuration of coding agent MCP configs
-- Open projects remotely via SSH when running Vibe Kanban on a remote server
+- Basculer facilement entre différents agents de codage
+- Orchestrer l'exécution de plusieurs agents de codage en parallèle ou en séquence
+- Réviser rapidement le travail et démarrer des serveurs de développement
+- Suivre le statut des tâches sur lesquelles vos agents de codage travaillent
+- Centraliser la configuration des configs MCP des agents de codage
+- Ouvrir des projets à distance via SSH lorsque Vibe Kanban fonctionne sur un serveur distant
 
-You can watch a video overview [here](https://youtu.be/TFT3KnZOOAk).
+Vous pouvez regarder une vidéo de présentation [ici](https://youtu.be/TFT3KnZOOAk).
 
 ## Installation
 
-Make sure you have authenticated with your favourite coding agent. A full list of supported coding agents can be found in the [docs](https://vibekanban.com/docs). Then in your terminal run:
+Assurez-vous d'être authentifié avec votre agent de codage préféré. Une liste complète des agents de codage pris en charge se trouve dans la [documentation](https://vibekanban.com/docs). Ensuite, dans votre terminal, exécutez :
 
 ```bash
 npx vibe-kanban
@@ -44,87 +44,87 @@ npx vibe-kanban
 
 ## Documentation
 
-Please head to the [website](https://vibekanban.com/docs) for the latest documentation and user guides.
+Veuillez consulter le [site web](https://vibekanban.com/docs) pour la documentation la plus récente et les guides d'utilisation.
 
 ## Support
 
-We use [GitHub Discussions](https://github.com/BloopAI/vibe-kanban/discussions) for feature requests. Please open a discussion to create a feature request. For bugs please open an issue on this repo.
+Nous utilisons les [Discussions GitHub](https://github.com/BloopAI/vibe-kanban/discussions) pour les demandes de fonctionnalités. Veuillez ouvrir une discussion pour créer une demande de fonctionnalité. Pour les bugs, veuillez ouvrir une issue sur ce dépôt.
 
-## Contributing
+## Contribuer
 
-We would prefer that ideas and changes are first raised with the core team via [GitHub Discussions](https://github.com/BloopAI/vibe-kanban/discussions) or [Discord](https://discord.gg/AC4nwVtJM3), where we can discuss implementation details and alignment with the existing roadmap. Please do not open PRs without first discussing your proposal with the team.
+Nous préférons que les idées et les changements soient d'abord soumis à l'équipe principale via les [Discussions GitHub](https://github.com/BloopAI/vibe-kanban/discussions) ou [Discord](https://discord.gg/AC4nwVtJM3), où nous pouvons discuter des détails d'implémentation et de l'alignement avec la feuille de route existante. Veuillez ne pas ouvrir de PRs sans avoir d'abord discuté de votre proposition avec l'équipe.
 
-## Development
+## Développement
 
-### Prerequisites
+### Prérequis
 
-- [Rust](https://rustup.rs/) (latest stable)
+- [Rust](https://rustup.rs/) (dernière version stable)
 - [Node.js](https://nodejs.org/) (>=18)
 - [pnpm](https://pnpm.io/) (>=8)
 
-Additional development tools:
+Outils de développement supplémentaires :
 ```bash
 cargo install cargo-watch
 cargo install sqlx-cli
 ```
 
-Install dependencies:
+Installer les dépendances :
 ```bash
 pnpm i
 ```
 
-### Running the dev server
+### Lancer le serveur de développement
 
 ```bash
 pnpm run dev
 ```
 
-This will start the backend. A blank DB will be copied from the `dev_assets_seed` folder.
+Cela démarrera le backend. Une base de données vide sera copiée depuis le dossier `dev_assets_seed`.
 
-### Building the frontend
+### Compiler le frontend
 
-To build just the frontend:
+Pour compiler uniquement le frontend :
 
 ```bash
 cd frontend
 pnpm build
 ```
 
-### Build from source (macOS)
+### Compiler depuis les sources (macOS)
 
-1. Run `./local-build.sh`
-2. Test with `cd npx-cli && node bin/cli.js`
+1. Exécutez `./local-build.sh`
+2. Testez avec `cd npx-cli && node bin/cli.js`
 
 
-### Environment Variables
+### Variables d'environnement
 
-The following environment variables can be configured at build time or runtime:
+Les variables d'environnement suivantes peuvent être configurées au moment de la compilation ou à l'exécution :
 
-| Variable | Type | Default | Description |
-|----------|------|---------|-------------|
-| `POSTHOG_API_KEY` | Build-time | Empty | PostHog analytics API key (disables analytics if empty) |
-| `POSTHOG_API_ENDPOINT` | Build-time | Empty | PostHog analytics endpoint (disables analytics if empty) |
-| `PORT` | Runtime | Auto-assign | **Production**: Server port. **Dev**: Frontend port (backend uses PORT+1) |
-| `BACKEND_PORT` | Runtime | `0` (auto-assign) | Backend server port (dev mode only, overrides PORT+1) |
-| `FRONTEND_PORT` | Runtime | `3000` | Frontend dev server port (dev mode only, overrides PORT) |
-| `HOST` | Runtime | `127.0.0.1` | Backend server host |
-| `DISABLE_WORKTREE_ORPHAN_CLEANUP` | Runtime | Not set | Disable git worktree cleanup (for debugging) |
+| Variable | Type | Défaut | Description |
+|----------|------|--------|-------------|
+| `POSTHOG_API_KEY` | Compilation | Vide | Clé API PostHog analytics (désactive les analytics si vide) |
+| `POSTHOG_API_ENDPOINT` | Compilation | Vide | Point de terminaison PostHog analytics (désactive les analytics si vide) |
+| `PORT` | Exécution | Auto-assigné | **Production** : Port du serveur. **Dev** : Port du frontend (le backend utilise PORT+1) |
+| `BACKEND_PORT` | Exécution | `0` (auto-assigné) | Port du serveur backend (mode dev uniquement, remplace PORT+1) |
+| `FRONTEND_PORT` | Exécution | `3000` | Port du serveur de dev frontend (mode dev uniquement, remplace PORT) |
+| `HOST` | Exécution | `127.0.0.1` | Hôte du serveur backend |
+| `DISABLE_WORKTREE_ORPHAN_CLEANUP` | Exécution | Non défini | Désactive le nettoyage des worktrees git (pour le débogage) |
 
-**Build-time variables** must be set when running `pnpm run build`. **Runtime variables** are read when the application starts.
+**Les variables de compilation** doivent être définies lors de l'exécution de `pnpm run build`. **Les variables d'exécution** sont lues au démarrage de l'application.
 
-### Remote Deployment
+### Déploiement distant
 
-When running Vibe Kanban on a remote server (e.g., via systemctl, Docker, or cloud hosting), you can configure your editor to open projects via SSH:
+Lorsque vous exécutez Vibe Kanban sur un serveur distant (par exemple via systemctl, Docker ou l'hébergement cloud), vous pouvez configurer votre éditeur pour ouvrir des projets via SSH :
 
-1. **Access via tunnel**: Use Cloudflare Tunnel, ngrok, or similar to expose the web UI
-2. **Configure remote SSH** in Settings → Editor Integration:
-   - Set **Remote SSH Host** to your server hostname or IP
-   - Set **Remote SSH User** to your SSH username (optional)
-3. **Prerequisites**:
-   - SSH access from your local machine to the remote server
-   - SSH keys configured (passwordless authentication)
-   - VSCode Remote-SSH extension
+1. **Accès via tunnel** : Utilisez Cloudflare Tunnel, ngrok ou similaire pour exposer l'interface web
+2. **Configurer le SSH distant** dans Paramètres → Intégration éditeur :
+   - Définissez **Hôte SSH distant** sur le nom d'hôte ou l'IP de votre serveur
+   - Définissez **Utilisateur SSH distant** sur votre nom d'utilisateur SSH (optionnel)
+3. **Prérequis** :
+   - Accès SSH depuis votre machine locale vers le serveur distant
+   - Clés SSH configurées (authentification sans mot de passe)
+   - Extension VSCode Remote-SSH
 
-When configured, the "Open in VSCode" buttons will generate URLs like `vscode://vscode-remote/ssh-remote+user@host/path` that open your local editor and connect to the remote server.
+Une fois configuré, les boutons "Ouvrir dans VSCode" généreront des URLs comme `vscode://vscode-remote/ssh-remote+user@host/path` qui ouvriront votre éditeur local et se connecteront au serveur distant.
 
-See the [documentation](https://vibekanban.com/docs/configuration-customisation/global-settings#remote-ssh-configuration) for detailed setup instructions.
+Consultez la [documentation](https://vibekanban.com/docs/configuration-customisation/global-settings#remote-ssh-configuration) pour des instructions de configuration détaillées.


### PR DESCRIPTION
## Summary

This PR translates the entire README.md file from English to French, making the project documentation accessible to French-speaking developers and contributors.

## Changes Made

- Translated all section headers (Overview → Aperçu, Contributing → Contribuer, Development → Développement, etc.)
- Translated all descriptive text and instructions
- Translated the environment variables table including column headers and descriptions
- Translated UI element references (e.g., "Settings → Editor Integration" → "Paramètres → Intégration éditeur")
- Preserved all code blocks, commands, URLs, and technical identifiers unchanged
- Maintained the original markdown structure and formatting

## Implementation Details

- Technical terms like "backend", "frontend", "SSH", "MCP", and command names remain in English for clarity
- All external links (documentation, npm, GitHub) are preserved
- Badge alt texts were translated for accessibility
- The hiring banner was translated: "We're hiring!" → "Nous recrutons !"

---

This PR was written using [Vibe Kanban](https://vibekanban.com)