### PR TITLE
fix(services): support git worktree repo paths

### DIFF
--- a/crates/services/src/services/worktree_manager.rs
+++ b/crates/services/src/services/worktree_manager.rs
@@ -215,18 +215,10 @@ impl WorktreeManager {
             let gitdir_path = entry.path().join("gitdir");
             if gitdir_path.exists()
                 && let Ok(gitdir_content) = fs::read_to_string(&gitdir_path)
-                && {
-                    let raw_gitdir_path = Path::new(gitdir_content.trim());
-                    let resolved_gitdir_path = if raw_gitdir_path.is_absolute() {
-                        raw_gitdir_path.to_path_buf()
-                    } else {
-                        entry.path().join(raw_gitdir_path)
-                    };
-                    normalize_macos_private_alias(&resolved_gitdir_path)
-                        .parent()
-                        .map(canonicalize_for_compare)
-                        .is_some_and(|p| p == worktree_root)
-                }
+                && normalize_macos_private_alias(Path::new(gitdir_content.trim()))
+                    .parent()
+                    .map(canonicalize_for_compare)
+                    .is_some_and(|p| p == worktree_root)
             {
                 return Ok(Some(entry.file_name().to_string_lossy().to_string()));
             }


### PR DESCRIPTION
Fixes #1814

### What
- Resolve worktree metadata path using `git2::Repository::commondir()` so `repo_path` can be a git worktree (where `.git` is a file).
- Use the same resolved path for worktree metadata cleanup.
- Add regression test: `crates/services/tests/worktree_manager_repo_path_worktree.rs`.

### Testing
- `cargo test -p services`
