### PR TITLE
Fix dev server visibility when switching sessions within a workspace (Vibe Kanban)

### DIFF
--- a/crates/db/.sqlx/query-f7ba5cadd0a4271ae01ad71cd520f685542d2476ae9dbe9c295d613c2a77d1e9.json
+++ b/crates/db/.sqlx/query-f7ba5cadd0a4271ae01ad71cd520f685542d2476ae9dbe9c295d613c2a77d1e9.json
@@ -1,0 +1,80 @@
+{
+  "db_name": "SQLite",
+  "query": "\n        SELECT\n            ep.id as \"id!: Uuid\",\n            ep.session_id as \"session_id!: Uuid\",\n            ep.run_reason as \"run_reason!: ExecutionProcessRunReason\",\n            ep.executor_action as \"executor_action!: sqlx::types::Json<ExecutorActionField>\",\n            ep.status as \"status!: ExecutionProcessStatus\",\n            ep.exit_code,\n            ep.dropped as \"dropped!: bool\",\n            ep.started_at as \"started_at!: DateTime<Utc>\",\n            ep.completed_at as \"completed_at?: DateTime<Utc>\",\n            ep.created_at as \"created_at!: DateTime<Utc>\",\n            ep.updated_at as \"updated_at!: DateTime<Utc>\"\n        FROM execution_processes ep\n        JOIN sessions s ON ep.session_id = s.id\n        WHERE s.workspace_id = ?\n          AND ep.run_reason = 'devserver'\n        ORDER BY ep.created_at DESC\n        ",
+  "describe": {
+    "columns": [
+      {
+        "name": "id!: Uuid",
+        "ordinal": 0,
+        "type_info": "Blob"
+      },
+      {
+        "name": "session_id!: Uuid",
+        "ordinal": 1,
+        "type_info": "Blob"
+      },
+      {
+        "name": "run_reason!: ExecutionProcessRunReason",
+        "ordinal": 2,
+        "type_info": "Text"
+      },
+      {
+        "name": "executor_action!: sqlx::types::Json<ExecutorActionField>",
+        "ordinal": 3,
+        "type_info": "Text"
+      },
+      {
+        "name": "status!: ExecutionProcessStatus",
+        "ordinal": 4,
+        "type_info": "Text"
+      },
+      {
+        "name": "exit_code",
+        "ordinal": 5,
+        "type_info": "Integer"
+      },
+      {
+        "name": "dropped!: bool",
+        "ordinal": 6,
+        "type_info": "Integer"
+      },
+      {
+        "name": "started_at!: DateTime<Utc>",
+        "ordinal": 7,
+        "type_info": "Text"
+      },
+      {
+        "name": "completed_at?: DateTime<Utc>",
+        "ordinal": 8,
+        "type_info": "Text"
+      },
+      {
+        "name": "created_at!: DateTime<Utc>",
+        "ordinal": 9,
+        "type_info": "Text"
+      },
+      {
+        "name": "updated_at!: DateTime<Utc>",
+        "ordinal": 10,
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      true,
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      false,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "f7ba5cadd0a4271ae01ad71cd520f685542d2476ae9dbe9c295d613c2a77d1e9"
+}

--- a/crates/services/src/services/events/streams.rs
+++ b/crates/services/src/services/events/streams.rs
@@ -1,7 +1,8 @@
 use db::models::{
-    execution_process::ExecutionProcess,
+    execution_process::{ExecutionProcess, ExecutionProcessRunReason},
     project::Project,
     scratch::Scratch,
+    session::Session,
     task::{Task, TaskWithAttemptStatus},
     workspace::Workspace,
 };
@@ -336,6 +337,111 @@ impl EventService {
                                             if *deleted_session_id == session_id {
                                                 return Some(Ok(LogMsg::JsonPatch(patch)));
                                             }
+                                        }
+                                        _ => {}
+                                    }
+                                }
+                            }
+                            None
+                        }
+                        Ok(other) => Some(Ok(other)), // Pass through non-patch messages
+                        Err(_) => None,               // Filter out broadcast errors
+                    }
+                }
+            });
+
+        // Start with initial snapshot, Ready signal, then live updates
+        let initial_stream = futures::stream::iter(vec![Ok(initial_msg), Ok(LogMsg::Ready)]);
+        let combined_stream = initial_stream.chain(filtered_stream).boxed();
+
+        Ok(combined_stream)
+    }
+
+    /// Stream dev server processes for a specific workspace (across all sessions) with initial snapshot
+    pub async fn stream_dev_servers_for_workspace_raw(
+        &self,
+        workspace_id: Uuid,
+    ) -> Result<futures::stream::BoxStream<'static, Result<LogMsg, std::io::Error>>, EventError>
+    {
+        // Get all dev server processes for this workspace (across all sessions)
+        let processes =
+            ExecutionProcess::find_dev_servers_by_workspace(&self.db.pool, workspace_id).await?;
+
+        // Convert processes array to object keyed by process ID
+        let processes_map: serde_json::Map<String, serde_json::Value> = processes
+            .into_iter()
+            .map(|process| {
+                (
+                    process.id.to_string(),
+                    serde_json::to_value(process).unwrap(),
+                )
+            })
+            .collect();
+
+        let initial_patch = json!([{
+            "op": "replace",
+            "path": "/execution_processes",
+            "value": processes_map
+        }]);
+        let initial_msg = LogMsg::JsonPatch(serde_json::from_value(initial_patch).unwrap());
+
+        // Clone necessary data for the async filter
+        let db_pool = self.db.pool.clone();
+
+        // Get filtered event stream - only dev server processes for this workspace
+        let filtered_stream =
+            BroadcastStream::new(self.msg_store.get_receiver()).filter_map(move |msg_result| {
+                let db_pool = db_pool.clone();
+                async move {
+                    match msg_result {
+                        Ok(LogMsg::JsonPatch(patch)) => {
+                            // Filter events based on workspace_id and run_reason
+                            if let Some(patch_op) = patch.0.first() {
+                                // Check if this is an execution process patch
+                                if patch_op.path().starts_with("/execution_processes/") {
+                                    match patch_op {
+                                        json_patch::PatchOperation::Add(op) => {
+                                            // Parse execution process data directly from value
+                                            if let Ok(process) =
+                                                serde_json::from_value::<ExecutionProcess>(
+                                                    op.value.clone(),
+                                                )
+                                                && process.run_reason
+                                                    == ExecutionProcessRunReason::DevServer
+                                            {
+                                                // Check if this process belongs to our workspace
+                                                if let Ok(Some(session)) =
+                                                    Session::find_by_id(&db_pool, process.session_id)
+                                                        .await
+                                                    && session.workspace_id == workspace_id
+                                                {
+                                                    return Some(Ok(LogMsg::JsonPatch(patch)));
+                                                }
+                                            }
+                                        }
+                                        json_patch::PatchOperation::Replace(op) => {
+                                            // Parse execution process data directly from value
+                                            if let Ok(process) =
+                                                serde_json::from_value::<ExecutionProcess>(
+                                                    op.value.clone(),
+                                                )
+                                                && process.run_reason
+                                                    == ExecutionProcessRunReason::DevServer
+                                            {
+                                                // Check if this process belongs to our workspace
+                                                if let Ok(Some(session)) =
+                                                    Session::find_by_id(&db_pool, process.session_id)
+                                                        .await
+                                                    && session.workspace_id == workspace_id
+                                                {
+                                                    return Some(Ok(LogMsg::JsonPatch(patch)));
+                                                }
+                                            }
+                                        }
+                                        json_patch::PatchOperation::Remove(_) => {
+                                            // For remove operations, we can't verify workspace membership
+                                            // so we allow all removals and let the client handle filtering
+                                            return Some(Ok(LogMsg::JsonPatch(patch)));
                                         }
                                         _ => {}
                                     }

--- a/crates/services/src/services/events/streams.rs
+++ b/crates/services/src/services/events/streams.rs
@@ -410,9 +410,11 @@ impl EventService {
                                                     == ExecutionProcessRunReason::DevServer
                                             {
                                                 // Check if this process belongs to our workspace
-                                                if let Ok(Some(session)) =
-                                                    Session::find_by_id(&db_pool, process.session_id)
-                                                        .await
+                                                if let Ok(Some(session)) = Session::find_by_id(
+                                                    &db_pool,
+                                                    process.session_id,
+                                                )
+                                                .await
                                                     && session.workspace_id == workspace_id
                                                 {
                                                     return Some(Ok(LogMsg::JsonPatch(patch)));
@@ -429,9 +431,11 @@ impl EventService {
                                                     == ExecutionProcessRunReason::DevServer
                                             {
                                                 // Check if this process belongs to our workspace
-                                                if let Ok(Some(session)) =
-                                                    Session::find_by_id(&db_pool, process.session_id)
-                                                        .await
+                                                if let Ok(Some(session)) = Session::find_by_id(
+                                                    &db_pool,
+                                                    process.session_id,
+                                                )
+                                                .await
                                                     && session.workspace_id == workspace_id
                                                 {
                                                     return Some(Ok(LogMsg::JsonPatch(patch)));

--- a/frontend/src/components/ui-new/actions/useActionVisibility.ts
+++ b/frontend/src/components/ui-new/actions/useActionVisibility.ts
@@ -4,7 +4,7 @@ import { useDiffViewStore, useDiffViewMode } from '@/stores/useDiffViewStore';
 import { useUiPreferencesStore } from '@/stores/useUiPreferencesStore';
 import { useWorkspaceContext } from '@/contexts/WorkspaceContext';
 import { useUserSystem } from '@/components/ConfigProvider';
-import { useDevServer } from '@/hooks/useDevServer';
+import { usePreviewDevServer } from '../hooks/usePreviewDevServer';
 import { useBranchStatus } from '@/hooks/useBranchStatus';
 import { useExecutionProcessesContext } from '@/contexts/ExecutionProcessesContext';
 import type { Workspace, Merge } from 'shared/types';
@@ -30,7 +30,7 @@ export function useActionVisibilityContext(): ActionVisibilityContext {
   const expanded = useUiPreferencesStore((s) => s.expanded);
   const { config } = useUserSystem();
   const { isStarting, isStopping, runningDevServers } =
-    useDevServer(workspaceId);
+    usePreviewDevServer(workspaceId);
   const { data: branchStatus } = useBranchStatus(workspaceId);
   const { isAttemptRunningVisible } = useExecutionProcessesContext();
 

--- a/frontend/src/components/ui-new/containers/PreviewBrowserContainer.tsx
+++ b/frontend/src/components/ui-new/containers/PreviewBrowserContainer.tsx
@@ -16,12 +16,10 @@ const MIN_RESPONSIVE_WIDTH = 320;
 const MIN_RESPONSIVE_HEIGHT = 480;
 
 interface PreviewBrowserContainerProps {
-  attemptId?: string;
   className?: string;
 }
 
 export function PreviewBrowserContainer({
-  attemptId,
   className,
 }: PreviewBrowserContainerProps) {
   const navigate = useNavigate();
@@ -29,6 +27,7 @@ export function PreviewBrowserContainer({
   const triggerPreviewRefresh = useLayoutStore((s) => s.triggerPreviewRefresh);
   const { repos, workspaceId } = useWorkspaceContext();
 
+  // Use workspace-scoped dev server streaming (visible across all sessions)
   const {
     start,
     stop,
@@ -36,7 +35,7 @@ export function PreviewBrowserContainer({
     isStopping,
     runningDevServers,
     devServerProcesses,
-  } = usePreviewDevServer(attemptId);
+  } = usePreviewDevServer(workspaceId);
 
   const primaryDevServer = runningDevServers[0];
   const { logs } = useLogStream(primaryDevServer?.id ?? '');
@@ -252,7 +251,7 @@ export function PreviewBrowserContainer({
   };
 
   const handleFixDevScript = useCallback(() => {
-    if (!attemptId || repos.length === 0) return;
+    if (!workspaceId || repos.length === 0) return;
 
     // Get session ID from the latest dev server process
     const sessionId = devServerProcesses[0]?.session_id;
@@ -260,11 +259,11 @@ export function PreviewBrowserContainer({
     ScriptFixerDialog.show({
       scriptType: 'dev_server',
       repos,
-      workspaceId: attemptId,
+      workspaceId,
       sessionId,
       initialRepoId: repos.length === 1 ? repos[0].id : undefined,
     });
-  }, [attemptId, repos, devServerProcesses]);
+  }, [workspaceId, repos, devServerProcesses]);
 
   return (
     <PreviewBrowser
@@ -292,7 +291,7 @@ export function PreviewBrowserContainer({
       repos={repos}
       handleEditDevScript={handleEditDevScript}
       handleFixDevScript={
-        attemptId && repos.length > 0 ? handleFixDevScript : undefined
+        workspaceId && repos.length > 0 ? handleFixDevScript : undefined
       }
       hasFailedDevServer={hasFailedDevServer}
       className={className}

--- a/frontend/src/components/ui-new/containers/PreviewControlsContainer.tsx
+++ b/frontend/src/components/ui-new/containers/PreviewControlsContainer.tsx
@@ -6,21 +6,20 @@ import { useLayoutStore } from '@/stores/useLayoutStore';
 import { useWorkspaceContext } from '@/contexts/WorkspaceContext';
 
 interface PreviewControlsContainerProps {
-  attemptId?: string;
   onViewProcessInPanel?: (processId: string) => void;
   className?: string;
 }
 
 export function PreviewControlsContainer({
-  attemptId,
   onViewProcessInPanel,
   className,
 }: PreviewControlsContainerProps) {
-  const { repos } = useWorkspaceContext();
+  const { repos, workspaceId } = useWorkspaceContext();
   const setLogsMode = useLayoutStore((s) => s.setLogsMode);
 
+  // Use workspace-scoped dev server streaming (visible across all sessions)
   const { isStarting, runningDevServers, devServerProcesses } =
-    usePreviewDevServer(attemptId);
+    usePreviewDevServer(workspaceId);
 
   const [activeProcessId, setActiveProcessId] = useState<string | null>(null);
 

--- a/frontend/src/components/ui-new/containers/WorkspacesLayout.tsx
+++ b/frontend/src/components/ui-new/containers/WorkspacesLayout.tsx
@@ -660,7 +660,6 @@ export function WorkspacesLayout() {
         <Allotment vertical onDragEnd={handleFileTreeResize} proportionalLayout>
           <Allotment.Pane minSize={200} preferredSize={fileTreeHeight}>
             <PreviewControlsContainer
-              attemptId={selectedWorkspace?.id}
               onViewProcessInPanel={handleViewProcessInPanel}
             />
           </Allotment.Pane>
@@ -792,9 +791,7 @@ export function WorkspacesLayout() {
                 onMatchIndicesChange={setLogMatchIndices}
               />
             )}
-            {isPreviewMode && (
-              <PreviewBrowserContainer attemptId={selectedWorkspace?.id} />
-            )}
+            {isPreviewMode && <PreviewBrowserContainer />}
           </div>
         </Allotment.Pane>
 

--- a/frontend/src/contexts/ActionsContext.tsx
+++ b/frontend/src/contexts/ActionsContext.tsx
@@ -17,7 +17,7 @@ import {
 } from '@/components/ui-new/actions';
 import { getActionLabel } from '@/components/ui-new/actions/useActionVisibility';
 import { useWorkspaceContext } from '@/contexts/WorkspaceContext';
-import { useDevServer } from '@/hooks/useDevServer';
+import { usePreviewDevServer } from '@/components/ui-new/hooks/usePreviewDevServer';
 
 interface ActionsContextValue {
   // Execute an action with optional workspaceId and repoId (for git actions)
@@ -51,8 +51,8 @@ export function ActionsProvider({ children }: ActionsProviderProps) {
   const { selectWorkspace, activeWorkspaces, workspaceId, workspace } =
     useWorkspaceContext();
 
-  // Get dev server state
-  const { start, stop, runningDevServers } = useDevServer(workspaceId);
+  // Get dev server state (workspace-scoped for cross-session visibility)
+  const { start, stop, runningDevServers } = usePreviewDevServer(workspaceId);
 
   // Build executor context from hooks
   const executorContext = useMemo<ActionExecutorContext>(

--- a/frontend/src/hooks/useWorkspaceDevServers.ts
+++ b/frontend/src/hooks/useWorkspaceDevServers.ts
@@ -1,0 +1,62 @@
+import { useCallback } from 'react';
+import { useJsonPatchWsStream } from './useJsonPatchWsStream';
+import type { ExecutionProcess } from 'shared/types';
+
+type DevServerState = {
+  execution_processes: Record<string, ExecutionProcess>;
+};
+
+interface UseWorkspaceDevServersResult {
+  devServers: ExecutionProcess[];
+  devServersById: Record<string, ExecutionProcess>;
+  runningDevServers: ExecutionProcess[];
+  isLoading: boolean;
+  isConnected: boolean;
+  error: string | null;
+}
+
+/**
+ * Stream dev server processes for a workspace (across all sessions) via WebSocket (JSON Patch).
+ * This enables dev servers to remain visible when switching between sessions within a workspace.
+ * Server sends initial snapshot: replace /execution_processes with an object keyed by id.
+ * Live updates arrive at /execution_processes/<id> via add/replace/remove operations.
+ */
+export function useWorkspaceDevServers(
+  workspaceId: string | undefined
+): UseWorkspaceDevServersResult {
+  let endpoint: string | undefined;
+
+  if (workspaceId) {
+    endpoint = `/api/execution-processes/stream/workspace-dev-servers/ws?workspace_id=${workspaceId}`;
+  }
+
+  const initialData = useCallback(
+    (): DevServerState => ({ execution_processes: {} }),
+    []
+  );
+
+  const { data, isConnected, isInitialized, error } =
+    useJsonPatchWsStream<DevServerState>(endpoint, !!workspaceId, initialData);
+
+  const devServersById = data?.execution_processes ?? {};
+  const devServers = Object.values(devServersById).sort(
+    (a, b) =>
+      new Date(b.created_at as unknown as string).getTime() -
+      new Date(a.created_at as unknown as string).getTime()
+  );
+
+  const runningDevServers = devServers.filter(
+    (process) => process.status === 'running'
+  );
+
+  const isLoading = !!workspaceId && !isInitialized && !error;
+
+  return {
+    devServers,
+    devServersById,
+    runningDevServers,
+    isLoading,
+    isConnected,
+    error,
+  };
+}


### PR DESCRIPTION
## Summary

This PR fixes a bug where dev servers would disappear from the preview panel when switching between sessions within the same workspace. The root cause was that the `ActionsContext` was using a session-scoped hook (`useDevServer`), which caused `runningDevServers` to be empty when viewing a different session than the one that started the dev server.

## Changes

### Backend (Rust)

- **New database query** (`crates/db/src/models/execution_process.rs`): Added `find_dev_servers_by_workspace()` to query dev servers across all sessions in a workspace
- **New WebSocket endpoint** (`crates/server/src/routes/execution_processes.rs`): Added `/stream/workspace-dev-servers/ws?workspace_id={id}` for workspace-scoped dev server streaming
- **Server-side filtering** (`crates/services/src/services/events/streams.rs`): Implemented `stream_dev_servers_for_workspace_raw()` that streams only dev server processes belonging to the specified workspace

### Frontend (React/TypeScript)

- **New hook** (`frontend/src/hooks/useWorkspaceDevServers.ts`): Low-level hook that connects to the workspace dev servers WebSocket stream
- **Updated `usePreviewDevServer`** (`frontend/src/components/ui-new/hooks/usePreviewDevServer.ts`): Changed from session-scoped to workspace-scoped data source
- **Fixed `ActionsContext`** (`frontend/src/contexts/ActionsContext.tsx`): Switched from `useDevServer` to `usePreviewDevServer` for workspace-scoped visibility
- **Updated preview components**: Removed unnecessary `attemptId` prop since workspace ID is now sourced from context

## Why These Changes

Previously, dev servers were tracked at the session level. When a user started a dev server in Session A, then switched to Session B, the preview panel would show no running dev server because Session B's execution processes didn't include the dev server from Session A.

With this change, dev servers are now tracked at the workspace level, making them visible regardless of which session is currently active. This matches user expectations since dev servers are workspace-wide resources.

## Implementation Details

- The new WebSocket endpoint filters events server-side, only sending dev server processes that belong to sessions within the target workspace
- Uses JSON Patch protocol (RFC 6902) for efficient incremental updates
- Follows existing patterns in the codebase (`useJsonPatchWsStream`, similar streaming endpoints)

---

This PR was written using [Vibe Kanban](https://vibekanban.com)