### PR TITLE
Fix right sidebar toggle using incorrect left-facing icon (Vibe Kanban)

### DIFF
--- a/frontend/src/components/ui-new/actions/index.ts
+++ b/frontend/src/components/ui-new/actions/index.ts
@@ -1,4 +1,5 @@
-import type { Icon } from '@phosphor-icons/react';
+import { forwardRef, createElement } from 'react';
+import type { Icon, IconProps } from '@phosphor-icons/react';
 import type { NavigateFunction } from 'react-router-dom';
 import type { QueryClient } from '@tanstack/react-query';
 import type { EditorType, ExecutionProcess, Workspace } from 'shared/types';
@@ -49,6 +50,17 @@ import { CreatePRDialog } from '@/components/dialogs/tasks/CreatePRDialog';
 import { getIdeName } from '@/components/ide/IdeIcon';
 import { EditorSelectionDialog } from '@/components/dialogs/tasks/EditorSelectionDialog';
 import { StartReviewDialog } from '@/components/dialogs/tasks/StartReviewDialog';
+
+// Mirrored sidebar icon for right sidebar toggle
+const RightSidebarIcon: Icon = forwardRef<SVGSVGElement, IconProps>(
+  (props, ref) =>
+    createElement(SidebarSimpleIcon, {
+      ref,
+      ...props,
+      style: { transform: 'scaleX(-1)', ...props.style },
+    })
+);
+RightSidebarIcon.displayName = 'RightSidebarIcon';
 
 // Special icon types for ContextBar
 export type SpecialIconType = 'ide-icon' | 'copy-icon';
@@ -440,7 +452,7 @@ export const Actions = {
       useLayoutStore.getState().isGitPanelVisible
         ? 'Hide Git Panel'
         : 'Show Git Panel',
-    icon: SidebarSimpleIcon,
+    icon: RightSidebarIcon,
     requiresTarget: false,
     isActive: (ctx) => ctx.isGitPanelVisible,
     execute: () => {


### PR DESCRIPTION
## Summary

Fixed the right sidebar (Git Panel) toggle button using the wrong icon direction. Both the left sidebar toggle and right sidebar toggle were using `SidebarSimpleIcon`, which visually points left. The right sidebar toggle should use a mirrored icon to indicate it controls the right panel.

## Changes

- Created `RightSidebarIcon` component that wraps `SidebarSimpleIcon` with CSS `transform: scaleX(-1)` to mirror it horizontally
- Updated `ToggleGitPanel` action to use `RightSidebarIcon` instead of `SidebarSimpleIcon`

## Implementation Details

The fix uses React's `forwardRef` and `createElement` to create a proper Phosphor Icon-compatible component that:
- Passes through all icon props (className, weight, etc.)
- Applies horizontal mirroring via CSS transform
- Maintains the same visual style as the left sidebar icon

**File modified:** `frontend/src/components/ui-new/actions/index.ts`

---

This PR was written using [Vibe Kanban](https://vibekanban.com)