### PR TITLE
fix: resolve ESLint tsconfig.json path using absolute path

### DIFF
--- a/frontend/.eslintrc.cjs
+++ b/frontend/.eslintrc.cjs
@@ -1,3 +1,5 @@
+const path = require('path');
+
 const i18nCheck = process.env.LINT_I18N === 'true';
 
 // Presentational components - these must be stateless and receive all data via props
@@ -26,7 +28,7 @@ module.exports = {
   parserOptions: {
     ecmaVersion: 'latest',
     sourceType: 'module',
-    project: './tsconfig.json',
+    project: path.join(__dirname, 'tsconfig.json'),
   },
   rules: {
     'eslint-comments/no-use': ['error', { allow: [] }],


### PR DESCRIPTION
Fix parsing error where ESLint was trying to read tsconfig.json from root directory instead of frontend directory. Use path.join(__dirname, 'tsconfig.json') to ensure correct resolution.