### PR TITLE
feat: remember panel mode per workspace (Vibe Kanban)

### DIFF
--- a/frontend/src/components/ui-new/containers/WorkspacesLayout.tsx
+++ b/frontend/src/components/ui-new/containers/WorkspacesLayout.tsx
@@ -36,6 +36,7 @@ import { useDiffStream } from '@/hooks/useDiffStream';
 import { useTask } from '@/hooks/useTask';
 import { useAttemptRepo } from '@/hooks/useAttemptRepo';
 import { useBranchStatus } from '@/hooks/useBranchStatus';
+import { useWorkspacePanelMode } from '@/hooks/useWorkspacePanelMode';
 import {
   PERSIST_KEYS,
   useExpandedAll,
@@ -299,6 +300,9 @@ export function WorkspacesLayout() {
     setSidebarVisible,
     setMainPanelVisible,
   } = useLayoutStore();
+
+  // Sync panel mode with workspace-specific persistence
+  useWorkspacePanelMode(selectedWorkspaceId, isCreateMode);
 
   const [rightMainPanelSize, setRightMainPanelSize] = usePaneSize(
     PERSIST_KEYS.rightMainPanel,

--- a/frontend/src/hooks/useWorkspacePanelMode.ts
+++ b/frontend/src/hooks/useWorkspacePanelMode.ts
@@ -1,0 +1,80 @@
+import { useEffect, useRef } from 'react';
+import { useLayoutStore } from '@/stores/useLayoutStore';
+import {
+  usePersistedPanelMode,
+  type PanelMode,
+} from '@/stores/useUiPreferencesStore';
+
+/**
+ * Hook that syncs panel mode (changes/logs/preview) between
+ * the global layout store and workspace-specific persistence.
+ *
+ * When workspace changes, restores the persisted mode for that workspace.
+ * When mode changes, saves it for the current workspace.
+ */
+export function useWorkspacePanelMode(
+  workspaceId: string | undefined,
+  isCreateMode: boolean = false
+) {
+  const [persistedMode, setPersistedMode] = usePersistedPanelMode(workspaceId);
+  const {
+    isChangesMode,
+    isLogsMode,
+    isPreviewMode,
+    setChangesMode,
+    setLogsMode,
+    setPreviewMode,
+  } = useLayoutStore();
+
+  // Track the previous workspace ID to detect changes
+  const prevWorkspaceIdRef = useRef<string | undefined>(undefined);
+  // Track whether we're in the middle of restoring to avoid save loop
+  const isRestoringRef = useRef(false);
+
+  // Derive current mode from layout store
+  const currentMode: PanelMode = isChangesMode
+    ? 'changes'
+    : isLogsMode
+      ? 'logs'
+      : isPreviewMode
+        ? 'preview'
+        : null;
+
+  // When workspace changes, restore the persisted mode
+  useEffect(() => {
+    if (workspaceId && workspaceId !== prevWorkspaceIdRef.current) {
+      isRestoringRef.current = true;
+      prevWorkspaceIdRef.current = workspaceId;
+
+      // Restore persisted mode for this workspace
+      if (persistedMode === 'changes') {
+        setChangesMode(true);
+      } else if (persistedMode === 'logs') {
+        setLogsMode(true);
+      } else if (persistedMode === 'preview') {
+        setPreviewMode(true);
+      } else {
+        // No mode was active - ensure all are off
+        setChangesMode(false);
+        setLogsMode(false);
+        setPreviewMode(false);
+      }
+
+      // Allow saves after restore completes
+      requestAnimationFrame(() => {
+        isRestoringRef.current = false;
+      });
+    }
+  }, [workspaceId, persistedMode, setChangesMode, setLogsMode, setPreviewMode]);
+
+  // When mode changes, persist it for the current workspace
+  useEffect(() => {
+    // Don't persist during create mode or while restoring
+    if (isCreateMode || isRestoringRef.current) return;
+
+    // Only persist if we have a workspace and it matches the current one
+    if (workspaceId && prevWorkspaceIdRef.current === workspaceId) {
+      setPersistedMode(currentMode);
+    }
+  }, [workspaceId, currentMode, setPersistedMode, isCreateMode]);
+}

--- a/frontend/src/stores/useUiPreferencesStore.ts
+++ b/frontend/src/stores/useUiPreferencesStore.ts
@@ -11,6 +11,8 @@ export type ContextBarPosition =
   | 'bottom-left'
   | 'bottom-right';
 
+export type PanelMode = 'changes' | 'logs' | 'preview' | null;
+
 // Centralized persist keys for type safety
 export const PERSIST_KEYS = {
   // Sidebar sections
@@ -68,6 +70,7 @@ type State = {
   contextBarPosition: ContextBarPosition;
   paneSizes: Record<string, number | string>;
   collapsedPaths: Record<string, string[]>;
+  panelModes: Record<string, PanelMode>;
   setRepoAction: (repoId: string, action: RepoAction) => void;
   setExpanded: (key: string, value: boolean) => void;
   toggleExpanded: (key: string, defaultValue?: boolean) => void;
@@ -75,6 +78,7 @@ type State = {
   setContextBarPosition: (position: ContextBarPosition) => void;
   setPaneSize: (key: string, size: number | string) => void;
   setCollapsedPaths: (key: string, paths: string[]) => void;
+  setPanelMode: (key: string, mode: PanelMode) => void;
 };
 
 export const useUiPreferencesStore = create<State>()(
@@ -85,6 +89,7 @@ export const useUiPreferencesStore = create<State>()(
       contextBarPosition: 'middle-right',
       paneSizes: {},
       collapsedPaths: {},
+      panelModes: {},
       setRepoAction: (repoId, action) =>
         set((s) => ({ repoActions: { ...s.repoActions, [repoId]: action } })),
       setExpanded: (key, value) =>
@@ -109,6 +114,8 @@ export const useUiPreferencesStore = create<State>()(
         set((s) => ({ paneSizes: { ...s.paneSizes, [key]: size } })),
       setCollapsedPaths: (key, paths) =>
         set((s) => ({ collapsedPaths: { ...s.collapsedPaths, [key]: paths } })),
+      setPanelMode: (key, mode) =>
+        set((s) => ({ panelModes: { ...s.panelModes, [key]: mode } })),
     }),
     { name: 'ui-preferences' }
   )
@@ -190,4 +197,22 @@ export function usePersistedCollapsedPaths(
   );
 
   return [pathSet, setPathSet];
+}
+
+// Hook for persisted panel mode (per workspace)
+export function usePersistedPanelMode(
+  workspaceId: string | undefined
+): [PanelMode, (mode: PanelMode) => void] {
+  const key = workspaceId ? `panel-mode:${workspaceId}` : '';
+  const mode = useUiPreferencesStore((s) => s.panelModes[key] ?? null);
+  const setMode = useUiPreferencesStore((s) => s.setPanelMode);
+
+  const setPanelMode = useCallback(
+    (newMode: PanelMode) => {
+      if (key) setMode(key, newMode);
+    },
+    [key, setMode]
+  );
+
+  return [mode, setPanelMode];
 }


### PR DESCRIPTION
## Summary

Panel modes (changes, logs, preview) are now remembered independently for each workspace. Previously, these modes were stored globally, so if you had the preview panel open and navigated to another workspace, the preview panel would remain open. Now, each workspace remembers its own panel state.

## Changes

- **`useUiPreferencesStore.ts`**: Added `PanelMode` type and `panelModes` state with per-workspace keys (`panel-mode:${workspaceId}`), following the existing pattern used for `collapsedPaths`
- **`useWorkspacePanelMode.ts`**: New hook that syncs between workspace-specific persistence (in localStorage) and the global layout store
- **`WorkspacesLayout.tsx`**: Integrated the hook to enable per-workspace panel state restoration

## How it works

1. When you open a workspace and toggle a panel mode (e.g., preview), the state is saved to localStorage with a workspace-specific key
2. When you switch to another workspace, the hook restores whatever panel mode was previously active for that workspace (or no mode if none was saved)
3. When you return to the original workspace, the previous panel state is restored
4. Create mode still resets all panels (existing behavior preserved)
5. State persists across page refreshes

## Testing

1. Open workspace A, toggle preview mode on
2. Navigate to workspace B, verify preview is off
3. Toggle changes mode on in workspace B
4. Navigate back to workspace A, verify preview is restored
5. Navigate to workspace B, verify changes mode is restored
6. Refresh page, verify state persists

---

This PR was written using [Vibe Kanban](https://vibekanban.com)