### PR TITLE
Fix mobile preview scaling to fit container (Vibe Kanban)

### DIFF
--- a/frontend/src/components/ui-new/containers/PreviewBrowserContainer.tsx
+++ b/frontend/src/components/ui-new/containers/PreviewBrowserContainer.tsx
@@ -1,4 +1,10 @@
-import { useCallback, useState, useEffect, useLayoutEffect, useRef } from 'react';
+import {
+  useCallback,
+  useState,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+} from 'react';
 import {
   PreviewBrowser,
   MOBILE_WIDTH,

--- a/frontend/src/components/ui-new/views/PreviewBrowser.tsx
+++ b/frontend/src/components/ui-new/views/PreviewBrowser.tsx
@@ -273,9 +273,7 @@ export function PreviewBrowser({
           <div
             className={cn(
               'h-full',
-              screenSize === 'desktop'
-                ? ''
-                : 'flex items-center justify-center'
+              screenSize === 'desktop' ? '' : 'flex items-center justify-center'
             )}
           >
             {screenSize === 'mobile' ? (
@@ -283,7 +281,8 @@ export function PreviewBrowser({
               <div
                 className="bg-primary rounded-[2rem] p-3 shadow-xl origin-center"
                 style={{
-                  transform: mobileScale < 1 ? `scale(${mobileScale})` : undefined,
+                  transform:
+                    mobileScale < 1 ? `scale(${mobileScale})` : undefined,
                 }}
               >
                 <div


### PR DESCRIPTION
## Summary

Fixes the mobile preview browser where the phone frame (390x844px) was getting cut off vertically when the container was smaller than the frame dimensions.

## Changes

- Added automatic scaling for the mobile phone frame when it doesn't fit in the available container space
- The phone frame now scales down proportionally using CSS `transform: scale()` while maintaining aspect ratio
- Uses `ResizeObserver` to dynamically recalculate the scale when the container size changes
- Changed overflow behavior to `overflow-hidden` in mobile mode to prevent scrollbars when the scaled content fits

## Implementation Details

- **Container component** (`PreviewBrowserContainer.tsx`): Added `useLayoutEffect` hook that calculates the appropriate scale factor based on available container dimensions vs. the phone frame dimensions (including padding). The scale is capped at 1.0 to prevent scaling up.

- **View component** (`PreviewBrowser.tsx`): Exported dimension constants (`MOBILE_WIDTH`, `MOBILE_HEIGHT`, `PHONE_FRAME_PADDING`) and added `mobileScale` prop. Applied CSS transform with `origin-center` to scale the phone frame from its center.

## Before/After

**Before**: Mobile preview frame was cut off when the container height was smaller than ~870px (844px frame + 24px padding)

**After**: Mobile preview automatically scales down to fit within the available space, maintaining the phone frame appearance

---

This PR was written using [Vibe Kanban](https://vibekanban.com)