### PR TITLE
Fix MCP tool descriptions and update documentation (Vibe Kanban)

### DIFF
--- a/crates/server/src/mcp/task_server.rs
+++ b/crates/server/src/mcp/task_server.rs
@@ -220,7 +220,7 @@ pub struct StartWorkspaceSessionRequest {
     #[schemars(description = "The ID of the task to start")]
     pub task_id: Uuid,
     #[schemars(
-        description = "The coding agent executor to run ('CLAUDE_CODE', 'CODEX', 'GEMINI', 'CURSOR_AGENT', 'OPENCODE')"
+        description = "The coding agent executor to run ('CLAUDE_CODE', 'AMP', 'GEMINI', 'CODEX', 'OPENCODE', 'CURSOR_AGENT', 'QWEN_CODE', 'COPILOT', 'DROID')"
     )]
     pub executor: String,
     #[schemars(description = "Optional executor variant, if needed")]
@@ -750,7 +750,7 @@ impl TaskServer {
     }
 
     #[tool(
-        description = "Update an existing task/ticket's title, description, or status. `project_id` and `task_id` are required! `title`, `description`, and `status` are optional."
+        description = "Update an existing task/ticket's title, description, or status. `task_id` is required. `title`, `description`, and `status` are optional."
     )]
     async fn update_task(
         &self,
@@ -799,9 +799,7 @@ impl TaskServer {
         TaskServer::success(&repsonse)
     }
 
-    #[tool(
-        description = "Delete a task/ticket from a project. `project_id` and `task_id` are required!"
-    )]
+    #[tool(description = "Delete a task/ticket. `task_id` is required.")]
     async fn delete_task(
         &self,
         Parameters(DeleteTaskRequest { task_id }): Parameters<DeleteTaskRequest>,
@@ -819,7 +817,7 @@ impl TaskServer {
     }
 
     #[tool(
-        description = "Get detailed information (like task description) about a specific task/ticket. You can use `list_tasks` to find the `task_ids` of all tasks in a project. `project_id` and `task_id` are required!"
+        description = "Get detailed information (like task description) about a specific task/ticket. You can use `list_tasks` to find the `task_ids` of all tasks in a project. `task_id` is required."
     )]
     async fn get_task(
         &self,

--- a/docs/integrations/vibe-kanban-mcp-server.mdx
+++ b/docs/integrations/vibe-kanban-mcp-server.mdx
@@ -59,6 +59,13 @@ The Vibe Kanban MCP server provides the following tools for managing projects, t
 | Tool | Purpose | Required Parameters | Optional Parameters | Returns |
 |------|---------|-------------------|-------------------|---------|
 | `list_projects` | Fetch all projects | None | None | List of projects with metadata |
+| `list_repos` | List repositories in a project | `project_id` | None | List of repositories with IDs |
+
+### Context
+
+| Tool | Purpose | Required Parameters | Optional Parameters | Returns |
+|------|---------|-------------------|-------------------|---------|
+| `get_context` | Get current workspace context (only available within an active workspace session) | None | None | Project, task, and workspace metadata |
 
 ### Task Management
 
@@ -74,11 +81,15 @@ The Vibe Kanban MCP server provides the following tools for managing projects, t
 
 | Tool | Purpose | Required Parameters | Optional Parameters | Returns |
 |------|---------|-------------------|-------------------|---------|
-| `start_task_attempt` | Start working on a task with a coding agent | `task_id`<br/>`executor`<br/>`base_branch` | `variant` | Attempt ID and confirmation |
+| `start_workspace_session` | Start working on a task with a coding agent | `task_id`<br/>`executor`<br/>`repos` | `variant` | Task ID and workspace ID |
+
+The `repos` parameter is an array of objects with:
+- `repo_id`: The repository ID (UUID)
+- `base_branch`: The base branch for this repository
 
 ### Supported Executors
 
-When using `start_task_attempt`, the following executors are supported (case-insensitive, accepts hyphens or underscores):
+When using `start_workspace_session`, the following executors are supported (case-insensitive, accepts hyphens or underscores):
 
 - `claude-code` / `CLAUDE_CODE`
 - `amp` / `AMP`
@@ -97,7 +108,7 @@ Once you have the MCP server configured, you can leverage it to streamline your 
 1. **Plan Your Work**: Describe a large feature or project to your MCP client
 2. **Request Task Creation**: At the end of your task description, simply add "then turn this plan into tasks"
 3. **Automatic Task Generation**: Your MCP client will use the Vibe Kanban MCP server to automatically create structured tasks in your project
-4. **Start Task Execution**: Use `start_task_attempt` to programmatically begin work on tasks with specific coding agents
+4. **Start Task Execution**: Use `start_workspace_session` to programmatically begin work on tasks with specific coding agents
 
 ## Example Usage
 
@@ -124,12 +135,17 @@ After tasks are created, you can start work on them programmatically:
 Start working on the user registration task using Claude Code on the main branch.
 ```
 
-Your MCP client will use the `start_task_attempt` tool with parameters like:
+Your MCP client will use the `start_workspace_session` tool with parameters like:
 ```json
 {
   "task_id": "123e4567-e89b-12d3-a456-426614174000",
   "executor": "claude-code",
-  "base_branch": "main"
+  "repos": [
+    {
+      "repo_id": "987fcdeb-51a2-3d4e-b678-426614174001",
+      "base_branch": "main"
+    }
+  ]
 }
 ```
 
@@ -144,7 +160,7 @@ This creates a new task attempt, generates a feature branch, and starts the codi
 4. Start a task attempt for the new task using Amp on the develop branch
 ```
 
-Each step uses the appropriate MCP tool (`list_projects`, `list_tasks`, `create_task`, `start_task_attempt`) to manage the complete workflow from planning to execution.
+Each step uses the appropriate MCP tool (`list_projects`, `list_tasks`, `create_task`, `start_workspace_session`) to manage the complete workflow from planning to execution.
 
 ### Internal Coding Agents (Within Vibe Kanban)
 


### PR DESCRIPTION
## Summary

Fixes incorrect MCP tool descriptions and updates documentation to accurately reflect the available tools and their parameters. This addresses GitHub issue #1942.

## Changes

### MCP Tool Descriptions (`crates/server/src/mcp/task_server.rs`)

- **`update_task`**: Removed incorrect `project_id` requirement - only `task_id` is required
- **`delete_task`**: Removed incorrect `project_id` requirement - only `task_id` is required  
- **`get_task`**: Removed incorrect `project_id` requirement - only `task_id` is required
- **`start_workspace_session` executor list**: Added missing executors (`AMP`, `QWEN_CODE`, `COPILOT`, `DROID`) to the schemars description

### Documentation (`docs/integrations/vibe-kanban-mcp-server.mdx`)

- Added `list_repos` tool to Project Operations table
- Added new "Context" section with `get_context` tool documentation
- Renamed `start_task_attempt` to `start_workspace_session` (the actual tool name)
- Updated `start_workspace_session` parameters to show `repos` array format instead of single `base_branch`
- Updated example JSON to demonstrate correct parameter structure

## Why

Users following the MCP documentation were encountering errors because:
1. Tool descriptions incorrectly stated `project_id` was required for operations that only need `task_id`
2. The documentation referenced a non-existent `start_task_attempt` tool instead of `start_workspace_session`
3. Missing tools (`list_repos`, `get_context`) were not documented
4. The executor list was incomplete, missing 4 supported agents

---

This PR was written using [Vibe Kanban](https://vibekanban.com)