### PR TITLE
feat: Hide 'Open pull request' button when PR is already open (Vibe Kanban)

### DIFF
--- a/frontend/src/components/ui-new/primitives/RepoCard.tsx
+++ b/frontend/src/components/ui-new/primitives/RepoCard.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import {
   GitBranchIcon,
   GitPullRequestIcon,
@@ -96,6 +97,20 @@ export function RepoCard({
   const { t } = useTranslation('tasks');
   const { t: tCommon } = useTranslation('common');
   const [selectedAction, setSelectedAction] = useRepoAction(repoId);
+
+  // Hide "Open pull request" option when PR is already open
+  const hasPrOpen = prStatus === 'open';
+  const availableActionOptions = useMemo(
+    () =>
+      hasPrOpen
+        ? repoActionOptions.filter((opt) => opt.value !== 'pull-request')
+        : repoActionOptions,
+    [hasPrOpen]
+  );
+
+  // If PR is open and 'pull-request' was selected, fall back to 'merge'
+  const effectiveSelectedAction =
+    hasPrOpen && selectedAction === 'pull-request' ? 'merge' : selectedAction;
 
   return (
     <CollapsibleSection
@@ -269,8 +284,8 @@ export function RepoCard({
       {/* Actions row */}
       <div className="my-base">
         <SplitButton
-          options={repoActionOptions}
-          selectedValue={selectedAction}
+          options={availableActionOptions}
+          selectedValue={effectiveSelectedAction}
           onSelectionChange={setSelectedAction}
           onAction={(action) => onActionsClick?.(action)}
         />


### PR DESCRIPTION
## Summary

This PR hides the "Open pull request" button in the Git Panel's RepoCard component when a pull request is already open for the current branch. The button reappears once the PR is closed or merged.

## Changes

- **Conditional filtering of action options**: When `prStatus === 'open'`, the "Open pull request" option is filtered out from the SplitButton dropdown, leaving only the "Merge" option available.

- **Fallback for persisted selection**: If a user previously had "Open pull request" selected and a PR becomes open, the component gracefully falls back to showing "Merge" as the selected action without causing UI issues.

## Implementation Details

- Uses `useMemo` to efficiently filter the action options based on PR status
- Computes an `effectiveSelectedAction` to handle the edge case where the persisted selection becomes invalid
- No side effects are used (avoiding `useEffect`), keeping the component as a pure presentational component per the project's lint rules

## Behavior

| PR Status | Available Actions |
|-----------|------------------|
| No PR | "Open pull request", "Merge" |
| PR Open | "Merge" only |
| PR Closed/Merged | "Open pull request", "Merge" |

---

This PR was written using [Vibe Kanban](https://vibekanban.com)