### PR TITLE
Bump claude code version to 2.1.7 (vibe-kanban)

### DIFF
--- a/crates/executors/src/executors/claude.rs
+++ b/crates/executors/src/executors/claude.rs
@@ -43,7 +43,7 @@ fn base_command(claude_code_router: bool) -> &'static str {
     if claude_code_router {
         "npx -y @musistudio/claude-code-router@1.0.66 code"
     } else {
-        "npx -y @anthropic-ai/claude-code@2.1.2"
+        "npx -y @anthropic-ai/claude-code@2.1.7"
     }
 }
 


### PR DESCRIPTION
Version seems to have warmup background subagents disabled.

Fixes issue where claude code main agent finishes before warmup subagent but after subagent triggers a PreToolUseHook, causing a "Stream closed" error on hook callback response

Related:
https://github.com/anthropics/claude-code/issues/16157#issuecomment-3737070631