### PR TITLE
Show scrollbar in chat panel when content overflows (Vibe Kanban)

### DIFF
--- a/frontend/src/components/ui-new/containers/ConversationListContainer.tsx
+++ b/frontend/src/components/ui-new/containers/ConversationListContainer.tsx
@@ -170,7 +170,7 @@ export function ConversationList({ attempt, task }: ConversationListProps) {
         >
           <VirtuosoMessageList<PatchTypeWithKey, MessageListContext>
             ref={messageListRef}
-            className="h-full scrollbar-none"
+            className="h-full scrollbar-thin scrollbar-thumb-panel scrollbar-track-transparent"
             data={channelData}
             initialLocation={INITIAL_TOP_ITEM}
             context={messageListContext}


### PR DESCRIPTION
## Summary

- Changed the chat panel's virtualized message list to display a thin scrollbar instead of hiding it completely
- The scrollbar now appears when content overflows, matching the styling used in other panels

## Changes

Updated `ConversationListContainer.tsx` to replace `scrollbar-none` with `scrollbar-thin scrollbar-thumb-panel scrollbar-track-transparent` on the `VirtuosoMessageList` component.

## Why

Previously, the chat panel in the workflow UI had its scrollbar explicitly hidden with `scrollbar-none`, making it difficult for users to see their scroll position or quickly navigate through long conversations. This change improves UX by showing a subtle, themed scrollbar that matches the rest of the application's styling (consistent with the changes panel and file tree).

## Implementation Details

- Uses Tailwind's scrollbar plugin classes for consistent styling
- `scrollbar-thin`: Shows a thin scrollbar
- `scrollbar-thumb-panel`: Uses the panel theme color for the scrollbar thumb
- `scrollbar-track-transparent`: Keeps the track transparent for a minimal look

---

This PR was written using [Vibe Kanban](https://vibekanban.com)