### PR TITLE
bump codex version and set the default model to gpt-5.2-codex

### DIFF
--- a/crates/executors/default_profiles.json
+++ b/crates/executors/default_profiles.json
@@ -56,13 +56,13 @@
     "CODEX": {
       "DEFAULT": {
         "CODEX": {
-          "model": "gpt-5.2",
+          "model": "gpt-5.2-codex",
           "sandbox": "danger-full-access"
         }
       },
       "HIGH": {
         "CODEX": {
-          "model": "gpt-5.2",
+          "model": "gpt-5.2-codex",
           "sandbox": "danger-full-access",
           "model_reasoning_effort": "high"
         }
@@ -77,12 +77,6 @@
       "MAX": {
         "CODEX": {
           "model": "gpt-5.1-codex-max",
-          "sandbox": "danger-full-access"
-        }
-      },
-      "CODEX": {
-        "CODEX": {
-          "model": "gpt-5.2-codex",
           "sandbox": "danger-full-access"
         }
       }

--- a/crates/executors/src/executors/codex.rs
+++ b/crates/executors/src/executors/codex.rs
@@ -256,7 +256,7 @@ impl StandardCodingAgentExecutor for Codex {
 
 impl Codex {
     pub fn base_command() -> &'static str {
-        "npx -y @openai/codex@0.77.0"
+        "npx -y @openai/codex@0.86.0"
     }
 
     fn build_command_builder(&self) -> Result<CommandBuilder, CommandBuildError> {


### PR DESCRIPTION
`gpt-5.2-codex` is now available to API users as well.

Fixes #1906