### PR TITLE
fix(mcp): add missing error_data field in ApiResponseEnvelope

### DIFF
--- a/crates/server/src/mcp/task_server.rs
+++ b/crates/server/src/mcp/task_server.rs
@@ -363,6 +363,8 @@ struct ApiResponseEnvelope<T> {
     success: bool,
     data: Option<T>,
     message: Option<String>,
+    #[serde(default)]
+    error_data: Option<serde_json::Value>,
 }
 
 impl TaskServer {


### PR DESCRIPTION
## Problem

MCP tools (list_projects, create_task, etc.) fail with the following error:
```
{"success": false, "error": "Failed to parse VK API response", "details": "error decoding response body"}
```

## Root Cause

Backend API returns responses with 4 fields:
- `success: bool`
- `data: Option<T>`
- `error_data: Option<E>` ← **This field was missing in MCP struct**
- `message: Option<String>`

The `ApiResponseEnvelope<T>` struct in `crates/server/src/mcp/task_server.rs` only defines 3 fields, causing Rust's serde to fail when deserializing backend responses.

## Solution

Add the missing `error_data` field to the `ApiResponseEnvelope` struct:

```rust
#[derive(Debug, Deserialize)]
struct ApiResponseEnvelope<T> {
    success: bool,
    data: Option<T>,
    message: Option<String>,
    #[serde(default)]  // Added for backward compatibility
    error_data: Option<serde_json::Value>,
}
```

## Testing

- ✅ Compiled and tested locally (v0.0.155)
- ✅ MCP tools now successfully parse backend responses
- ✅ All existing functionality works correctly
- ✅ No breaking changes

## Files Changed

- `crates/server/src/mcp/task_server.rs` (+2 lines)

---

🤖 Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>