### PR TITLE
Fix left main panel width restoration after collapse/expand (Vibe Kanban)

### DIFF
--- a/frontend/src/components/ui-new/containers/WorkspacesLayout.tsx
+++ b/frontend/src/components/ui-new/containers/WorkspacesLayout.tsx
@@ -100,7 +100,7 @@ export function WorkspacesLayout() {
       : { 'left-main': 50, 'right-main': 50 };
 
   const onLayoutChange = (layout: Layout) => {
-    if (rightMainPanelMode !== null)
+    if (isLeftMainPanelVisible && rightMainPanelMode !== null)
       setRightMainPanelSize(layout['right-main']);
   };
 


### PR DESCRIPTION
## Summary

- Fixed a bug where the left main panel would have virtually no width after being collapsed and re-expanded in `WorkspacesLayout.tsx`

## Problem

When users collapsed the left main panel and then expanded it again, the panel would restore with an incorrect (near-zero) width instead of its previous size.

## Root Cause

The `onLayoutChange` callback was saving panel sizes whenever the right panel was visible (`rightMainPanelMode !== null`), regardless of whether the left panel was also visible. When the left panel was hidden, the layout values being saved were incorrect (since only one panel existed in the resizable group), causing the persisted `rightMainPanelSize` to be invalid.

## Solution

Updated the `onLayoutChange` condition to only persist sizes when **both** panels are visible:

```tsx
// Before
if (rightMainPanelMode !== null)

// After  
if (isLeftMainPanelVisible && rightMainPanelMode !== null)
```

This ensures sizes are only saved when the separator can actually be dragged between two panels, preventing incorrect values from being persisted.

## Test Plan

- [ ] Open a workspace with both left and right panels visible
- [ ] Resize the panels by dragging the separator
- [ ] Collapse the left main panel
- [ ] Expand the left main panel
- [ ] Verify the width is restored to its previous size

---

This PR was written using [Vibe Kanban](https://vibekanban.com)