### PR TITLE
feat: add workspace notes section to RightSidebar (Vibe Kanban)

### DIFF
--- a/crates/db/src/models/scratch.rs
+++ b/crates/db/src/models/scratch.rs
@@ -37,6 +37,12 @@ pub struct PreviewSettingsData {
     pub responsive_height: Option<i32>,
 }
 
+/// Data for workspace notes scratch
+#[derive(Debug, Clone, Serialize, Deserialize, TS)]
+pub struct WorkspaceNotesData {
+    pub content: String,
+}
+
 /// Data for a draft workspace scratch (new workspace creation)
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
 pub struct DraftWorkspaceData {
@@ -70,6 +76,7 @@ pub enum ScratchPayload {
     DraftFollowUp(DraftFollowUpData),
     DraftWorkspace(DraftWorkspaceData),
     PreviewSettings(PreviewSettingsData),
+    WorkspaceNotes(WorkspaceNotesData),
 }
 
 impl ScratchPayload {

--- a/crates/server/src/bin/generate_types.rs
+++ b/crates/server/src/bin/generate_types.rs
@@ -37,6 +37,7 @@ fn generate_types_content() -> String {
         db::models::scratch::DraftWorkspaceData::decl(),
         db::models::scratch::DraftWorkspaceRepo::decl(),
         db::models::scratch::PreviewSettingsData::decl(),
+        db::models::scratch::WorkspaceNotesData::decl(),
         db::models::scratch::ScratchPayload::decl(),
         db::models::scratch::ScratchType::decl(),
         db::models::scratch::Scratch::decl(),

--- a/frontend/src/components/ui-new/containers/RightSidebar.tsx
+++ b/frontend/src/components/ui-new/containers/RightSidebar.tsx
@@ -7,6 +7,7 @@ import { TerminalPanelContainer } from '@/components/ui-new/containers/TerminalP
 import { CreateModeProjectSectionContainer } from '@/components/ui-new/containers/CreateModeProjectSectionContainer';
 import { CreateModeReposSectionContainer } from '@/components/ui-new/containers/CreateModeReposSectionContainer';
 import { CreateModeAddReposSectionContainer } from '@/components/ui-new/containers/CreateModeAddReposSectionContainer';
+import { WorkspaceNotesContainer } from '@/components/ui-new/containers/WorkspaceNotesContainer';
 import { useChangesView } from '@/contexts/ChangesViewContext';
 import { useWorkspaceContext } from '@/contexts/WorkspaceContext';
 import type { Workspace, RepoWithTargetBranch } from 'shared/types';
@@ -66,7 +67,11 @@ export function RightSidebar({
   );
   const [terminalExpanded] = usePersistedExpanded(
     PERSIST_KEYS.terminalSection,
-    true
+    false
+  );
+  const [notesExpanded] = usePersistedExpanded(
+    PERSIST_KEYS.notesSection,
+    false
   );
 
   const hasUpperContent =
@@ -133,6 +138,13 @@ export function RightSidebar({
         visible: isTerminalVisible,
         expanded: terminalExpanded,
         content: <TerminalPanelContainer />,
+      },
+      {
+        title: t('common:sections.notes'),
+        persistKey: PERSIST_KEYS.notesSection,
+        visible: true,
+        expanded: notesExpanded,
+        content: <WorkspaceNotesContainer />,
       },
     ];
 

--- a/frontend/src/components/ui-new/containers/WorkspaceNotesContainer.tsx
+++ b/frontend/src/components/ui-new/containers/WorkspaceNotesContainer.tsx
@@ -1,0 +1,42 @@
+import { useTranslation } from 'react-i18next';
+import { useWorkspaceContext } from '@/contexts/WorkspaceContext';
+import { useWorkspaceNotes } from '@/hooks/useWorkspaceNotes';
+import WYSIWYGEditor from '@/components/ui/wysiwyg';
+import { SpinnerIcon } from '@phosphor-icons/react';
+
+export function WorkspaceNotesContainer() {
+  const { t } = useTranslation('common');
+  const { workspace } = useWorkspaceContext();
+  const workspaceId = workspace?.id;
+
+  const { content, isLoading, setContent } = useWorkspaceNotes(workspaceId);
+
+  if (!workspaceId) {
+    return (
+      <div className="p-base text-low text-sm flex-1">
+        {t('notes.selectWorkspace')}
+      </div>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center flex-1 p-base">
+        <SpinnerIcon className="animate-spin h-5 w-5 text-low" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-base flex flex-col flex-1 min-h-0 overflow-y-auto">
+      <WYSIWYGEditor
+        placeholder={t('notes.placeholder')}
+        value={content}
+        onChange={setContent}
+        workspaceId={workspaceId}
+        autoFocus={false}
+        className="min-h-[300px]"
+      />
+    </div>
+  );
+}

--- a/frontend/src/hooks/useWorkspaceNotes.ts
+++ b/frontend/src/hooks/useWorkspaceNotes.ts
@@ -1,0 +1,88 @@
+import { useCallback, useState, useEffect, useRef } from 'react';
+import { ScratchType, type WorkspaceNotesData } from 'shared/types';
+import { useScratch } from './useScratch';
+import { useDebouncedCallback } from './useDebouncedCallback';
+
+export interface UseWorkspaceNotesResult {
+  content: string;
+  isLoading: boolean;
+  isConnected: boolean;
+  error: string | null;
+  setContent: (content: string) => void;
+}
+
+/**
+ * Hook for managing workspace notes stored in scratch memory.
+ * Provides debounced saves and local state for immediate UI feedback.
+ */
+export function useWorkspaceNotes(
+  workspaceId: string | undefined
+): UseWorkspaceNotesResult {
+  const {
+    scratch,
+    updateScratch,
+    isLoading: isScratchLoading,
+    isConnected,
+    error,
+  } = useScratch(ScratchType.WORKSPACE_NOTES, workspaceId ?? '', {
+    enabled: !!workspaceId,
+  });
+
+  // Local state for immediate UI feedback
+  const [localContent, setLocalContent] = useState('');
+
+  // Track if user is actively editing to prevent server overwrites
+  const isEditingRef = useRef(false);
+
+  // Extract content from scratch payload
+  const scratchData: WorkspaceNotesData | undefined =
+    scratch?.payload?.type === 'WORKSPACE_NOTES'
+      ? scratch.payload.data
+      : undefined;
+
+  // Sync from server when scratch loads (but not while editing)
+  useEffect(() => {
+    if (isScratchLoading) return;
+    if (isEditingRef.current) return;
+    setLocalContent(scratchData?.content ?? '');
+  }, [isScratchLoading, scratchData?.content]);
+
+  // Debounced save to server
+  const { debounced: saveContent } = useDebouncedCallback(
+    useCallback(
+      async (content: string) => {
+        if (!workspaceId) return;
+        try {
+          await updateScratch({
+            payload: {
+              type: 'WORKSPACE_NOTES',
+              data: { content },
+            },
+          });
+        } catch (e) {
+          console.error('Failed to save workspace notes', e);
+        }
+        isEditingRef.current = false;
+      },
+      [workspaceId, updateScratch]
+    ),
+    500
+  );
+
+  const setContent = useCallback(
+    (content: string) => {
+      isEditingRef.current = true;
+      setLocalContent(content);
+      saveContent(content);
+    },
+    [saveContent]
+  );
+
+  return {
+    content: localContent,
+    isLoading: isScratchLoading,
+    isConnected,
+    error,
+    setContent,
+  };
+}

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -166,7 +166,12 @@
     "recent": "Recent",
     "other": "Other",
     "devServerPreview": "Dev Server Preview",
-    "terminal": "Terminal"
+    "terminal": "Terminal",
+    "notes": "Notes"
+  },
+  "notes": {
+    "placeholder": "Add notes about this workspace...",
+    "selectWorkspace": "Select a workspace to view notes"
   },
   "repos": {
     "loading": "Loading repositories...",

--- a/frontend/src/i18n/locales/es/common.json
+++ b/frontend/src/i18n/locales/es/common.json
@@ -166,7 +166,12 @@
     "recent": "Reciente",
     "other": "Otro",
     "devServerPreview": "Vista previa del servidor de desarrollo",
-    "terminal": "Terminal"
+    "terminal": "Terminal",
+    "notes": "Notas"
+  },
+  "notes": {
+    "placeholder": "Agregar notas sobre este espacio de trabajo...",
+    "selectWorkspace": "Selecciona un espacio de trabajo para ver notas"
   },
   "repos": {
     "loading": "Cargando repositorios...",

--- a/frontend/src/i18n/locales/fr/common.json
+++ b/frontend/src/i18n/locales/fr/common.json
@@ -166,7 +166,12 @@
     "recent": "Récent",
     "other": "Autre",
     "devServerPreview": "Aperçu du serveur de développement",
-    "terminal": "Terminal"
+    "terminal": "Terminal",
+    "notes": "Notes"
+  },
+  "notes": {
+    "placeholder": "Ajouter des notes sur cet espace de travail...",
+    "selectWorkspace": "Sélectionnez un espace de travail pour voir les notes"
   },
   "repos": {
     "loading": "Chargement des dépôts...",

--- a/frontend/src/i18n/locales/ja/common.json
+++ b/frontend/src/i18n/locales/ja/common.json
@@ -166,7 +166,12 @@
     "recent": "最近",
     "other": "その他",
     "devServerPreview": "開発サーバープレビュー",
-    "terminal": "ターミナル"
+    "terminal": "ターミナル",
+    "notes": "メモ"
+  },
+  "notes": {
+    "placeholder": "このワークスペースについてメモを追加...",
+    "selectWorkspace": "メモを表示するにはワークスペースを選択してください"
   },
   "repos": {
     "loading": "リポジトリを読み込み中...",

--- a/frontend/src/i18n/locales/ko/common.json
+++ b/frontend/src/i18n/locales/ko/common.json
@@ -166,7 +166,12 @@
     "recent": "최근",
     "other": "기타",
     "devServerPreview": "개발 서버 미리보기",
-    "terminal": "터미널"
+    "terminal": "터미널",
+    "notes": "노트"
+  },
+  "notes": {
+    "placeholder": "이 워크스페이스에 대한 노트 추가...",
+    "selectWorkspace": "노트를 보려면 워크스페이스를 선택하세요"
   },
   "repos": {
     "loading": "저장소 로딩 중...",

--- a/frontend/src/i18n/locales/zh-Hans/common.json
+++ b/frontend/src/i18n/locales/zh-Hans/common.json
@@ -166,7 +166,12 @@
     "recent": "最近",
     "other": "其他",
     "devServerPreview": "开发服务器预览",
-    "terminal": "终端"
+    "terminal": "终端",
+    "notes": "笔记"
+  },
+  "notes": {
+    "placeholder": "添加关于此工作区的笔记...",
+    "selectWorkspace": "选择一个工作区以查看笔记"
   },
   "repos": {
     "loading": "正在加载仓库...",

--- a/frontend/src/i18n/locales/zh-Hant/common.json
+++ b/frontend/src/i18n/locales/zh-Hant/common.json
@@ -166,7 +166,12 @@
     "recent": "最近",
     "other": "其他",
     "devServerPreview": "開發伺服器預覽",
-    "terminal": "終端機"
+    "terminal": "終端機",
+    "notes": "筆記"
+  },
+  "notes": {
+    "placeholder": "新增關於此工作區的筆記...",
+    "selectWorkspace": "選擇一個工作區以查看筆記"
   },
   "repos": {
     "loading": "正在載入儲存庫...",

--- a/frontend/src/stores/useUiPreferencesStore.ts
+++ b/frontend/src/stores/useUiPreferencesStore.ts
@@ -50,6 +50,8 @@ export const PERSIST_KEYS = {
   devServerSection: 'dev-server-section',
   // Terminal panel section
   terminalSection: 'terminal-section',
+  // Notes panel section
+  notesSection: 'notes-section',
   // GitHub comments toggle
   showGitHubComments: 'show-github-comments',
   // Panel sizes
@@ -71,6 +73,7 @@ export type PersistKey =
   | typeof PERSIST_KEYS.changesSection
   | typeof PERSIST_KEYS.devServerSection
   | typeof PERSIST_KEYS.terminalSection
+  | typeof PERSIST_KEYS.notesSection
   | typeof PERSIST_KEYS.showGitHubComments
   | typeof PERSIST_KEYS.rightMainPanel
   | typeof PERSIST_KEYS.rightPanelprocesses

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -60,9 +60,11 @@ export type DraftWorkspaceRepo = { repo_id: string, target_branch: string, };
 
 export type PreviewSettingsData = { url: string, screen_size: string | null, responsive_width: number | null, responsive_height: number | null, };
 
-export type ScratchPayload = { "type": "DRAFT_TASK", "data": string } | { "type": "DRAFT_FOLLOW_UP", "data": DraftFollowUpData } | { "type": "DRAFT_WORKSPACE", "data": DraftWorkspaceData } | { "type": "PREVIEW_SETTINGS", "data": PreviewSettingsData };
+export type WorkspaceNotesData = { content: string, };
 
-export enum ScratchType { DRAFT_TASK = "DRAFT_TASK", DRAFT_FOLLOW_UP = "DRAFT_FOLLOW_UP", DRAFT_WORKSPACE = "DRAFT_WORKSPACE", PREVIEW_SETTINGS = "PREVIEW_SETTINGS" }
+export type ScratchPayload = { "type": "DRAFT_TASK", "data": string } | { "type": "DRAFT_FOLLOW_UP", "data": DraftFollowUpData } | { "type": "DRAFT_WORKSPACE", "data": DraftWorkspaceData } | { "type": "PREVIEW_SETTINGS", "data": PreviewSettingsData } | { "type": "WORKSPACE_NOTES", "data": WorkspaceNotesData };
+
+export enum ScratchType { DRAFT_TASK = "DRAFT_TASK", DRAFT_FOLLOW_UP = "DRAFT_FOLLOW_UP", DRAFT_WORKSPACE = "DRAFT_WORKSPACE", PREVIEW_SETTINGS = "PREVIEW_SETTINGS", WORKSPACE_NOTES = "WORKSPACE_NOTES" }
 
 export type Scratch = { id: string, payload: ScratchPayload, created_at: string, updated_at: string, };
 


### PR DESCRIPTION
## Summary

Add a WYSIWYG notes section to the right sidebar that allows users to jot down notes per workspace. Notes are saved to scratch memory and persist across page refreshes.

## Changes

### Backend (Rust)
- Added `WorkspaceNotesData` struct to store workspace notes content
- Added `WORKSPACE_NOTES` variant to `ScratchPayload` enum for type-safe scratch storage
- Registered the new type in `generate_types.rs` for TypeScript generation

### Frontend (React/TypeScript)
- **`useWorkspaceNotes.ts`**: New hook that manages workspace notes with:
  - Integration with `useScratch` for server persistence via WebSocket
  - Local state for immediate UI feedback while typing
  - Debounced auto-save (500ms) to avoid excessive API calls
  - Automatic sync from server when scratch loads

- **`WorkspaceNotesContainer.tsx`**: New container component that:
  - Gets workspace ID from `useWorkspaceContext`
  - Renders the existing WYSIWYG editor with placeholder text
  - Shows loading spinner while scratch is loading
  - Handles the case when no workspace is selected

- **`RightSidebar.tsx`**: Added Notes section after Terminal:
  - Uses `CollapsibleSectionHeader` for consistent UI
  - Both Terminal and Notes sections are now collapsed by default

- **`useUiPreferencesStore.ts`**: Added `notesSection` persist key for section expand/collapse state

## Why

Users need a way to jot down quick notes about their workspaces - ideas, TODOs, context, or any relevant information. The WYSIWYG editor provides rich text formatting (bold, lists, code blocks, etc.) for better note organization.

## Testing

1. Open a workspace in the UI
2. Expand the "Notes" section in the right sidebar
3. Add some text using the WYSIWYG editor
4. Verify formatting works (bold, lists, code blocks, etc.)
5. Refresh the page and verify notes persist
6. Switch to a different workspace and verify notes are workspace-specific

---

This PR was written using [Vibe Kanban](https://vibekanban.com)