### PR TITLE
fix: correct console.warn! to console.warn syntax

### DIFF
--- a/frontend/src/hooks/useConversationHistory.ts
+++ b/frontend/src/hooks/useConversationHistory.ts
@@ -139,7 +139,7 @@ export const useConversationHistory = ({
           resolve(allEntries);
         },
         onError: (err) => {
-          console.warn!(
+          console.warn(
             `Error loading entries for historic execution process ${executionProcess.id}`,
             err
           );


### PR DESCRIPTION
## Summary
- Fixed invalid JavaScript syntax where `console.warn!` (Rust macro syntax) was used instead of `console.warn()` in `useConversationHistory.ts`

## Test plan
- [x] TypeScript compilation passes (`pnpm run check`)
- [x] Frontend lint passes (`pnpm run frontend:lint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)