### PR TITLE
feat(utils): add VIBE_KANBAN_ASSET_DIR env var override

### DIFF
--- a/crates/utils/src/assets.rs
+++ b/crates/utils/src/assets.rs
@@ -4,7 +4,9 @@ use rust_embed::RustEmbed;
 const PROJECT_ROOT: &str = env!("CARGO_MANIFEST_DIR");
 
 pub fn asset_dir() -> std::path::PathBuf {
-    let path = if cfg!(debug_assertions) {
+    let path = if let Ok(override_path) = std::env::var("VIBE_KANBAN_ASSET_DIR") {
+        std::path::PathBuf::from(override_path)
+    } else if cfg!(debug_assertions) {
         std::path::PathBuf::from(PROJECT_ROOT).join("../../dev_assets")
     } else {
         ProjectDirs::from("ai", "bloop", "vibe-kanban")


### PR DESCRIPTION
## Summary
- Adds `VIBE_KANBAN_ASSET_DIR` environment variable override for the asset directory
- Allows running dev mode against the global database instead of the local `dev_assets` copy - **this can simplify testing any bugfixes to vibe-kanban**

## Test plan
- [x] Set `VIBE_KANBAN_ASSET_DIR=/tmp/test-assets` and run `pnpm run dev`, verify it uses the override path
- [x] Run without the env var, verify default behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)