### PR TITLE
fix: collapse notes and terminal sections by default in RightSidebar (Vibe Kanban)

### DIFF
--- a/frontend/src/components/ui-new/containers/RightSidebar.tsx
+++ b/frontend/src/components/ui-new/containers/RightSidebar.tsx
@@ -214,6 +214,7 @@ export function RightSidebar({
             <CollapsibleSectionHeader
               title={section.title}
               persistKey={section.persistKey}
+              defaultExpanded={section.expanded}
             >
               <div className="flex flex-1 border-t min-h-[200px]">
                 {section.content}


### PR DESCRIPTION
## Summary

- Fixed the Notes and Terminal sections in `RightSidebar` to be collapsed by default as originally intended

## Problem

The Notes and Terminal sections were appearing expanded when first loaded, even though the code defined their default expanded state as `false`:

```tsx
const [terminalExpanded] = usePersistedExpanded(PERSIST_KEYS.terminalSection, false);
const [notesExpanded] = usePersistedExpanded(PERSIST_KEYS.notesSection, false);
```

## Root Cause

The `CollapsibleSectionHeader` component has a default prop `defaultExpanded = true`. When rendering sections, the `RightSidebar` was not passing the `defaultExpanded` prop:

```tsx
<CollapsibleSectionHeader
  title={section.title}
  persistKey={section.persistKey}
>
```

This meant `CollapsibleSectionHeader` used its own default of `true`, ignoring the section's intended default of `false`.

## Solution

Pass the section's `expanded` value to `CollapsibleSectionHeader`:

```tsx
<CollapsibleSectionHeader
  title={section.title}
  persistKey={section.persistKey}
  defaultExpanded={section.expanded}
>
```

## Testing

1. Clear localStorage to remove persisted state
2. Open a workspace (not create mode)
3. Verify Terminal and Notes sections are collapsed by default
4. Verify Git section remains expanded by default
5. Toggle sections and refresh to confirm state persists correctly

---

This PR was written using [Vibe Kanban](https://vibekanban.com)