### PR TITLE
fix(frontend): filter token_usage_info entries to fix VirtuosoMessageList rendering

### DIFF
--- a/frontend/src/hooks/useConversationHistory.ts
+++ b/frontend/src/hooks/useConversationHistory.ts
@@ -251,11 +251,14 @@ export const useConversationHistory = ({
             );
             entries.push(userPatchTypeWithKey);
 
-            // Remove all coding agent added user messages, replace with our custom one
+            // Remove user_message entries (replaced with our custom one) and
+            // token_usage_info entries (render as null causing VirtuosoMessageList
+            // height issues; token usage is displayed in header gauge instead)
             const entriesExcludingUser = p.entries.filter(
               (e) =>
                 e.type !== 'NORMALIZED_ENTRY' ||
-                e.content.entry_type.type !== 'user_message'
+                (e.content.entry_type.type !== 'user_message' &&
+                  e.content.entry_type.type !== 'token_usage_info')
             );
 
             const hasPendingApprovalEntry = entriesExcludingUser.some(


### PR DESCRIPTION
## Summary
- Filter out `token_usage_info` entries in `flattenEntriesForEmit` because they render as `null` in `DisplayConversationEntry`
- This fixes VirtuosoMessageList calculating zero height for these entries, causing the list to get stuck when starting from the last item
- Token usage continues to be displayed in the header gauge via the separate `useTokenUsage` hook

## Test plan
- [ ] Run the app and start a conversation
- [ ] Verify VirtuosoMessageList scrolls correctly to the bottom
- [ ] Verify token usage is still displayed in the header gauge
- [ ] Verify no stuck/frozen list behavior when new messages arrive

🤖 Generated with [Claude Code](https://claude.com/claude-code)