### PR TITLE
Remove "Unknown" agent availability state from UI (Vibe Kanban)

### DIFF
--- a/frontend/src/components/AgentAvailabilityIndicator.tsx
+++ b/frontend/src/components/AgentAvailabilityIndicator.tsx
@@ -1,4 +1,4 @@
-import { Check, AlertCircle, Loader2 } from 'lucide-react';
+import { Check, Loader2 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import type { AgentAvailabilityState } from '@/hooks/useAgentAvailability';
 
@@ -46,19 +46,6 @@ export function AgentAvailabilityIndicator({
           </div>
           <p className="text-xs text-muted-foreground pl-6">
             {t('settings.agents.availability.installationFoundTooltip')}
-          </p>
-        </>
-      )}
-      {availability.status === 'not_found' && (
-        <>
-          <div className="flex items-center gap-2">
-            <AlertCircle className="h-4 w-4 text-warning" />
-            <span className="text-warning">
-              {t('settings.agents.availability.notFound')}
-            </span>
-          </div>
-          <p className="text-xs text-muted-foreground pl-6">
-            {t('settings.agents.availability.notFoundTooltip')}
           </p>
         </>
       )}

--- a/frontend/src/i18n/locales/en/settings.json
+++ b/frontend/src/i18n/locales/en/settings.json
@@ -259,9 +259,7 @@
         "loginDetected": "Recent Usage Detected",
         "loginDetectedTooltip": "Recent authentication credentials found for this agent",
         "installationFound": "Previous Usage Detected",
-        "installationFoundTooltip": "Agent configuration found. You may need to log in to use it.",
-        "notFound": "Unknown",
-        "notFoundTooltip": "We couldn't verify this agent is set up, but go ahead and try it."
+        "installationFoundTooltip": "Agent configuration found. You may need to log in to use it."
       },
       "editor": {
         "formLabel": "Edit JSON",

--- a/frontend/src/i18n/locales/es/settings.json
+++ b/frontend/src/i18n/locales/es/settings.json
@@ -259,9 +259,7 @@
         "loginDetected": "Uso reciente detectado",
         "loginDetectedTooltip": "Se encontraron credenciales de autenticación recientes para este agente",
         "installationFound": "Uso previo detectado",
-        "installationFoundTooltip": "Se encontró la configuración del agente. Es posible que debas iniciar sesión para usarlo.",
-        "notFound": "Desconocido",
-        "notFoundTooltip": "No pudimos verificar que este agente esté configurado, pero pruébalo."
+        "installationFoundTooltip": "Se encontró la configuración del agente. Es posible que debas iniciar sesión para usarlo."
       },
       "editor": {
         "formLabel": "Editar JSON",

--- a/frontend/src/i18n/locales/fr/settings.json
+++ b/frontend/src/i18n/locales/fr/settings.json
@@ -259,9 +259,7 @@
         "loginDetected": "Utilisation récente détectée",
         "loginDetectedTooltip": "Identifiants d'authentification récents trouvés pour cet agent",
         "installationFound": "Utilisation précédente détectée",
-        "installationFoundTooltip": "Configuration d'agent trouvée. Vous devrez peut-être vous connecter pour l'utiliser.",
-        "notFound": "Inconnu",
-        "notFoundTooltip": "Nous n'avons pas pu vérifier que cet agent est configuré, mais vous pouvez essayer."
+        "installationFoundTooltip": "Configuration d'agent trouvée. Vous devrez peut-être vous connecter pour l'utiliser."
       },
       "editor": {
         "formLabel": "Modifier le JSON",

--- a/frontend/src/i18n/locales/ja/settings.json
+++ b/frontend/src/i18n/locales/ja/settings.json
@@ -259,9 +259,7 @@
         "loginDetected": "最近の使用を検出",
         "loginDetectedTooltip": "このエージェントの最近の認証情報が見つかりました",
         "installationFound": "以前の使用を検出",
-        "installationFoundTooltip": "エージェント設定が見つかりました。使用するにはログインが必要な場合があります。",
-        "notFound": "不明",
-        "notFoundTooltip": "このエージェントが設定されているか確認できませんでしたが、試してみてください。"
+        "installationFoundTooltip": "エージェント設定が見つかりました。使用するにはログインが必要な場合があります。"
       },
       "editor": {
         "formLabel": "JSONを編集",

--- a/frontend/src/i18n/locales/ko/settings.json
+++ b/frontend/src/i18n/locales/ko/settings.json
@@ -259,9 +259,7 @@
         "loginDetected": "최근 사용 감지됨",
         "loginDetectedTooltip": "이 에이전트에 대한 최근 인증 자격 증명이 발견되었습니다",
         "installationFound": "이전 사용 감지됨",
-        "installationFoundTooltip": "에이전트 구성이 발견되었습니다. 사용하려면 로그인해야 할 수 있습니다.",
-        "notFound": "알 수 없음",
-        "notFoundTooltip": "이 에이전트가 설정되어 있는지 확인할 수 없지만, 시도해 보세요."
+        "installationFoundTooltip": "에이전트 구성이 발견되었습니다. 사용하려면 로그인해야 할 수 있습니다."
       },
       "editor": {
         "formLabel": "JSON 편집",

--- a/frontend/src/i18n/locales/zh-Hans/settings.json
+++ b/frontend/src/i18n/locales/zh-Hans/settings.json
@@ -259,9 +259,7 @@
         "loginDetected": "检测到最近使用",
         "loginDetectedTooltip": "找到此代理的最近身份验证凭据",
         "installationFound": "检测到以前使用",
-        "installationFoundTooltip": "找到代理配置。您可能需要登录才能使用它。",
-        "notFound": "未知",
-        "notFoundTooltip": "我们无法验证此代理是否已设置，但请继续尝试。"
+        "installationFoundTooltip": "找到代理配置。您可能需要登录才能使用它。"
       },
       "editor": {
         "formLabel": "编辑 JSON",

--- a/frontend/src/i18n/locales/zh-Hant/settings.json
+++ b/frontend/src/i18n/locales/zh-Hant/settings.json
@@ -259,9 +259,7 @@
         "loginDetected": "偵測到最近使用",
         "loginDetectedTooltip": "找到此代理的最近驗證憑證",
         "installationFound": "偵測到曾使用",
-        "installationFoundTooltip": "找到代理設定。您可能需要登入才能使用。",
-        "notFound": "未知",
-        "notFoundTooltip": "我們無法驗證此代理是否已設定，但請繼續嘗試。"
+        "installationFoundTooltip": "找到代理設定。您可能需要登入才能使用。"
       },
       "editor": {
         "formLabel": "編輯 JSON",


### PR DESCRIPTION
## Summary

Remove the confusing "Unknown" agent availability state from the frontend UI. When the system cannot determine if an agent is configured, it previously displayed an "Unknown" status with a warning icon, which was confusing to users.

## Changes

- **Removed the `not_found` status display** from `AgentAvailabilityIndicator.tsx`
- **Removed unused `AlertCircle` import** since it was only used for the Unknown state
- **Cleaned up translation files** (all 7 locales) by removing the `notFound` and `notFoundTooltip` keys from the availability section

## What's Preserved

The other two availability states remain unchanged:
- ✅ **"Recent Usage Detected"** (`login_detected`) - shown when recent auth credentials are found
- ✅ **"Previous Usage Detected"** (`installation_found`) - shown when agent configuration exists

## Behavior Change

When agent availability cannot be verified, the UI now simply shows nothing instead of displaying a confusing "Unknown" warning.

---

- [x] tested

This PR was written using [Vibe Kanban](https://vibekanban.com)