### PR TITLE
feat: add branch name search to workspaces sidebar (Vibe Kanban)

### DIFF
--- a/frontend/src/components/ui-new/hooks/useWorkspaces.ts
+++ b/frontend/src/components/ui-new/hooks/useWorkspaces.ts
@@ -13,6 +13,7 @@ export interface SidebarWorkspace {
   id: string;
   taskId: string;
   name: string;
+  branch: string;
   description: string;
   filesChanged?: number;
   linesAdded?: number;
@@ -53,6 +54,7 @@ function toSidebarWorkspace(
     id: ws.id,
     taskId: ws.task_id,
     name: ws.name ?? ws.branch, // Use name if available, fallback to branch
+    branch: ws.branch,
     description: '',
     // Use real stats from summary if available
     filesChanged: summary?.files_changed ?? undefined,

--- a/frontend/src/components/ui-new/views/WorkspacesSidebar.tsx
+++ b/frontend/src/components/ui-new/views/WorkspacesSidebar.tsx
@@ -97,11 +97,19 @@ export function WorkspacesSidebar({
   const DISPLAY_LIMIT = 10;
 
   const filteredWorkspaces = workspaces
-    .filter((workspace) => workspace.name.toLowerCase().includes(searchLower))
+    .filter(
+      (workspace) =>
+        workspace.name.toLowerCase().includes(searchLower) ||
+        workspace.branch.toLowerCase().includes(searchLower)
+    )
     .slice(0, isSearching ? undefined : DISPLAY_LIMIT);
 
   const filteredArchivedWorkspaces = archivedWorkspaces
-    .filter((workspace) => workspace.name.toLowerCase().includes(searchLower))
+    .filter(
+      (workspace) =>
+        workspace.name.toLowerCase().includes(searchLower) ||
+        workspace.branch.toLowerCase().includes(searchLower)
+    )
     .slice(0, isSearching ? undefined : DISPLAY_LIMIT);
 
   // Categorize workspaces for accordion layout


### PR DESCRIPTION
## Summary
- Added branch name search capability to the workspaces sidebar
- Search now matches against both workspace name and git branch name

## Why
Previously, the workspaces sidebar search only matched against workspace names. When workspaces don't have custom names (which is common), they display their branch name as the title. However, searching by branch name didn't work, making it difficult to find workspaces when you knew the branch but not the exact display name.

## Implementation Details
- Added `branch` field to the `SidebarWorkspace` interface in `useWorkspaces.ts`
- Updated `toSidebarWorkspace` transformation to include the branch from the workspace data
- Modified the filter logic in `WorkspacesSidebar.tsx` to check both `name` and `branch` fields
- Both active and archived workspace lists now support branch name search
- Search remains case-insensitive

## Files Changed
- `frontend/src/components/ui-new/hooks/useWorkspaces.ts`
- `frontend/src/components/ui-new/views/WorkspacesSidebar.tsx`

---
This PR was written using [Vibe Kanban](https://vibekanban.com)