### PR TITLE
feat: override default worktree directory

### DIFF
--- a/crates/local-deployment/src/lib.rs
+++ b/crates/local-deployment/src/lib.rs
@@ -20,6 +20,7 @@ use services::services::{
     queued_message::QueuedMessageService,
     remote_client::{RemoteClient, RemoteClientError},
     repo::RepoService,
+    worktree_manager::WorktreeManager,
 };
 use tokio::sync::RwLock;
 use utils::{
@@ -89,6 +90,11 @@ impl Deployment for LocalDeployment {
 
         // Always save config (may have been migrated or version updated)
         save_config_to_file(&raw_config, &config_path()).await?;
+
+        if let Some(workspace_dir) = &raw_config.workspace_dir {
+            let path = utils::path::expand_tilde(workspace_dir);
+            WorktreeManager::set_workspace_dir_override(path);
+        }
 
         let config = Arc::new(RwLock::new(raw_config));
         let user_id = generate_user_id();

--- a/frontend/src/i18n/locales/en/settings.json
+++ b/frontend/src/i18n/locales/en/settings.json
@@ -135,6 +135,14 @@
             "invalidChars": "Contains invalid characters.",
             "controlChars": "Contains control characters."
           }
+        },
+        "workspaceDir": {
+          "label": "Workspace Directory",
+          "placeholder": "~/",
+          "helper": "Workspaces will be created in a .vibe-kanban-workspaces subdirectory within this path. Leave empty to use the system default. Changes require an app restart.",
+          "browse": "Browse",
+          "dialogTitle": "Select Workspace Directory",
+          "dialogDescription": "Choose a directory. Workspaces will be created in a .vibe-kanban-workspaces subdirectory within it."
         }
       },
       "pullRequests": {

--- a/frontend/src/i18n/locales/es/settings.json
+++ b/frontend/src/i18n/locales/es/settings.json
@@ -135,6 +135,14 @@
             "invalidChars": "Contiene caracteres no válidos.",
             "controlChars": "Contiene caracteres de control."
           }
+        },
+        "workspaceDir": {
+          "label": "Directorio de Espacios de Trabajo",
+          "placeholder": "~/",
+          "helper": "Los espacios de trabajo se crearán en un subdirectorio .vibe-kanban-workspaces dentro de esta ruta. Dejar vacío para usar el valor predeterminado del sistema. Los cambios requieren reiniciar la aplicación.",
+          "browse": "Explorar",
+          "dialogTitle": "Seleccionar Directorio de Espacios de Trabajo",
+          "dialogDescription": "Elija un directorio. Los espacios de trabajo se crearán en un subdirectorio .vibe-kanban-workspaces dentro de él."
         }
       },
       "pullRequests": {

--- a/frontend/src/i18n/locales/fr/settings.json
+++ b/frontend/src/i18n/locales/fr/settings.json
@@ -135,6 +135,14 @@
             "invalidChars": "Contient des caractères invalides.",
             "controlChars": "Contient des caractères de contrôle."
           }
+        },
+        "workspaceDir": {
+          "label": "Répertoire des espaces de travail",
+          "placeholder": "~/",
+          "helper": "Les espaces de travail seront créés dans un sous-répertoire .vibe-kanban-workspaces à l'intérieur de ce chemin. Laissez vide pour utiliser la valeur par défaut du système. Les modifications nécessitent un redémarrage de l'application.",
+          "browse": "Parcourir",
+          "dialogTitle": "Sélectionner le répertoire des espaces de travail",
+          "dialogDescription": "Choisissez un répertoire. Les espaces de travail seront créés dans un sous-répertoire .vibe-kanban-workspaces à l'intérieur."
         }
       },
       "pullRequests": {

--- a/frontend/src/i18n/locales/ja/settings.json
+++ b/frontend/src/i18n/locales/ja/settings.json
@@ -135,6 +135,14 @@
             "invalidChars": "無効な文字が含まれています。",
             "controlChars": "制御文字が含まれています。"
           }
+        },
+        "workspaceDir": {
+          "label": "ワークスペースディレクトリ",
+          "placeholder": "~/",
+          "helper": "このパス内の .vibe-kanban-workspaces サブディレクトリにワークスペースが作成されます。システムのデフォルトを使用する場合は空白のままにしてください。変更を反映するにはアプリの再起動が必要です。",
+          "browse": "参照",
+          "dialogTitle": "ワークスペースディレクトリを選択",
+          "dialogDescription": "ディレクトリを選択してください。ワークスペースはその中の .vibe-kanban-workspaces サブディレクトリに作成されます。"
         }
       },
       "pullRequests": {

--- a/frontend/src/i18n/locales/ko/settings.json
+++ b/frontend/src/i18n/locales/ko/settings.json
@@ -135,6 +135,14 @@
             "invalidChars": "유효하지 않은 문자가 포함되어 있습니다.",
             "controlChars": "제어 문자가 포함되어 있습니다."
           }
+        },
+        "workspaceDir": {
+          "label": "워크스페이스 디렉토리",
+          "placeholder": "~/",
+          "helper": "이 경로 내의 .vibe-kanban-workspaces 하위 디렉토리에 워크스페이스가 생성됩니다. 시스템 기본값을 사용하려면 비워두세요. 변경 사항은 앱을 다시 시작해야 적용됩니다.",
+          "browse": "찾아보기",
+          "dialogTitle": "워크스페이스 디렉토리 선택",
+          "dialogDescription": "디렉토리를 선택하세요. 워크스페이스는 해당 디렉토리 내의 .vibe-kanban-workspaces 하위 디렉토리에 생성됩니다."
         }
       },
       "pullRequests": {

--- a/frontend/src/i18n/locales/zh-Hans/settings.json
+++ b/frontend/src/i18n/locales/zh-Hans/settings.json
@@ -135,6 +135,14 @@
             "invalidChars": "包含无效字符。",
             "controlChars": "包含控制字符。"
           }
+        },
+        "workspaceDir": {
+          "label": "工作区目录",
+          "placeholder": "~/",
+          "helper": "工作区将在此路径内的 .vibe-kanban-workspaces 子目录中创建。留空以使用系统默认值。更改需要重启应用程序。",
+          "browse": "浏览",
+          "dialogTitle": "选择工作区目录",
+          "dialogDescription": "选择一个目录。工作区将在其中的 .vibe-kanban-workspaces 子目录中创建。"
         }
       },
       "pullRequests": {

--- a/frontend/src/i18n/locales/zh-Hant/settings.json
+++ b/frontend/src/i18n/locales/zh-Hant/settings.json
@@ -135,6 +135,14 @@
             "invalidChars": "包含無效字元。",
             "controlChars": "包含控制字元。"
           }
+        },
+        "workspaceDir": {
+          "label": "工作區目錄",
+          "placeholder": "~/",
+          "helper": "工作區將在此路徑內的 .vibe-kanban-workspaces 子目錄中建立。留空以使用系統預設值。變更需要重新啟動應用程式。",
+          "browse": "瀏覽",
+          "dialogTitle": "選擇工作區目錄",
+          "dialogDescription": "選擇一個目錄。工作區將在其中的 .vibe-kanban-workspaces 子目錄中建立。"
         }
       },
       "pullRequests": {

--- a/frontend/src/pages/settings/GeneralSettings.tsx
+++ b/frontend/src/pages/settings/GeneralSettings.tsx
@@ -20,7 +20,7 @@ import { Label } from '@/components/ui/label';
 import { Input } from '@/components/ui/input';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Checkbox } from '@/components/ui/checkbox';
-import { Loader2, Volume2 } from 'lucide-react';
+import { FolderOpen, Loader2, Volume2 } from 'lucide-react';
 import {
   DEFAULT_PR_DESCRIPTION_PROMPT,
   EditorType,
@@ -36,6 +36,7 @@ import { EditorAvailabilityIndicator } from '@/components/EditorAvailabilityIndi
 import { useTheme } from '@/components/ThemeProvider';
 import { useUserSystem } from '@/components/ConfigProvider';
 import { TagManager } from '@/components/TagManager';
+import { FolderPickerDialog } from '@/components/dialogs/shared/FolderPickerDialog';
 
 export function GeneralSettings() {
   const { t } = useTranslation(['settings', 'common']);
@@ -167,6 +168,17 @@ export function GeneralSettings() {
     if (!config) return;
     setDraft(cloneDeep(config));
     setDirty(false);
+  };
+
+  const handleBrowseWorkspaceDir = async () => {
+    const result = await FolderPickerDialog.show({
+      value: draft?.workspace_dir ?? '',
+      title: t('settings.general.git.workspaceDir.dialogTitle'),
+      description: t('settings.general.git.workspaceDir.dialogDescription'),
+    });
+    if (result) {
+      updateDraft({ workspace_dir: result });
+    }
   };
 
   const resetDisclaimer = async () => {
@@ -461,6 +473,36 @@ export function GeneralSettings() {
                   </code>
                 </>
               )}
+            </p>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="workspace-dir">
+              {t('settings.general.git.workspaceDir.label')}
+            </Label>
+            <div className="flex space-x-2">
+              <Input
+                id="workspace-dir"
+                type="text"
+                placeholder={t('settings.general.git.workspaceDir.placeholder')}
+                value={draft?.workspace_dir ?? ''}
+                onChange={(e) => {
+                  const value = e.target.value;
+                  updateDraft({ workspace_dir: value || null });
+                }}
+                className="flex-1"
+              />
+              <Button
+                type="button"
+                variant="outline"
+                onClick={handleBrowseWorkspaceDir}
+              >
+                <FolderOpen className="h-4 w-4 mr-2" />
+                {t('settings.general.git.workspaceDir.browse')}
+              </Button>
+            </div>
+            <p className="text-sm text-muted-foreground">
+              {t('settings.general.git.workspaceDir.helper')}
             </p>
           </div>
         </CardContent>


### PR DESCRIPTION
Adds a global override for the default worktree directory.

Addresses:
- https://github.com/BloopAI/vibe-kanban/issues/2093
- https://github.com/BloopAI/vibe-kanban/issues/1830
- https://github.com/BloopAI/vibe-kanban/issues/1620
- https://github.com/BloopAI/vibe-kanban/issues/1244

