### PR TITLE
fix: remove misleading shebang from script placeholder text (Vibe Kanban)

### DIFF
--- a/frontend/src/components/dialogs/scripts/ScriptFixerDialog.tsx
+++ b/frontend/src/components/dialogs/scripts/ScriptFixerDialog.tsx
@@ -307,10 +307,10 @@ const ScriptFixerDialogImpl = NiceModal.create<ScriptFixerDialogProps>(
                     className="font-mono text-sm p-3 border-0 min-h-full bg-panel"
                     placeholder={
                       scriptType === 'setup'
-                        ? '#!/bin/bash\nnpm install'
+                        ? 'npm install'
                         : scriptType === 'cleanup'
-                          ? '#!/bin/bash\nrm -rf node_modules'
-                          : '#!/bin/bash\nnpm run dev'
+                          ? 'rm -rf node_modules'
+                          : 'npm run dev'
                     }
                     disableInternalScroll
                   />

--- a/frontend/src/utils/scriptPlaceholders.ts
+++ b/frontend/src/utils/scriptPlaceholders.ts
@@ -27,14 +27,11 @@ REM This runs after coding agent execution - only if changes were made`,
 class UnixScriptPlaceholderStrategy implements ScriptPlaceholderStrategy {
   getPlaceholders(): ScriptPlaceholders {
     return {
-      setup: `#!/bin/bash
-npm install
+      setup: `npm install
 # Add any setup commands here...`,
-      dev: `#!/bin/bash
-npm run dev
+      dev: `npm run dev
 # Add dev server start command here...`,
-      cleanup: `#!/bin/bash
-# Add cleanup commands here...
+      cleanup: `# Add cleanup commands here...
 # This runs after coding agent execution - only if changes were made`,
     };
   }


### PR DESCRIPTION
## Summary

Removes the `#!/bin/bash` shebang lines from script input placeholder text to fix a UX disconnect where users were misled into thinking shebangs would be respected.

## Problem

The script input boxes (setup, dev server, cleanup) displayed placeholder text starting with `#!/bin/bash`, implying that shebang directives would be honored. However, the backend executes scripts by passing them as string arguments to the user's `$SHELL` (e.g., `bash -c "script content"`), which means shebangs are completely ignored and treated as comments.

This caused issues for users with non-POSIX shells like Fish, where bash-specific syntax would fail unexpectedly.

Relates to #2143

## Changes

- **`frontend/src/utils/scriptPlaceholders.ts`**: Removed `#!/bin/bash` from Unix script placeholders (setup, dev, cleanup)
- **`frontend/src/components/dialogs/scripts/ScriptFixerDialog.tsx`**: Removed `#!/bin/bash` from hardcoded placeholder strings

## Before/After

**Before:**
```
#!/bin/bash
npm install
# Add any setup commands here...
```

**After:**
```
npm install
# Add any setup commands here...
```

---

This PR was written using [Vibe Kanban](https://vibekanban.com)