### PR TITLE
Add tooltips to attach images and review icons in chat box (Vibe Kanban)

### DIFF
--- a/frontend/src/components/ui-new/actions/index.ts
+++ b/frontend/src/components/ui-new/actions/index.ts
@@ -346,7 +346,7 @@ export const Actions = {
     icon: HighlighterIcon,
     requiresTarget: true,
     isVisible: (ctx) => ctx.hasWorkspace,
-    getTooltip: () => 'Ask the agent to review your changes',
+    getTooltip: () => 'Review changes with agent',
     execute: async (_ctx, workspaceId) => {
       await StartReviewDialog.show({
         workspaceId,

--- a/frontend/src/components/ui-new/primitives/CreateChatBox.tsx
+++ b/frontend/src/components/ui-new/primitives/CreateChatBox.tsx
@@ -132,7 +132,8 @@ export function CreateChatBox({
         <>
           <ToolbarIconButton
             icon={PaperclipIcon}
-            aria-label="Attach file"
+            aria-label={t('tasks:taskFormDialog.attachImage')}
+            title={t('tasks:taskFormDialog.attachImage')}
             onClick={handleAttachClick}
             disabled={isSending}
           />

--- a/frontend/src/components/ui-new/primitives/SessionChatBox.tsx
+++ b/frontend/src/components/ui-new/primitives/SessionChatBox.tsx
@@ -34,7 +34,10 @@ import {
   type ActionVisibilityContext,
   isSpecialIcon,
 } from '../actions';
-import { isActionEnabled } from '../actions/useActionVisibility';
+import {
+  isActionEnabled,
+  getActionTooltip,
+} from '../actions/useActionVisibility';
 import {
   DropdownMenuItem,
   DropdownMenuLabel,
@@ -642,7 +645,8 @@ export function SessionChatBox({
         <>
           <ToolbarIconButton
             icon={PaperclipIcon}
-            aria-label="Attach file"
+            aria-label={t('tasks:taskFormDialog.attachImage')}
+            title={t('tasks:taskFormDialog.attachImage')}
             onClick={handleAttachClick}
             disabled={isDisabled || isRunning}
           />
@@ -667,11 +671,13 @@ export function SessionChatBox({
               typeof action.label === 'function'
                 ? action.label()
                 : action.label;
+            const tooltip = getActionTooltip(action, toolbarActions.context);
             return (
               <ToolbarIconButton
                 key={action.id}
                 icon={icon}
                 aria-label={label}
+                title={tooltip}
                 onClick={() => toolbarActions.onExecuteAction(action)}
                 disabled={isButtonDisabled}
               />


### PR DESCRIPTION
## Summary

This PR adds tooltips to the icon buttons in the chat box UI to improve discoverability and accessibility:

- **Attach images button** (paperclip icon): Now shows "Attach image" tooltip using the existing i18n translation key
- **Review button** (highlighter icon): Now shows "Review changes with agent" tooltip
- **All toolbar action buttons**: Now display their respective tooltips from the action definitions

## Changes Made

1. **SessionChatBox.tsx**:
   - Added `title` prop to the attach images button using the `tasks:taskFormDialog.attachImage` translation
   - Imported `getActionTooltip` from the action visibility utilities
   - Added tooltip rendering for all toolbar action buttons

2. **CreateChatBox.tsx**:
   - Added `title` prop to the attach images button using the same translation key

3. **actions/index.ts**:
   - Updated the StartReview action tooltip from "Ask the agent to review your changes" to the more concise "Review changes with agent"

## Why

Icon-only buttons can be difficult for users to understand, especially for new users. Adding tooltips improves the user experience by providing context on hover without cluttering the UI.

---

This PR was written using [Vibe Kanban](https://vibekanban.com)