### PR TITLE
feat: add VIBE_KANBAN_PORT env var to avoid conflicts with child processes

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ The following environment variables can be configured at build time or runtime:
 |----------|------|---------|-------------|
 | `POSTHOG_API_KEY` | Build-time | Empty | PostHog analytics API key (disables analytics if empty) |
 | `POSTHOG_API_ENDPOINT` | Build-time | Empty | PostHog analytics endpoint (disables analytics if empty) |
+| `VIBE_KANBAN_PORT` | Runtime | Auto-assign | Same as `PORT` but takes precedence; avoids conflicts with child processes that read `PORT` |
 | `PORT` | Runtime | Auto-assign | **Production**: Server port. **Dev**: Frontend port (backend uses PORT+1) |
 | `BACKEND_PORT` | Runtime | `0` (auto-assign) | Backend server port (dev mode only, overrides PORT+1) |
 | `FRONTEND_PORT` | Runtime | `3000` | Frontend dev server port (dev mode only, overrides PORT) |

--- a/crates/server/src/bin/mcp_task_server.rs
+++ b/crates/server/src/bin/mcp_task_server.rs
@@ -42,6 +42,7 @@ fn main() -> anyhow::Result<()> {
                 // Get port from environment variables or fall back to port file
                 let port = match std::env::var("MCP_PORT")
                     .or_else(|_| std::env::var("BACKEND_PORT"))
+                    .or_else(|_| std::env::var("VIBE_KANBAN_PORT"))
                     .or_else(|_| std::env::var("PORT"))
                 {
                     Ok(port_str) => {

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -86,6 +86,7 @@ async fn main() -> Result<(), VibeKanbanError> {
     let app_router = routes::router(deployment.clone());
 
     let port = std::env::var("BACKEND_PORT")
+        .or_else(|_| std::env::var("VIBE_KANBAN_PORT"))
         .or_else(|_| std::env::var("PORT"))
         .ok()
         .and_then(|s| {

--- a/scripts/setup-dev-environment.js
+++ b/scripts/setup-dev-environment.js
@@ -83,9 +83,11 @@ async function verifyPorts(ports) {
  * Allocate ports for development
  */
 async function allocatePorts() {
-  // If PORT env is set, use it for frontend and PORT+1 for backend
-  if (process.env.PORT) {
-    const frontendPort = parseInt(process.env.PORT, 10);
+  // If VIBE_KANBAN_PORT or PORT env is set, use it for frontend and port+1 for backend
+  // VIBE_KANBAN_PORT takes precedence to avoid conflicts with child processes that read PORT
+  const explicitPort = process.env.VIBE_KANBAN_PORT || process.env.PORT;
+  if (explicitPort) {
+    const frontendPort = parseInt(explicitPort, 10);
     const backendPort = frontendPort + 1;
 
     const ports = {
@@ -95,7 +97,8 @@ async function allocatePorts() {
     };
 
     if (process.argv[2] === "get") {
-      console.log("Using PORT environment variable:");
+      const envVar = process.env.VIBE_KANBAN_PORT ? "VIBE_KANBAN_PORT" : "PORT";
+      console.log(`Using ${envVar} environment variable:`);
       console.log(`Frontend: ${ports.frontend}`);
       console.log(`Backend: ${ports.backend}`);
     }


### PR DESCRIPTION
## Problem

Many apps depend on the `PORT` env var. When running Vibe Kanban with `PORT=3000`, any child processes (e.g., Node.js dev servers spawned by task attempts) inherit this variable and try to bind to the same port, causing conflicts.

## Solution

Add `VIBE_KANBAN_PORT` as an alternative that takes precedence over `PORT`. This allows setting a dedicated port for Vibe Kanban without affecting child processes that read `PORT`.

## Changes
- `crates/server/src/main.rs` - read `VIBE_KANBAN_PORT` before `PORT`
- `crates/server/src/bin/mcp_task_server.rs` - read `VIBE_KANBAN_PORT` before `PORT`
- `scripts/setup-dev-environment.js` - check `VIBE_KANBAN_PORT` before `PORT`
- `README.md` - document the new env var

## Test plan
- [x] `cargo check --workspace` passes
- [x] `pnpm run check` passes
- [x] Dev build: `VIBE_KANBAN_PORT=4444` correctly allocates ports 4444/4445
- [x] Dev build: `PORT=3000 VIBE_KANBAN_PORT=4444` uses 4444 (precedence verified)
- [x] Release build: `VIBE_KANBAN_PORT=4444` starts server on :4444
- [x] Release build: `PORT=3000 VIBE_KANBAN_PORT=5555` starts server on :5555 (precedence verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)