### PR TITLE
feat(i18n): add missing dialogs.selectGitRepository translations (Vibe Kanban)

### DIFF
--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -205,6 +205,10 @@
     "defaultConfirm": "Confirm",
     "defaultCancel": "Cancel"
   },
+  "dialogs": {
+    "selectGitRepository": "Select Git Repository",
+    "chooseExistingRepo": "Choose an existing repository from your file system"
+  },
   "empty": {
     "noChanges": "No changes to display"
   },

--- a/frontend/src/i18n/locales/es/common.json
+++ b/frontend/src/i18n/locales/es/common.json
@@ -205,6 +205,10 @@
     "defaultConfirm": "Confirmar",
     "defaultCancel": "Cancelar"
   },
+  "dialogs": {
+    "selectGitRepository": "Seleccionar repositorio Git",
+    "chooseExistingRepo": "Elige un repositorio existente de tu sistema de archivos"
+  },
   "empty": {
     "noChanges": "No hay cambios para mostrar"
   },

--- a/frontend/src/i18n/locales/fr/common.json
+++ b/frontend/src/i18n/locales/fr/common.json
@@ -205,6 +205,10 @@
     "defaultConfirm": "Confirmer",
     "defaultCancel": "Annuler"
   },
+  "dialogs": {
+    "selectGitRepository": "Sélectionner un dépôt Git",
+    "chooseExistingRepo": "Choisissez un dépôt existant depuis votre système de fichiers"
+  },
   "empty": {
     "noChanges": "Aucune modification à afficher"
   },

--- a/frontend/src/i18n/locales/ja/common.json
+++ b/frontend/src/i18n/locales/ja/common.json
@@ -205,6 +205,10 @@
     "defaultConfirm": "確認",
     "defaultCancel": "キャンセル"
   },
+  "dialogs": {
+    "selectGitRepository": "Gitリポジトリを選択",
+    "chooseExistingRepo": "ファイルシステムから既存のリポジトリを選択してください"
+  },
   "empty": {
     "noChanges": "表示する変更がありません"
   },

--- a/frontend/src/i18n/locales/ko/common.json
+++ b/frontend/src/i18n/locales/ko/common.json
@@ -205,6 +205,10 @@
     "defaultConfirm": "확인",
     "defaultCancel": "취소"
   },
+  "dialogs": {
+    "selectGitRepository": "Git 저장소 선택",
+    "chooseExistingRepo": "파일 시스템에서 기존 저장소를 선택하세요"
+  },
   "empty": {
     "noChanges": "표시할 변경사항이 없습니다"
   },

--- a/frontend/src/i18n/locales/zh-Hans/common.json
+++ b/frontend/src/i18n/locales/zh-Hans/common.json
@@ -205,6 +205,10 @@
     "defaultConfirm": "确认",
     "defaultCancel": "取消"
   },
+  "dialogs": {
+    "selectGitRepository": "选择 Git 仓库",
+    "chooseExistingRepo": "从文件系统中选择现有仓库"
+  },
   "empty": {
     "noChanges": "没有要显示的更改"
   },

--- a/frontend/src/i18n/locales/zh-Hant/common.json
+++ b/frontend/src/i18n/locales/zh-Hant/common.json
@@ -205,6 +205,10 @@
     "defaultConfirm": "確認",
     "defaultCancel": "取消"
   },
+  "dialogs": {
+    "selectGitRepository": "選擇 Git 儲存庫",
+    "chooseExistingRepo": "從檔案系統中選擇現有儲存庫"
+  },
   "empty": {
     "noChanges": "沒有要顯示的變更"
   },


### PR DESCRIPTION
## Summary

Adds missing i18n translations for the `dialogs.selectGitRepository` and `dialogs.chooseExistingRepo` keys across all supported locales.

## Changes

- Added new `dialogs` section to `common.json` for all 7 locales:
  - English (en)
  - Spanish (es)
  - French (fr)
  - Japanese (ja)
  - Korean (ko)
  - Simplified Chinese (zh-Hans)
  - Traditional Chinese (zh-Hant)

## Why

The `BrowseRepoButtonContainer` component uses these translation keys for the folder picker dialog title and description when browsing for git repositories. These keys were being referenced but not defined, causing the raw keys to display instead of localized text.

## Implementation Details

- Translation keys added:
  - `dialogs.selectGitRepository` - Dialog title (e.g., "Select Git Repository")
  - `dialogs.chooseExistingRepo` - Dialog description (e.g., "Choose an existing repository from your file system")
- All translations follow the existing conventions in each locale file
- Placed alphabetically after the `confirm` section in each `common.json`

## Testing

- [x] `pnpm run check` passes
- [x] `scripts/check-i18n.sh` passes (no missing keys, no duplicate keys)

---

This PR was written using [Vibe Kanban](https://vibekanban.com)