### PR TITLE
fix(npx-cli): restore scoped package name

### DIFF
--- a/npx-cli/package.json
+++ b/npx-cli/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "vibe-kanban",
+  "name": "@mxyhi/vibe-kanban",
   "private": false,
   "version": "0.0.158",
   "main": "index.js",


### PR DESCRIPTION
## Summary
- Restore scoped npm package name for npx-cli

## Context
Upstream sync reverted the scoped name, causing publishes to target the upstream-owned `vibe-kanban` package and fail with 403.

## Testing
- Not run (metadata change only)