### PR TITLE
fix: prevent placeholder overlap with footer in chat box

### DIFF
--- a/frontend/src/components/ui-new/primitives/ChatBoxBase.tsx
+++ b/frontend/src/components/ui-new/primitives/ChatBoxBase.tsx
@@ -179,10 +179,10 @@ export function ChatBoxBase({
           onChange={editor.onChange}
           onCmdEnter={onCmdEnter}
           disabled={disabled}
-          // min-h-6 (1.5rem) ensures space for at least one line of text,
+          // min-h-double ensures space for at least one line of text,
           // preventing the absolutely-positioned placeholder from overlapping
           // with the footer when the editor is empty
-          className="min-h-6 max-h-[50vh] overflow-y-auto"
+          className="min-h-double max-h-[50vh] overflow-y-auto"
           workspaceId={workspaceId}
           projectId={projectId}
           autoFocus={autoFocus}


### PR DESCRIPTION
The chat box editor had min-h-0 which allowed it to collapse to zero height when empty. Since the placeholder text is absolutely positioned, it doesn't contribute to the container's height, causing it to visually overlap with the footer controls (variant dropdown, attach button, etc.) when the editor collapsed.

Changed min-h-0 to min-h-6 (1.5rem) to ensure the editor always reserves space for at least one line of text, preventing the overlap while still allowing the editor to grow and scroll normally.