### PR TITLE
Datetime in cards (vibe-kanban)

### DIFF
--- a/frontend/src/components/tasks/TaskCard.tsx
+++ b/frontend/src/components/tasks/TaskCard.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { KanbanCard } from '@/components/ui/shadcn-io/kanban';
-import { Link, Loader2, XCircle } from 'lucide-react';
+import { Calendar, Link, Loader2, RefreshCw, XCircle } from 'lucide-react';
 import type { TaskWithAttemptStatus } from 'shared/types';
 import { ActionsDropdown } from '@/components/ui/actions-dropdown';
 import { Button } from '@/components/ui/button';
@@ -9,6 +9,7 @@ import { paths } from '@/lib/paths';
 import { attemptsApi } from '@/lib/api';
 import { TaskCardHeader } from './TaskCardHeader';
 import { useTranslation } from 'react-i18next';
+import { formatRelativeTime } from '@/utils/date';
 
 type Task = TaskWithAttemptStatus;
 
@@ -119,6 +120,17 @@ export function TaskCard({
               : task.description}
           </p>
         )}
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          <Calendar className="h-3 w-3 shrink-0" />
+          <span>{formatRelativeTime(task.created_at)}</span>
+          {task.updated_at !== task.created_at && (
+            <>
+              <span className="text-muted-foreground/30">•</span>
+              <RefreshCw className="h-3 w-3 shrink-0" />
+              <span>{formatRelativeTime(task.updated_at)}</span>
+            </>
+          )}
+        </div>
       </div>
     </KanbanCard>
   );


### PR DESCRIPTION
## Summary

This PR adds task timestamp visibility to kanban cards and introduces a workspace directory configuration option.

## Changes

### Task Card Timestamps
- Added creation date and last updated date display to task cards
- Uses relative time formatting (e.g., "5m ago", "2h ago", "3d ago")
- Visual distinction with `Calendar` icon for creation and `RefreshCw` icon for updates
- Only displays update timestamp when it differs from creation time
- Subtle styling that doesn't clutter the card UI

### Workspace Directory Configuration
- Users can now specify a custom directory for workspace creation
- Added folder picker dialog in General Settings
- Workspaces are organized in `.vibe-kanban-workspaces` subdirectory within the chosen path
- Backend support for workspace directory override across all workspace management services

## Implementation Details

**TaskCard.tsx changes:**
```tsx
<div className="flex items-center gap-2 text-xs text-muted-foreground">
  <Calendar className="h-3 w-3 shrink-0" />
  <span>{formatRelativeTime(task.created_at)}</span>
  {task.updated_at !== task.created_at && (
    <>
      <span className="text-muted-foreground/30">•</span>
      <RefreshCw className="h-3 w-3 shrink-0" />
      <span>{formatRelativeTime(task.updated_at)}</span>
    </>
  )}
</div>
```

## Files Changed
- 14 files modified
- 170 insertions, 14 deletions
- Full i18n support across 7 locales

---

This PR was written using [Vibe Kanban](https://vibekanban.com)