### PR TITLE
refactor: remove redundant check_auth from git_host providers (Vibe Kanban)

### DIFF
--- a/crates/services/src/services/git_host/azure/cli.rs
+++ b/crates/services/src/services/git_host/azure/cli.rs
@@ -308,14 +308,6 @@ impl AzCli {
         Self::parse_pr_response(&raw)
     }
 
-    pub fn check_auth(&self) -> Result<(), AzCliError> {
-        match self.run(["account", "show"], None) {
-            Ok(_) => Ok(()),
-            Err(AzCliError::CommandFailed(msg)) => Err(AzCliError::AuthFailed(msg)),
-            Err(err) => Err(err),
-        }
-    }
-
     pub fn view_pr(&self, pr_url: &str) -> Result<PullRequestInfo, AzCliError> {
         let (organization, pr_id) = Self::parse_pr_url(pr_url).ok_or_else(|| {
             AzCliError::UnexpectedOutput(format!("Could not parse Azure DevOps PR URL: {pr_url}"))

--- a/crates/services/src/services/git_host/github/cli.rs
+++ b/crates/services/src/services/git_host/github/cli.rs
@@ -231,15 +231,6 @@ impl GhCli {
         Self::parse_pr_create_text(&raw)
     }
 
-    /// Ensure the GitHub CLI has valid auth.
-    pub fn check_auth(&self) -> Result<(), GhCliError> {
-        match self.run(["auth", "status"], None) {
-            Ok(_) => Ok(()),
-            Err(GhCliError::CommandFailed(msg)) => Err(GhCliError::AuthFailed(msg)),
-            Err(err) => Err(err),
-        }
-    }
-
     /// Retrieve details for a pull request by URL.
     pub fn view_pr(&self, pr_url: &str) -> Result<PullRequestInfo, GhCliError> {
         let raw = self.run(


### PR DESCRIPTION
## Summary

Removes the redundant `check_auth` function from both GitHub and Azure DevOps git_host providers.

## Changes Made

- Removed `check_auth()` function from `GhCli` (GitHub CLI wrapper)
- Removed `check_auth()` function from `AzCli` (Azure CLI wrapper)
- Removed async `check_auth()` wrapper methods from `GitHubProvider` and `AzureDevOpsProvider`
- Removed the `check_auth().await?` calls from `create_pr()` in both providers

## Why These Changes Were Made

The `check_auth` function was redundant because:

1. **The underlying `run()` method already detects auth failures** - Both CLI wrappers have robust auth detection via exit codes (GitHub CLI uses exit code 4) and string pattern matching for phrases like "unauthorized", "gh auth login", "az login", etc.

2. **`check_auth` was actually less precise** - It converted ALL `CommandFailed` errors to `AuthFailed`, which could incorrectly attribute network errors or other failures as authentication issues.

3. **Other operations already work without it** - Methods like `get_pr_status()`, `list_prs_for_branch()`, and `get_pr_comments()` don't use `check_auth` and handle auth failures correctly through the underlying `run()` method.

## Implementation Details

- Auth failures are now detected at the first actual operation (`get_repo_info()`) in `create_pr()`, which uses the more precise error detection in `run()`
- The error handling flow remains the same - `AuthFailed` errors are still correctly categorized and marked as non-retryable
- 69 lines of redundant code removed across 4 files

---

- [x] tested

---

This PR was written using [Vibe Kanban](https://vibekanban.com)