### PR TITLE
fix: clear chat box contents after queueing follow-up message (Vibe Kanban)

### DIFF
--- a/frontend/src/components/ui-new/containers/SessionChatBoxContainer.tsx
+++ b/frontend/src/components/ui-new/containers/SessionChatBoxContainer.tsx
@@ -416,6 +416,11 @@ export function SessionChatBoxContainer(props: SessionChatBoxContainerProps) {
     cancelDebouncedSave();
     await saveToScratch(localMessage, selectedVariant);
     await queueMessage(combinedMessage, selectedVariant);
+
+    // Clear local state after queueing (same as handleSend)
+    setLocalMessage('');
+    clearUploadedImages();
+    reviewContext?.clearComments();
   }, [
     localMessage,
     reviewMarkdown,
@@ -423,6 +428,9 @@ export function SessionChatBoxContainer(props: SessionChatBoxContainerProps) {
     queueMessage,
     cancelDebouncedSave,
     saveToScratch,
+    setLocalMessage,
+    clearUploadedImages,
+    reviewContext,
   ]);
 
   // Editor change handler


### PR DESCRIPTION
## Summary

Fixes an issue where the chat box contents were not cleared after a queued follow-up message starts executing.

## Changes

- Added cleanup logic to `handleQueueMessage` in `SessionChatBoxContainer.tsx` to clear local state after successfully queueing a message

## Problem

When a user queued a follow-up message while a session was running:
1. The message was correctly queued and displayed in the editor
2. When the queued message started executing, `queuedMessage` became `null`
3. However, `localMessage` still contained the old text
4. The editor fell back to showing `localMessage` via the fallback: `queuedMessage ?? localMessage`
5. This caused the stale message to remain visible in the chat box

## Solution

Added the same cleanup logic that exists in `handleSend` to `handleQueueMessage`:

```typescript
// Clear local state after queueing (same as handleSend)
setLocalMessage('');
clearUploadedImages();
reviewContext?.clearComments();
```

This ensures the local state is cleared immediately after queueing, so when the queued message starts executing, the editor displays an empty string.

## Files Modified

- `frontend/src/components/ui-new/containers/SessionChatBoxContainer.tsx`

---

This PR was written using [Vibe Kanban](https://vibekanban.com)