### PR TITLE
fix: preserve WYSIWYG contents when cancelling queued message (Vibe Kanban)

### DIFF
--- a/frontend/src/components/ui-new/containers/SessionChatBoxContainer.tsx
+++ b/frontend/src/components/ui-new/containers/SessionChatBoxContainer.tsx
@@ -474,6 +474,14 @@ export function SessionChatBoxContainer(props: SessionChatBoxContainerProps) {
     feedbackContext?.exitFeedbackMode();
   }, [feedbackContext]);
 
+  // Handle cancel queue - restore message to editor
+  const handleCancelQueue = useCallback(async () => {
+    if (queuedMessage) {
+      setLocalMessage(queuedMessage);
+    }
+    await cancelQueue();
+  }, [queuedMessage, setLocalMessage, cancelQueue]);
+
   // Message edit retry mutation
   const editRetryMutation = useMessageEditRetry(sessionId ?? '', () => {
     // On success, clear edit mode and reset editor
@@ -666,7 +674,7 @@ export function SessionChatBoxContainer(props: SessionChatBoxContainerProps) {
       actions={{
         onSend: handleSend,
         onQueue: handleQueueMessage,
-        onCancelQueue: cancelQueue,
+        onCancelQueue: handleCancelQueue,
         onStop: stopExecution,
         onPasteFiles: uploadFiles,
       }}


### PR DESCRIPTION
## Summary
When a user cancels a queued follow-up message, the WYSIWYG editor contents are now preserved instead of being cleared.

## Problem
Previously, when cancelling a queued message:
1. The message was queued and `localMessage` was cleared (to show a clean editor while queued)
2. The editor displayed `queuedMessage` while in queued state
3. When cancelled, `queuedMessage` became `null` but `localMessage` was already empty
4. Result: The editor showed nothing, and the user's draft was lost

## Solution
Added a `handleCancelQueue` callback that restores the queued message content back to `localMessage` before cancelling the queue. This ensures users don't lose their draft when they decide not to send a queued message.

## Changes
- Added `handleCancelQueue` callback in `SessionChatBoxContainer.tsx`
- Updated `onCancelQueue` prop to use the new handler instead of calling `cancelQueue` directly

## Files Modified
- `frontend/src/components/ui-new/containers/SessionChatBoxContainer.tsx`

---
This PR was written using [Vibe Kanban](https://vibekanban.com)