### PR TITLE
fix: wait for dev server URL detection before showing scratch URL in preview (Vibe Kanban)

### DIFF
--- a/frontend/src/components/ui-new/containers/PreviewBrowserContainer.tsx
+++ b/frontend/src/components/ui-new/containers/PreviewBrowserContainer.tsx
@@ -132,7 +132,13 @@ export function PreviewBrowserContainer({
     setShowIframe(false);
     const timer = setTimeout(() => setShowIframe(true), 2000);
     return () => clearTimeout(timer);
-  }, [effectiveUrl, previewRefreshKey, immediateLoad, hasOverride, urlInfo?.url]);
+  }, [
+    effectiveUrl,
+    previewRefreshKey,
+    immediateLoad,
+    hasOverride,
+    urlInfo?.url,
+  ]);
 
   // Responsive resize state - use refs for values that shouldn't trigger re-renders
   const [localDimensions, setLocalDimensions] = useState(responsiveDimensions);


### PR DESCRIPTION
## Summary

Updates the preview browser to wait for dev server URL detection before showing the iframe when there's a pre-existing URL override stored in scratch storage.

### Changes

- Added `immediateLoad` state to track when user explicitly triggers immediate iframe display
- Modified the `showIframe` effect to require URL detection from dev server logs when an override URL exists in scratch storage
- Refresh and URL submit actions now bypass the wait, allowing immediate iframe loading when the user explicitly requests it
- Added effect to reset `immediateLoad` state when the dev server stops

### Why

Previously, when a user had a URL override saved in scratch storage and reloaded the page, the iframe would display immediately after a 2-second delay without waiting for the dev server to be ready. This could result in showing an error or blank page if the server hadn't started yet.

Now the behavior is consistent with the non-override flow: the iframe waits for the dev server to detect a URL (indicating the server is ready) before displaying, while still using the user's saved override URL.

### Implementation Details

The logic uses a `shouldShow` condition:
```typescript
const shouldShow = immediateLoad || !hasOverride || urlInfo?.url;
```

- If no override → normal flow (show when effectiveUrl exists)
- If override exists → wait for `urlInfo?.url` (server ready) OR `immediateLoad` (user action)
- User actions (refresh, URL submit) set `immediateLoad` to bypass the wait

---

This PR was written using [Vibe Kanban](https://vibekanban.com)