### PR TITLE
Lower beta workspaces invite threshold to 5 task attempts (Vibe Kanban)

### DIFF
--- a/frontend/src/pages/ProjectTasks.tsx
+++ b/frontend/src/pages/ProjectTasks.tsx
@@ -215,7 +215,7 @@ export function ProjectTasks() {
   useEffect(() => {
     if (!isLoaded) return;
     if (config?.beta_workspaces_invitation_sent) return;
-    if (workspaceCount === undefined || workspaceCount <= 50) return;
+    if (workspaceCount === undefined || workspaceCount <= 5) return;
 
     BetaWorkspacesDialog.show().then((joinBeta) => {
       BetaWorkspacesDialog.hide();


### PR DESCRIPTION
## Summary

Lowers the threshold for showing the Beta Workspaces invitation dialog from 50 to 5 task attempts.

## Changes

- Modified `frontend/src/pages/ProjectTasks.tsx` to change the workspace count threshold from `<= 50` to `<= 5`

## Why

This change allows users to discover and try the new workspaces UI much earlier in their usage journey. Previously, users had to create over 50 task attempts before being prompted to try the beta workspaces feature. Now they'll see the invitation after just 5 attempts, enabling faster adoption and feedback collection for the new UI.

## Implementation Details

The `BetaWorkspacesDialog` is shown to users when:
1. The user config hasn't already recorded that the invitation was sent (`beta_workspaces_invitation_sent`)
2. The user's total workspace count exceeds the threshold (now 5, previously 50)

When users accept the invitation, they're redirected to the new `/workspaces` UI and their preference is saved.

---

This PR was written using [Vibe Kanban](https://vibekanban.com)