### PR TITLE
fix: handle MutationResponse wrapper in RemoteClient create_project (Vibe Kanban)

### DIFF
--- a/crates/services/src/services/remote_client.rs
+++ b/crates/services/src/services/remote_client.rs
@@ -31,6 +31,13 @@ use uuid::Uuid;
 
 use super::{auth::AuthContext, oauth_credentials::Credentials};
 
+#[derive(Debug, Deserialize)]
+struct MutationResponse<T> {
+    data: T,
+    #[allow(dead_code)]
+    txid: i64,
+}
+
 #[derive(Debug, Clone, Error)]
 pub enum RemoteClientError {
     #[error("network error: {0}")]
@@ -425,7 +432,10 @@ impl RemoteClient {
         &self,
         request: &CreateRemoteProjectPayload,
     ) -> Result<RemoteProject, RemoteClientError> {
-        self.post_authed("/v1/projects", Some(request)).await
+        // Remote service returns MutationResponse<Project> with { data, txid }
+        let response: MutationResponse<RemoteProject> =
+            self.post_authed("/v1/projects", Some(request)).await?;
+        Ok(response.data)
     }
 
     /// Gets a specific organization by ID.


### PR DESCRIPTION
## Summary

Fixes the "Unexpected response from remote service" error when creating and linking a new remote project.

## Problem

PR #2184 introduced the `MutationResponse<T>` wrapper for mutation endpoints in the remote service, changing the `POST /v1/projects` response format from:

```json
{ "id": "...", "organization_id": "...", "name": "...", ... }
```

to:

```json
{ "data": { "id": "...", "organization_id": "...", "name": "...", ... }, "txid": 12345 }
```

However, `RemoteClient::create_project` was not updated to handle this new response format, causing a `Serde` deserialization error when attempting to parse the wrapped response as a plain `RemoteProject`.

## Changes

- Added a local `MutationResponse<T>` struct in `remote_client.rs` to deserialize the wrapped response
- Updated `create_project` to unwrap the `data` field from the response

## Testing

After this fix, the "Create and Link Remote Project" flow in the Organization Settings should work correctly.

---

This PR was written using [Vibe Kanban](https://vibekanban.com)