### PR TITLE
Fix Codex apply_patch approvals by updating entries in place (Vibe Kanban)

### DIFF
--- a/crates/executors/src/executors/codex/client.rs
+++ b/crates/executors/src/executors/codex/client.rs
@@ -270,7 +270,6 @@ impl AppServerClient {
         tool_input: Value,
         tool_call_id: &str,
     ) -> Result<ApprovalStatus, ExecutorError> {
-        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
         if self.auto_approve {
             return Ok(ApprovalStatus::Approved);
         }

--- a/crates/executors/src/executors/codex/normalize_logs.rs
+++ b/crates/executors/src/executors/codex/normalize_logs.rs
@@ -515,13 +515,42 @@ pub fn normalize_logs(msg_store: Arc<MsgStore>, worktree_path: &Path) {
                     let normalized = normalize_file_changes(&worktree_path_str, &changes);
                     let patch_state = state.patches.entry(call_id.clone()).or_default();
 
-                    for entry in patch_state.entries.drain(..) {
-                        if let Some(index) = entry.index {
-                            msg_store.push_patch(ConversationPatch::remove(index));
+                    // Update existing entries in place to keep them in MsgStore
+                    let normalized_len = normalized.len();
+                    let mut iter = normalized.into_iter();
+                    for entry in &mut patch_state.entries {
+                        if let Some((path, file_changes)) = iter.next() {
+                            entry.path = path;
+                            entry.changes = file_changes;
+                            entry.awaiting_approval = true;
+                            if let Some(index) = entry.index {
+                                replace_normalized_entry(
+                                    &msg_store,
+                                    index,
+                                    entry.to_normalized_entry(),
+                                );
+                            } else {
+                                let index = add_normalized_entry(
+                                    &msg_store,
+                                    &entry_index,
+                                    entry.to_normalized_entry(),
+                                );
+                                entry.index = Some(index);
+                            }
                         }
                     }
 
-                    for (path, file_changes) in normalized {
+                    // Remove stale entries if new changes have fewer files
+                    if normalized_len < patch_state.entries.len() {
+                        for entry in patch_state.entries.drain(normalized_len..) {
+                            if let Some(index) = entry.index {
+                                msg_store.push_patch(ConversationPatch::remove(index));
+                            }
+                        }
+                    }
+
+                    // Add new entries if changes have more files
+                    for (path, file_changes) in iter {
                         let mut entry = PatchEntry {
                             index: None,
                             path,


### PR DESCRIPTION
## Summary
- Update Codex apply_patch approval handling to replace existing patch entries in place instead of remove/re-add
- Remove the 20ms approval recall sleep that masked the underlying race
- Keep cleanup for trailing stale patch entries when the file list shrinks

## Why
Pending approval tool entries were briefly removed and re-added at new indices, creating a race where the approvals service could not reliably update the matching entry. This caused approve/reject buttons to disappear even though the backend logged pending_approval status. The fix preserves stable indices so approvals can consistently patch the correct entry.

## Implementation Details
- Reuse existing PatchEntry indices and emit replace patches when approvals arrive, mirroring the PatchApplyBegin behavior
- Only remove trailing stale entries if the normalized change set is shorter, and append new entries if it grows
- Drop the prior 20ms sleep used as a timing workaround

- [x] tested

This PR was written using [Vibe Kanban](https://vibekanban.com)
