### PR TITLE
Auto-scroll chat to bottom when user submits a message (Vibe Kanban)

### DIFF
--- a/frontend/src/components/ui-new/containers/SessionChatBoxContainer.tsx
+++ b/frontend/src/components/ui-new/containers/SessionChatBoxContainer.tsx
@@ -74,6 +74,8 @@ interface SharedProps {
   linesRemoved: number;
   /** Callback to scroll to previous user message */
   onScrollToPreviousMessage: () => void;
+  /** Callback to scroll to bottom of conversation */
+  onScrollToBottom: () => void;
 }
 
 /** Props for existing session mode */
@@ -115,6 +117,7 @@ export function SessionChatBoxContainer(props: SessionChatBoxContainerProps) {
     linesAdded,
     linesRemoved,
     onScrollToPreviousMessage,
+    onScrollToBottom,
   } = props;
 
   // Extract mode-specific values
@@ -384,6 +387,7 @@ export function SessionChatBoxContainer(props: SessionChatBoxContainerProps) {
       clearUploadedImages();
       if (isNewSessionMode) await clearDraft();
       reviewContext?.clearComments();
+      onScrollToBottom();
     }
   }, [
     send,
@@ -396,6 +400,7 @@ export function SessionChatBoxContainer(props: SessionChatBoxContainerProps) {
     isNewSessionMode,
     clearDraft,
     reviewContext,
+    onScrollToBottom,
   ]);
 
   // Track previous process count for queue refresh

--- a/frontend/src/components/ui-new/containers/WorkspacesMainContainer.tsx
+++ b/frontend/src/components/ui-new/containers/WorkspacesMainContainer.tsx
@@ -64,6 +64,10 @@ export const WorkspacesMainContainer = forwardRef<
     conversationListRef.current?.scrollToPreviousUserMessage();
   }, []);
 
+  const handleScrollToBottom = useCallback(() => {
+    conversationListRef.current?.scrollToBottom();
+  }, []);
+
   useImperativeHandle(
     ref,
     () => ({
@@ -91,6 +95,7 @@ export const WorkspacesMainContainer = forwardRef<
         linesRemoved: diffStats.lines_removed,
       }}
       onScrollToPreviousMessage={handleScrollToPreviousMessage}
+      onScrollToBottom={handleScrollToBottom}
     />
   );
 });

--- a/frontend/src/components/ui-new/views/WorkspacesMain.tsx
+++ b/frontend/src/components/ui-new/views/WorkspacesMain.tsx
@@ -37,6 +37,8 @@ interface WorkspacesMainProps {
   diffStats?: DiffStats;
   /** Callback to scroll to previous user message */
   onScrollToPreviousMessage: () => void;
+  /** Callback to scroll to bottom of conversation */
+  onScrollToBottom: () => void;
 }
 
 export function WorkspacesMain({
@@ -51,6 +53,7 @@ export function WorkspacesMain({
   onStartNewSession,
   diffStats,
   onScrollToPreviousMessage,
+  onScrollToBottom,
 }: WorkspacesMainProps) {
   const { t } = useTranslation(['tasks', 'common']);
   const { session } = workspaceWithSession ?? {};
@@ -118,6 +121,7 @@ export function WorkspacesMain({
                 linesAdded={diffStats?.linesAdded ?? 0}
                 linesRemoved={diffStats?.linesRemoved ?? 0}
                 onScrollToPreviousMessage={onScrollToPreviousMessage}
+                onScrollToBottom={onScrollToBottom}
               />
             </div>
           </MessageEditProvider>


### PR DESCRIPTION
## Summary
Automatically scroll the chat to the bottom when a user submits a message. This improves UX by ensuring users can immediately see their sent message and any subsequent agent responses.

## Changes
- Added `onScrollToBottom` callback prop to `SessionChatBoxContainer`
- Threaded `handleScrollToBottom` from `WorkspacesMainContainer` through `WorkspacesMain` to `SessionChatBoxContainer`
- Called `onScrollToBottom()` in `handleSend()` after successful message submission

## Implementation Details
The existing `scrollToBottom()` method in `ConversationListContainer` was already available but not triggered on message send. This change threads that functionality through the component hierarchy:

1. `WorkspacesMainContainer` creates `handleScrollToBottom` callback
2. `WorkspacesMain` receives and passes `onScrollToBottom` prop
3. `SessionChatBoxContainer` calls `onScrollToBottom()` after successful send in `handleSend()`

The scroll uses smooth behavior and scrolls to the last item in the virtualized message list.

---
This PR was written using [Vibe Kanban](https://vibekanban.com)