### PR TITLE
[medium] Add security headers (nosniff, sameorigin, xss, strict-origin-when-cross-origin)

### DIFF
--- a/crates/server/src/middleware/mod.rs
+++ b/crates/server/src/middleware/mod.rs
@@ -1,5 +1,7 @@
 pub mod model_loaders;
 pub mod origin;
+pub mod security_headers;
 
 pub use model_loaders::*;
 pub use origin::*;
+pub use security_headers::*;

--- a/crates/server/src/middleware/security_headers.rs
+++ b/crates/server/src/middleware/security_headers.rs
@@ -1,0 +1,56 @@
+use axum::{
+    extract::Request,
+    http::{HeaderValue, header},
+    middleware::Next,
+    response::Response,
+};
+
+pub async fn add_security_headers(req: Request, next: Next) -> Response {
+    let response = next.run(req).await;
+    apply_security_headers(response)
+}
+
+fn apply_security_headers(mut response: Response) -> Response {
+    let headers = response.headers_mut();
+
+    headers.insert(
+        header::X_CONTENT_TYPE_OPTIONS,
+        HeaderValue::from_static("nosniff"),
+    );
+    headers.insert(
+        header::X_FRAME_OPTIONS,
+        HeaderValue::from_static("SAMEORIGIN"),
+    );
+    headers.insert(
+        header::X_XSS_PROTECTION,
+        HeaderValue::from_static("1; mode=block"),
+    );
+    headers.insert(
+        header::REFERRER_POLICY,
+        HeaderValue::from_static("strict-origin-when-cross-origin"),
+    );
+
+    response
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::body::Body;
+
+    use super::*;
+
+    #[test]
+    fn test_security_headers_applied() {
+        let response = Response::new(Body::empty());
+        let response = apply_security_headers(response);
+        let headers = response.headers();
+
+        assert_eq!(headers.get("X-Content-Type-Options").unwrap(), "nosniff");
+        assert_eq!(headers.get("X-Frame-Options").unwrap(), "SAMEORIGIN");
+        assert_eq!(headers.get("X-XSS-Protection").unwrap(), "1; mode=block");
+        assert_eq!(
+            headers.get("Referrer-Policy").unwrap(),
+            "strict-origin-when-cross-origin"
+        );
+    }
+}

--- a/crates/server/src/routes/mod.rs
+++ b/crates/server/src/routes/mod.rs
@@ -57,5 +57,6 @@ pub fn router(deployment: DeploymentImpl) -> IntoMakeService<Router> {
         .route("/", get(frontend::serve_frontend_root))
         .route("/{*path}", get(frontend::serve_frontend))
         .nest("/api", base_routes)
+        .layer(axum::middleware::from_fn(middleware::add_security_headers))
         .into_make_service()
 }


### PR DESCRIPTION
Used Jules AI to identify and apply fixes for security.

🛡️ Sentinel: [medium] Add security headers

💡 Vulnerability: Missing HTTP security headers (X-Frame-Options, X-Content-Type-Options, etc.) which leaves the application vulnerable to Clickjacking and MIME sniffing attacks.
🎯 Impact: Reduces attack surface against Clickjacking, MIME type confusion, and reflected XSS.
🔧 Fix: Added a new middleware `security_headers` that injects `X-Content-Type-Options: nosniff`, `X-Frame-Options: SAMEORIGIN`, `X-XSS-Protection: 1; mode=block`, and `Referrer-Policy: strict-origin-when-cross-origin` to all API and frontend responses.
✅ Verification: Added a unit test `test_security_headers_applied` to verify headers are present.