### PR TITLE
refactor: rename CopyPath to CopyWorkspacePath and consolidate git/repo pages (Vibe Kanban)

### DIFF
--- a/frontend/src/components/ui-new/actions/index.ts
+++ b/frontend/src/components/ui-new/actions/index.ts
@@ -727,9 +727,9 @@ export const Actions = {
     },
   },
 
-  CopyPath: {
-    id: 'copy-path',
-    label: 'Copy path',
+  CopyWorkspacePath: {
+    id: 'copy-workspace-path',
+    label: 'Copy Workspace Path',
     icon: 'copy-icon' as const,
     shortcut: 'Y P',
     requiresTarget: false,
@@ -1144,7 +1144,7 @@ export type ContextBarItem = ActionDefinition | typeof ContextBarDivider;
 
 // ContextBar action groups define which actions appear in each section
 export const ContextBarActionGroups = {
-  primary: [Actions.OpenInIDE, Actions.CopyPath] as ActionDefinition[],
+  primary: [Actions.OpenInIDE, Actions.CopyWorkspacePath] as ActionDefinition[],
   secondary: [
     Actions.ToggleDevServer,
     Actions.TogglePreviewMode,

--- a/frontend/src/components/ui-new/actions/pages.ts
+++ b/frontend/src/components/ui-new/actions/pages.ts
@@ -9,8 +9,7 @@ export type PageId =
   | 'workspaceActions'
   | 'diffOptions'
   | 'viewOptions'
-  | 'gitActions'
-  | 'repoActions' // Page for repo-specific actions (opened from repo card)
+  | 'repoActions' // Page for repo-specific actions (opened from repo card or CMD+K)
   | 'selectRepo'; // Dynamic page for repo selection (not in Pages record)
 
 // Items that can appear inside a group
@@ -70,12 +69,12 @@ export const Pages: Record<StaticPageId, CommandBarPage> = {
         items: [
           { type: 'action', action: Actions.NewWorkspace },
           { type: 'action', action: Actions.OpenInIDE },
-          { type: 'action', action: Actions.CopyPath },
+          { type: 'action', action: Actions.CopyWorkspacePath },
           { type: 'action', action: Actions.CopyRawLogs },
           { type: 'action', action: Actions.ToggleDevServer },
           { type: 'action', action: Actions.OpenInOldUI },
           { type: 'childPages', id: 'workspaceActions' },
-          { type: 'childPages', id: 'gitActions' },
+          { type: 'childPages', id: 'repoActions' },
         ],
       },
       {
@@ -171,31 +170,11 @@ export const Pages: Record<StaticPageId, CommandBarPage> = {
     ],
   },
 
-  // Git actions page - git operations
-  gitActions: {
-    id: 'git-actions',
-    title: 'Git Actions',
-    parent: 'root',
-    isVisible: (ctx) => ctx.hasWorkspace && ctx.hasGitRepos,
-    items: [
-      {
-        type: 'group',
-        label: 'Git',
-        items: [
-          { type: 'action', action: Actions.GitCreatePR },
-          { type: 'action', action: Actions.GitMerge },
-          { type: 'action', action: Actions.GitPush },
-          { type: 'action', action: Actions.GitRebase },
-          { type: 'action', action: Actions.GitChangeTarget },
-        ],
-      },
-    ],
-  },
-
-  // Repo actions page - shown when clicking "..." on a repo card
+  // Repository actions page - shown when clicking "..." on a repo card or via CMD+K
   repoActions: {
     id: 'repo-actions',
     title: 'Repository Actions',
+    parent: 'root',
     isVisible: (ctx) => ctx.hasWorkspace && ctx.hasGitRepos,
     items: [
       {
@@ -207,6 +186,7 @@ export const Pages: Record<StaticPageId, CommandBarPage> = {
           { type: 'action', action: Actions.RepoSettings },
           { type: 'action', action: Actions.GitCreatePR },
           { type: 'action', action: Actions.GitMerge },
+          { type: 'action', action: Actions.GitPush },
           { type: 'action', action: Actions.GitRebase },
           { type: 'action', action: Actions.GitChangeTarget },
         ],

--- a/frontend/src/components/ui-new/dialogs/commandBar/injectSearchMatches.ts
+++ b/frontend/src/components/ui-new/dialogs/commandBar/injectSearchMatches.ts
@@ -18,7 +18,7 @@ const INJECTABLE_PAGES: Array<{
   { id: 'workspaceActions', condition: (ctx) => ctx.hasWorkspace },
   { id: 'diffOptions', condition: () => true },
   { id: 'viewOptions', condition: () => true },
-  { id: 'gitActions', condition: (ctx) => ctx.hasGitRepos },
+  { id: 'repoActions', condition: (ctx) => ctx.hasGitRepos },
 ];
 
 export function injectSearchMatches(

--- a/frontend/src/components/ui-new/dialogs/commandBar/useResolvedPage.ts
+++ b/frontend/src/components/ui-new/dialogs/commandBar/useResolvedPage.ts
@@ -4,7 +4,6 @@ import {
   SlidersIcon,
   SquaresFourIcon,
   GitBranchIcon,
-  FolderIcon,
 } from '@phosphor-icons/react';
 import type { Workspace } from 'shared/types';
 import {
@@ -34,8 +33,7 @@ const PAGE_ICONS = {
   workspaceActions: StackIcon,
   diffOptions: SlidersIcon,
   viewOptions: SquaresFourIcon,
-  gitActions: GitBranchIcon,
-  repoActions: FolderIcon,
+  repoActions: GitBranchIcon,
 } as const satisfies Record<StaticPageId, typeof StackIcon>;
 
 function expandGroupItems(

--- a/frontend/src/keyboard/useWorkspaceShortcuts.ts
+++ b/frontend/src/keyboard/useWorkspaceShortcuts.ts
@@ -61,7 +61,7 @@ export function useWorkspaceShortcuts() {
   useHotkeys('x>r', () => execute(Actions.GitRebase), OPTIONS);
   useHotkeys('x>u', () => execute(Actions.GitPush), OPTIONS);
 
-  useHotkeys('y>p', () => execute(Actions.CopyPath), OPTIONS);
+  useHotkeys('y>p', () => execute(Actions.CopyWorkspacePath), OPTIONS);
   useHotkeys('y>l', () => execute(Actions.CopyRawLogs), OPTIONS);
 
   useHotkeys('t>d', () => execute(Actions.ToggleDevServer), OPTIONS);


### PR DESCRIPTION
## Summary

This PR addresses naming collisions and page duplication in the command bar actions system:

1. **Renamed `CopyPath` to `CopyWorkspacePath`** - The previous "Copy path" action was confusingly similar to "Copy Repo Path", making it unclear which path would be copied. The new name explicitly indicates it copies the workspace path.

2. **Consolidated `gitActions` and `repoActions` pages** - There were two separate pages with overlapping functionality:
   - "Git Actions" page (accessible from CMD+K)
   - "Repository Actions" page (accessible from repo card context menu)
   
   Both contained the same git operations (Create PR, Merge, Rebase, etc.). These have been merged into a single "Repository Actions" page that is now accessible from both locations.

## Changes

### Action Rename
- `CopyPath` → `CopyWorkspacePath`
- ID: `copy-path` → `copy-workspace-path`
- Label: "Copy path" → "Copy Workspace Path"

### Page Consolidation
- Removed `gitActions` page entirely
- Added `parent: 'root'` to `repoActions` so it appears in CMD+K menu
- Added `GitPush` action to `repoActions` (was only in `gitActions`)
- Updated icon from `FolderIcon` to `GitBranchIcon` for consistency

## Files Modified
- `frontend/src/components/ui-new/actions/index.ts`
- `frontend/src/components/ui-new/actions/pages.ts`
- `frontend/src/keyboard/useWorkspaceShortcuts.ts`
- `frontend/src/components/ui-new/dialogs/commandBar/useResolvedPage.ts`
- `frontend/src/components/ui-new/dialogs/commandBar/injectSearchMatches.ts`

---

This PR was written using [Vibe Kanban](https://vibekanban.com)