### PR TITLE
fix: Only collapse renamed files by default when there are no changes (Vibe Kanban)

### DIFF
--- a/frontend/src/components/ui-new/containers/ChangesPanelContainer.tsx
+++ b/frontend/src/components/ui-new/containers/ChangesPanelContainer.tsx
@@ -27,13 +27,20 @@ const COLLAPSE_BY_CHANGE_TYPE: Record<DiffChangeKind, boolean> = {
 const COLLAPSE_MAX_LINES = 200;
 
 function shouldAutoCollapse(diff: Diff): boolean {
-  // Collapse based on change type
+  const totalLines = (diff.additions ?? 0) + (diff.deletions ?? 0);
+
+  // For renamed files, only collapse if there are no content changes
+  // OR if the diff is large
+  if (diff.change === 'renamed') {
+    return totalLines === 0 || totalLines > COLLAPSE_MAX_LINES;
+  }
+
+  // Collapse based on change type for other types
   if (COLLAPSE_BY_CHANGE_TYPE[diff.change]) {
     return true;
   }
 
   // Collapse large diffs
-  const totalLines = (diff.additions ?? 0) + (diff.deletions ?? 0);
   if (totalLines > COLLAPSE_MAX_LINES) {
     return true;
   }


### PR DESCRIPTION
## Summary

This PR improves the UX for reviewing renamed files in the Changes Panel by expanding renamed files that contain actual content changes.

## Changes

- Modified the `shouldAutoCollapse` function in `ChangesPanelContainer.tsx` to handle renamed files specially
- Renamed files now **expand by default** if they have content changes (additions/deletions)
- Renamed files still **collapse by default** if:
  - They are pure renames (0 additions + 0 deletions)
  - They have large diffs (>200 lines of changes)

## Why

Previously, all renamed files were collapsed by default regardless of whether they contained content changes. This made it easy to miss important modifications when a file was both renamed and edited. Now, reviewers will see expanded diffs for renamed files that have actual changes, making code review more thorough.

## Implementation Details

The `shouldAutoCollapse` function now checks for renamed files first and applies special logic:
```typescript
if (diff.change === 'renamed') {
  return totalLines === 0 || totalLines > COLLAPSE_MAX_LINES;
}
```

This preserves the existing behavior for all other change types (added, deleted, modified, copied, permissionChange) while giving renamed files with changes the same treatment as modified files.

---

This PR was written using [Vibe Kanban](https://vibekanban.com)