### PR TITLE
fix: create initial project when organization is created (Vibe Kanban)

### DIFF
--- a/crates/remote/src/db/organizations.rs
+++ b/crates/remote/src/db/organizations.rs
@@ -161,6 +161,15 @@ impl<'a> OrganizationRepository<'a> {
             IdentityError::from(e)
         })?;
 
+        // Create initial project with default tags and statuses
+        ProjectRepository::create_initial_project_tx(&mut tx, org.id)
+            .await
+            .map_err(|e| {
+                IdentityError::Database(sqlx::Error::Protocol(format!(
+                    "Failed to create initial project: {e}"
+                )))
+            })?;
+
         add_member(&mut *tx, org.id, creator_user_id, MemberRole::Admin).await?;
 
         tx.commit().await?;


### PR DESCRIPTION
## Summary

When an existing user creates a new (non-personal) organization via the API, the organization was created without any projects, leaving users with an empty workspace.

This PR fixes the issue by automatically creating an initial project with default tags and statuses when any organization is created, not just during user signup.

## Changes

- Modified `create_organization()` in `crates/remote/src/db/organizations.rs` to call `ProjectRepository::create_initial_project_tx()` within the existing transaction

## Implementation Details

The fix mirrors the existing behavior in `ensure_personal_org_and_admin_membership()` which is used during user signup. By calling `create_initial_project_tx()` within the transaction, new organizations now automatically get:

- An "Initial Project" with the default blue color
- 4 default tags (bug, feature, documentation, enhancement)
- 6 default statuses (Backlog, To do, In progress, In review, Done, Cancelled)

This ensures consistency between personal organizations created at signup and non-personal organizations created later.

---

This PR was written using [Vibe Kanban](https://vibekanban.com)