### PR TITLE
fix(ui): hide SplitButton in git panel when no actions available

### DIFF
--- a/frontend/src/components/ui-new/primitives/RepoCard.tsx
+++ b/frontend/src/components/ui-new/primitives/RepoCard.tsx
@@ -239,15 +239,17 @@ export function RepoCard({
         </div>
       )}
 
-      {/* Actions row */}
-      <div className="my-base">
-        <SplitButton
-          options={availableActionOptions}
-          selectedValue={effectiveSelectedAction}
-          onSelectionChange={setSelectedAction}
-          onAction={(action) => onActionsClick?.(action)}
-        />
-      </div>
+      {/* Actions row - only show when there are available actions */}
+      {availableActionOptions.length > 0 && (
+        <div className="my-base">
+          <SplitButton
+            options={availableActionOptions}
+            selectedValue={effectiveSelectedAction}
+            onSelectionChange={setSelectedAction}
+            onAction={(action) => onActionsClick?.(action)}
+          />
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
When a PR is open, both 'Open pull request' and 'Merge' options are filtered out, leaving an empty availableActionOptions array. This caused the SplitButton to render with an empty label.

Now the SplitButton is conditionally rendered only when there are available actions, providing better UX while keeping the PR link button and Push button available for user actions.

Fixes regression introduced in PR #2265.