### PR TITLE
Extend DISABLE_WORKTREE_CLEANUP to prevent all worktree cleanup (Vibe Kanban)

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ The following environment variables can be configured at build time or runtime:
 | `HOST` | Runtime | `127.0.0.1` | Backend server host |
 | `MCP_HOST` | Runtime | Value of `HOST` | MCP server connection host (use `127.0.0.1` when `HOST=0.0.0.0` on Windows) |
 | `MCP_PORT` | Runtime | Value of `BACKEND_PORT` | MCP server connection port |
-| `DISABLE_WORKTREE_ORPHAN_CLEANUP` | Runtime | Not set | Disable git worktree cleanup (for debugging) |
+| `DISABLE_WORKTREE_CLEANUP` | Runtime | Not set | Disable all git worktree cleanup including orphan and expired workspace cleanup (for debugging) |
 | `VK_ALLOWED_ORIGINS` | Runtime | Not set | Comma-separated list of origins that are allowed to make backend API requests (e.g., `https://my-vibekanban-frontend.com`) |
 
 **Build-time variables** must be set when running `pnpm run build`. **Runtime variables** are read when the application starts.

--- a/crates/local-deployment/src/container.rs
+++ b/crates/local-deployment/src/container.rs
@@ -174,6 +174,13 @@ impl LocalContainerService {
     }
 
     pub async fn cleanup_expired_workspaces(db: &DBService) -> Result<(), DeploymentError> {
+        if std::env::var("DISABLE_WORKTREE_CLEANUP").is_ok() {
+            tracing::info!(
+                "Expired workspace cleanup is disabled via DISABLE_WORKTREE_CLEANUP environment variable"
+            );
+            return Ok(());
+        }
+
         let expired_workspaces = Workspace::find_expired_for_cleanup(&db.pool).await?;
         if expired_workspaces.is_empty() {
             tracing::debug!("No expired workspaces found");

--- a/crates/services/src/services/workspace_manager.rs
+++ b/crates/services/src/services/workspace_manager.rs
@@ -285,9 +285,9 @@ impl WorkspaceManager {
     }
 
     pub async fn cleanup_orphan_workspaces(db: &Pool<Sqlite>) {
-        if std::env::var("DISABLE_WORKTREE_ORPHAN_CLEANUP").is_ok() {
-            debug!(
-                "Orphan workspace cleanup is disabled via DISABLE_WORKTREE_ORPHAN_CLEANUP environment variable"
+        if std::env::var("DISABLE_WORKTREE_CLEANUP").is_ok() {
+            info!(
+                "Orphan workspace cleanup is disabled via DISABLE_WORKTREE_CLEANUP environment variable"
             );
             return;
         }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "backend:lint": "cargo clippy --workspace --all-targets --all-features -- -D warnings",
     "backend:dev": "BACKEND_PORT=$(node scripts/setup-dev-environment.js backend) pnpm run backend:dev:watch",
     "backend:check": "cargo check",
-    "backend:dev:watch": "DISABLE_WORKTREE_ORPHAN_CLEANUP=1 RUST_LOG=debug cargo watch -w crates -x 'run --bin server'",
+    "backend:dev:watch": "DISABLE_WORKTREE_CLEANUP=1 RUST_LOG=debug cargo watch -w crates -x 'run --bin server'",
     "dev:qa": "export FRONTEND_PORT=$(node scripts/setup-dev-environment.js frontend) && export BACKEND_PORT=$(node scripts/setup-dev-environment.js backend) && export VK_ALLOWED_ORIGINS=\"http://localhost:${FRONTEND_PORT}\" && export VITE_VK_SHARED_API_BASE=${VK_SHARED_API_BASE:-} && concurrently \"pnpm run backend:dev:watch:qa\" \"pnpm run frontend:dev\"",
     "generate-types": "cargo run --bin generate_types",
     "generate-types:check": "cargo run --bin generate_types -- --check",


### PR DESCRIPTION
## Summary

Renames `DISABLE_WORKTREE_ORPHAN_CLEANUP` to `DISABLE_WORKTREE_CLEANUP` and extends its functionality to disable **all** worktree cleanup operations, not just orphan cleanup.

## Changes

- **Renamed environment variable**: `DISABLE_WORKTREE_ORPHAN_CLEANUP` → `DISABLE_WORKTREE_CLEANUP`
- **Extended functionality**: The env var now also disables `cleanup_expired_workspaces()`, which removes workspaces that have exceeded their idle timeout (1 hour for archived/inactive tasks, 72 hours for active tasks)
- **Updated log level**: Changed the "cleanup disabled" log messages from `debug` to `info` for better visibility
- **Updated documentation**: README now reflects the broader scope of the environment variable

## Why

During development and debugging, it's useful to prevent workspaces from being automatically cleaned up. Previously, `DISABLE_WORKTREE_ORPHAN_CLEANUP` only prevented orphan cleanup (workspaces without database records), but expired workspace cleanup could still remove workspaces you're actively debugging. This change provides a single environment variable to disable all automatic worktree cleanup.

## Files Changed

- `crates/services/src/services/workspace_manager.rs` - Renamed env var check in `cleanup_orphan_workspaces()`
- `crates/local-deployment/src/container.rs` - Added env var check to `cleanup_expired_workspaces()`
- `package.json` - Updated `backend:dev:watch` script
- `README.md` - Updated documentation

---

This PR was written using [Vibe Kanban](https://vibekanban.com)