### PR TITLE
feat(frontend): load project repos in workspace

### DIFF
--- a/frontend/src/components/ui-new/containers/CreateModeProjectSectionContainer.tsx
+++ b/frontend/src/components/ui-new/containers/CreateModeProjectSectionContainer.tsx
@@ -5,18 +5,16 @@ import { ProjectSelectorContainer } from './ProjectSelectorContainer';
 import { CreateProjectDialog } from '@/components/ui-new/dialogs/CreateProjectDialog';
 
 export function CreateModeProjectSectionContainer() {
-  const { selectedProjectId, setSelectedProjectId, clearRepos } =
-    useCreateMode();
+  const { selectedProjectId, setSelectedProjectId } = useCreateMode();
   const { projects } = useProjects();
   const selectedProject = projects.find((p) => p.id === selectedProjectId);
 
   const handleCreateProject = useCallback(async () => {
     const result = await CreateProjectDialog.show({});
     if (result.status === 'saved') {
-      setSelectedProjectId(result.project.id);
-      clearRepos();
+      await setSelectedProjectId(result.project.id);
     }
-  }, [setSelectedProjectId, clearRepos]);
+  }, [setSelectedProjectId]);
 
   return (
     <div className="p-base">

--- a/frontend/src/contexts/CreateModeContext.tsx
+++ b/frontend/src/contexts/CreateModeContext.tsx
@@ -7,7 +7,7 @@ import { useAttemptRepo } from '@/hooks/useAttemptRepo';
 
 interface CreateModeContextValue {
   selectedProjectId: string | null;
-  setSelectedProjectId: (id: string | null) => void;
+  setSelectedProjectId: (id: string | null) => Promise<void>;
   repos: Repo[];
   addRepo: (repo: Repo) => void;
   removeRepo: (repoId: string) => void;


### PR DESCRIPTION
This PR concerns the new workspaces UI.

In particular, when a new workspace is created, I noticed that the list of repositories wouldn't update when I switched projects, and I had to add repositories manually each time I wanted to switch to a new "set".

This change makes it so that the repositories associated with a project are loaded when the project is selected, so users (me included) can use a project as a "set of repositories" and easily switch betwen them when creating a workspace