### PR TITLE
fix(utils): reduce path relative warning to debug level (Vibe Kanban)

### DIFF
--- a/crates/utils/src/path.rs
+++ b/crates/utils/src/path.rs
@@ -57,7 +57,7 @@ pub fn make_path_relative(path: &str, worktree_path: &str) -> String {
                     result
                 }
                 Err(e) => {
-                    tracing::warn!(
+                    tracing::debug!(
                         "Failed to make canonical path relative: '{}' relative to '{}', error: {}, returning original",
                         canon_path.display(),
                         canon_worktree.display(),


### PR DESCRIPTION
## Summary

Reduces the log level for "Failed to make canonical path relative" messages from `warn!` to `debug!`.

## Changes

- Changed `tracing::warn!` to `tracing::debug!` in `crates/utils/src/path.rs:60`

## Why

The warning was being triggered frequently when paths legitimately cannot be made relative to the worktree. For example, Claude plan files stored in `~/.claude/plans/` can never be made relative to a worktree path like `/var/folders/.../vibe-kanban/worktrees/...`. This is expected behavior, not an error condition.

Demoting to debug level reduces log noise while preserving the information for troubleshooting when needed.

## Verification

- `cargo check --workspace` passes
- `cargo test --workspace` passes

---

This PR was written using [Vibe Kanban](https://vibekanban.com)