### PR TITLE
feat(ci): use npm OIDC trusted publishing instead of NPM_TOKEN (Vibe Kanban)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,6 +19,7 @@ concurrency:
 permissions:
   contents: write
   packages: write
+  id-token: write  # Required for OIDC trusted publishing
 
 env:
   NODE_VERSION: 22
@@ -37,9 +38,8 @@ jobs:
       - name: Setup Node
         uses: ./.github/actions/setup-node
 
-      - name: Configure npm authentication
-        run: |
-          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
+      - name: Upgrade npm for OIDC support
+        run: npm install -g npm@latest
 
       - name: Download release assets
         uses: actions/github-script@v8
@@ -110,16 +110,14 @@ jobs:
       - name: Publish to npm
         run: |
           cd npx-cli
-          
+
           # Publish the exact same package that was tested
           PACKAGE_FILE="${{ steps.verify.outputs.package-file }}"
-          
+
           echo "Publishing $PACKAGE_FILE to npm..."
-          npm publish "$PACKAGE_FILE"
-          
+          npm publish "$PACKAGE_FILE" --provenance --access public
+
           echo "✅ Successfully published to npm!"
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Update release description
         uses: actions/github-script@v8


### PR DESCRIPTION
## Summary

This PR updates the CI publish workflow to use npm's OIDC-based trusted publishing instead of the `NPM_TOKEN` secret.

## Changes

- **Added `id-token: write` permission** - Required for OIDC authentication with npm
- **Replaced npm token auth with npm upgrade** - Upgrades npm at runtime to ensure OIDC support (npm 11.5.1+ required, Node.js 22 bundles npm 10.x)
- **Updated publish command** - Added `--provenance --access public` flags for automatic provenance attestations
- **Removed `NPM_TOKEN` secret usage** - No longer needed with OIDC authentication

## Why

npm trusted publishing offers several security benefits:
- **No token management** - No need to create, store, or rotate long-lived tokens
- **Enhanced security** - Uses short-lived, cryptographically signed, workflow-specific credentials
- **Automatic provenance** - Generates provenance statements providing build-origin transparency
- **Industry standard** - Implements the OpenSSF trusted publishers specification

Note: Classic npm tokens were deprecated on December 9, 2025.

## Setup Required

Before this works, the trusted publisher must be configured on npmjs.com:
1. Go to the package settings on npmjs.com
2. Navigate to **Settings** → **Trusted Publisher** → **GitHub Actions**
3. Configure the repository and workflow filename (`publish.yml`)
4. Click **Set up connection**

After verification, the `NPM_TOKEN` secret can be removed from repository settings.

---

This PR was written using [Vibe Kanban](https://vibekanban.com)