### PR TITLE
fix: use the selected agent for slash commands

### DIFF
--- a/frontend/src/components/ui-new/containers/SessionChatBoxContainer.tsx
+++ b/frontend/src/components/ui-new/containers/SessionChatBoxContainer.tsx
@@ -745,7 +745,7 @@ export function SessionChatBoxContainer(props: SessionChatBoxContainerProps) {
         conflictedFilesCount,
       }}
       error={sendError}
-      agent={latestProfileId?.executor}
+      agent={effectiveExecutor}
       todos={todos}
       inProgressTodo={inProgressTodo}
       executor={


### PR DESCRIPTION
Fixes a bug when creating a new session and selecting a different coding agent, slash commands would show commands for the previously used agent (e.g. Claude Code) instead of the selected one (e.g. Opencode).