### PR TITLE
fix(ci): add repository field to package.json for npm provenance (Vibe Kanban)

### DIFF
--- a/npx-cli/package.json
+++ b/npx-cli/package.json
@@ -8,6 +8,10 @@
   },
   "keywords": [],
   "author": "bloop",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/BloopAI/vibe-kanban"
+  },
   "license": "",
   "description": "NPX wrapper around vibe-kanban and vibe-kanban-mcp",
   "dependencies": {


### PR DESCRIPTION
## Summary

Fixes npm Trusted Publishing by adding the missing `repository` field to `npx-cli/package.json`.

## Problem

After switching to npm OIDC Trusted Publishing in #2358, the publish workflow was failing with:

```
npm error 422 Unprocessable Entity - Error verifying sigstore provenance bundle: 
Failed to validate repository information: package.json: "repository.url" is "", 
expected to match "https://github.com/BloopAI/vibe-kanban" from provenance
```

## Root Cause

When using `npm publish --provenance`, npm validates that the `repository` field in `package.json` matches the GitHub repository generating the provenance attestation. The `npx-cli/package.json` was missing this field entirely.

## Changes

- Added `repository` field to `npx-cli/package.json` with the correct GitHub URL

## Testing

Re-run the failed publish workflow to verify npm provenance validation passes.

---

This PR was written using [Vibe Kanban](https://vibekanban.com)