### PR TITLE
Wire up workspaces section in issue panel with PR info (Vibe Kanban)

### DIFF
--- a/frontend/src/components/ui-new/containers/KanbanIssuePanelContainer.tsx
+++ b/frontend/src/components/ui-new/containers/KanbanIssuePanelContainer.tsx
@@ -7,6 +7,7 @@ import {
   KanbanIssuePanel,
   type IssueFormData,
 } from '@/components/ui-new/views/KanbanIssuePanel';
+import type { WorkspaceWithStats } from '@/components/ui-new/views/IssueWorkspaceCard';
 import { useActions } from '@/contexts/ActionsContext';
 
 /**
@@ -40,6 +41,7 @@ export function KanbanIssuePanelContainer() {
     tags,
     issueAssignees,
     issueTags,
+    pullRequests,
     insertIssue,
     updateIssue,
     insertIssueAssignee,
@@ -47,10 +49,11 @@ export function KanbanIssuePanelContainer() {
     removeIssueTag,
     insertTag,
     getTagsForIssue,
+    getWorkspacesForIssue,
     isLoading: projectLoading,
   } = useProjectContext();
 
-  const { isLoading: orgLoading } = useOrgContext();
+  const { membersWithProfilesById, isLoading: orgLoading } = useOrgContext();
 
   // Get action methods from actions context
   const { openStatusSelection, openPrioritySelection, openAssigneeSelection } =
@@ -117,6 +120,44 @@ export function KanbanIssuePanelContainer() {
     const tagLinks = getTagsForIssue(selectedKanbanIssueId);
     return tagLinks.map((it) => it.tag_id);
   }, [getTagsForIssue, selectedKanbanIssueId]);
+
+  // Get workspaces for the selected issue, with PR info
+  const workspacesWithStats: WorkspaceWithStats[] = useMemo(() => {
+    if (!selectedKanbanIssueId) return [];
+
+    const rawWorkspaces = getWorkspacesForIssue(selectedKanbanIssueId);
+
+    return rawWorkspaces
+      .filter((w) => !w.archived)
+      .map((workspace) => {
+        // Find linked PR for this workspace
+        const linkedPr = pullRequests.find(
+          (pr) => pr.workspace_id === workspace.id
+        );
+
+        // Get owner
+        const owner =
+          membersWithProfilesById.get(workspace.owner_user_id) ?? null;
+
+        return {
+          id: workspace.id,
+          localWorkspaceId: workspace.local_workspace_id,
+          filesChanged: workspace.files_changed ?? 0,
+          linesAdded: workspace.lines_added ?? 0,
+          linesRemoved: workspace.lines_removed ?? 0,
+          prNumber: linkedPr?.number,
+          prUrl: linkedPr?.url,
+          prStatus: linkedPr?.status as 'open' | 'merged' | 'closed' | null,
+          owner,
+          createdAt: workspace.created_at,
+        };
+      });
+  }, [
+    selectedKanbanIssueId,
+    getWorkspacesForIssue,
+    pullRequests,
+    membersWithProfilesById,
+  ]);
 
   // Determine mode (only edit when an issue is selected)
   const mode = kanbanCreateMode || !selectedKanbanIssueId ? 'create' : 'edit';
@@ -521,7 +562,7 @@ export function KanbanIssuePanelContainer() {
       issueId={selectedKanbanIssueId}
       parentIssue={parentIssue}
       onParentIssueClick={handleParentIssueClick}
-      workspaces={[]}
+      workspaces={workspacesWithStats}
       linkedPrs={[]}
       onClose={closeKanbanIssuePanel}
       onSubmit={handleSubmit}

--- a/frontend/src/components/ui-new/views/IssueWorkspaceCard.tsx
+++ b/frontend/src/components/ui-new/views/IssueWorkspaceCard.tsx
@@ -6,15 +6,14 @@ import type { OrganizationMemberWithProfile } from 'shared/types';
 
 export interface WorkspaceWithStats {
   id: string;
-  displayId: string;
-  branchName: string;
+  localWorkspaceId: string | null;
   filesChanged: number;
   linesAdded: number;
   linesRemoved: number;
   prNumber?: number;
   prUrl?: string;
   prStatus?: 'open' | 'merged' | 'closed' | null;
-  assignees: OrganizationMemberWithProfile[];
+  owner: OrganizationMemberWithProfile | null;
   createdAt: string;
 }
 
@@ -31,6 +30,7 @@ export function IssueWorkspaceCard({
 }: IssueWorkspaceCardProps) {
   const { t } = useTranslation('common');
   const timeAgo = getTimeAgo(workspace.createdAt);
+  const displayId = workspace.localWorkspaceId ?? workspace.id.slice(0, 8);
 
   return (
     <div
@@ -53,13 +53,10 @@ export function IssueWorkspaceCard({
           : undefined
       }
     >
-      {/* Row 1: Workspace ID + Branch Badge */}
+      {/* Row 1: Workspace ID */}
       <div className="flex items-center gap-half">
         <span className="font-ibm-plex-mono text-sm text-high font-medium">
-          {workspace.displayId}
-        </span>
-        <span className="inline-flex items-center px-base py-px bg-secondary rounded-sm text-sm text-low">
-          {workspace.branchName}
+          {displayId}
         </span>
       </div>
 
@@ -118,21 +115,13 @@ export function IssueWorkspaceCard({
             <span className="text-sm text-low">{t('kanban.noPrCreated')}</span>
           )}
 
-          {/* Assignee Avatars */}
-          <div className="flex items-center -space-x-1">
-            {workspace.assignees.slice(0, 3).map((user) => (
-              <UserAvatar
-                key={user.user_id}
-                user={user}
-                className="h-5 w-5 text-[10px] border-2 border-panel"
-              />
-            ))}
-            {workspace.assignees.length > 3 && (
-              <span className="h-5 w-5 rounded-full bg-secondary flex items-center justify-center text-[10px] text-low border-2 border-panel">
-                +{workspace.assignees.length - 3}
-              </span>
-            )}
-          </div>
+          {/* Owner Avatar */}
+          {workspace.owner && (
+            <UserAvatar
+              user={workspace.owner}
+              className="h-5 w-5 text-[10px] border-2 border-panel"
+            />
+          )}
         </div>
       </div>
     </div>

--- a/frontend/src/components/ui-new/views/KanbanIssuePanel.tsx
+++ b/frontend/src/components/ui-new/views/KanbanIssuePanel.tsx
@@ -224,7 +224,7 @@ export function KanbanIssuePanel({
         )}
 
         {/* Workspaces Section (Edit mode only) */}
-        {!isCreateMode && workspaces.length > 0 && (
+        {!isCreateMode && (
           <div className="border-t">
             <CollapsibleSectionHeader
               title="Workspaces"


### PR DESCRIPTION
## Summary

This PR adds a fully functional workspaces section to the Kanban issue panel, wiring up real data from `ProjectContext` to display workspaces linked to the current issue.

## Changes Made

### `IssueWorkspaceCard.tsx`
- Updated `WorkspaceWithStats` interface to match actual `Workspace` type from the backend
- Changed placeholder fields (`displayId`, `branchName`, `assignees`) to real data fields (`localWorkspaceId`, `owner`)
- Simplified UI to display workspace ID (from `localWorkspaceId` or truncated UUID) with single owner avatar

### `KanbanIssuePanelContainer.tsx`
- Added `getWorkspacesForIssue` and `pullRequests` from `ProjectContext`
- Added `membersWithProfilesById` from `OrgContext` to resolve workspace owners
- Created `workspacesWithStats` memo that:
  - Fetches workspaces for the selected issue
  - Filters out archived workspaces
  - Enriches each workspace with linked PR info (number, URL, status)
  - Resolves owner user profile for avatar display
- Passed the transformed workspaces to `KanbanIssuePanel` instead of empty array

### `KanbanIssuePanel.tsx`
- Changed render condition to always show the "Workspaces" section header (even when there are no workspaces), consistent with Sub-Issues and Comments sections

## Implementation Details

The workspaces are fetched using `getWorkspacesForIssue(issueId)` which filters workspaces by `issue_id`. Each workspace is enriched with:
- **PR information**: Found by matching `workspace_id` in pull requests
- **Owner profile**: Resolved from `membersWithProfilesById` map using `owner_user_id`

The UI displays:
- Workspace ID (short local ID or truncated UUID)
- Time since creation
- File change stats (files changed, lines added/removed)
- PR link with status-based coloring (open=brand, merged=success, closed=error)
- Owner avatar

---

This PR was written using [Vibe Kanban](https://vibekanban.com)