### PR TITLE
chore: bump Claude Code to 2.1.22 (Vibe Kanban)

### DIFF
--- a/crates/executors/src/executors/claude.rs
+++ b/crates/executors/src/executors/claude.rs
@@ -52,7 +52,7 @@ fn base_command(claude_code_router: bool) -> &'static str {
     if claude_code_router {
         "npx -y @musistudio/claude-code-router@1.0.66 code"
     } else {
-        "npx -y @anthropic-ai/claude-code@2.1.12"
+        "npx -y @anthropic-ai/claude-code@2.1.22"
     }
 }
 


### PR DESCRIPTION
## Summary

Bumps the `@anthropic-ai/claude-code` dependency from version 2.1.12 to 2.1.22.

## Changes

- Updated the Claude Code NPX package version in `crates/executors/src/executors/claude.rs`

## Why

Keeps the Claude Code executor up to date with the latest version, ensuring access to bug fixes and improvements in the Claude Code CLI.

- [x] tested

---

This PR was written using [Vibe Kanban](https://vibekanban.com)