### PR TITLE
Add VK_SESSION_ID to agent session env vars

### DIFF
--- a/crates/local-deployment/src/container.rs
+++ b/crates/local-deployment/src/container.rs
@@ -1159,6 +1159,7 @@ impl ContainerService for LocalContainerService {
         env.insert("VK_TASK_ID", task.id.to_string());
         env.insert("VK_WORKSPACE_ID", workspace.id.to_string());
         env.insert("VK_WORKSPACE_BRANCH", &workspace.branch);
+        env.insert("VK_SESSION_ID", execution_process.session_id.to_string());
 
         // Create the child and stream, add to execution tracker with timeout
         let mut spawned = tokio::time::timeout(


### PR DESCRIPTION
This PR adds a `VK_SESSION_ID` env var to the agent context, to convey the agent's own session id to any code run by the agent.

There are existing env vars for `VK_WORKSPACE_ID` and `VK_TASK_ID` etc. for this same context, with a small gap to be filled for the session id as well.