### PR TITLE
fix: base command handling bug

### DIFF
--- a/crates/executors/src/command.rs
+++ b/crates/executors/src/command.rs
@@ -103,6 +103,10 @@ impl CommandBuilder {
             .collect::<Vec<String>>()
             .join(" ");
 
+        if joined.trim().is_empty() {
+            return Ok(self);
+        }
+
         let extra: Vec<String> = split_command_line(&joined)
             .map_err(|err| CommandBuildError::InvalidShellParams(format!("{joined}: {err}")))?;
 


### PR DESCRIPTION
Base command override is broken on Windows, it consistenly errors with "base command is empty after parsing".