### PR TITLE
Trigger manual path load on Enter (Vibe Kanban)

### DIFF
--- a/frontend/src/components/dialogs/shared/FolderPickerDialog.tsx
+++ b/frontend/src/components/dialogs/shared/FolderPickerDialog.tsx
@@ -111,13 +111,22 @@ const FolderPickerDialogImpl = NiceModal.create<FolderPickerDialogProps>(
       // Don't set manual path here since home directory path varies by system
     };
 
-    const handleManualPathChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-      setManualPath(e.target.value);
-    };
+  const handleManualPathChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setManualPath(e.target.value);
+  };
 
-    const handleManualPathSubmit = () => {
-      loadDirectory(manualPath);
-    };
+  const handleManualPathKeyDown = (
+    e: React.KeyboardEvent<HTMLInputElement>
+  ) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      handleManualPathSubmit();
+    }
+  };
+
+  const handleManualPathSubmit = () => {
+    loadDirectory(manualPath);
+  };
 
     const handleSelectCurrent = () => {
       const selectedPath = manualPath || currentPath;
@@ -165,6 +174,7 @@ const FolderPickerDialogImpl = NiceModal.create<FolderPickerDialogProps>(
                   <Input
                     value={manualPath}
                     onChange={handleManualPathChange}
+                    onKeyDown={handleManualPathKeyDown}
                     placeholder="/path/to/your/project"
                     className="flex-1 min-w-0"
                   />


### PR DESCRIPTION
## Summary
- Add Enter key handling to the manual path input in the folder picker dialog.
- Keep behavior aligned with the existing "Go" button action.

## Why
On Windows, pressing Enter in the "Enter path manually" input did nothing, which made it seem like manual path entry was unsupported. The task is to ensure Enter triggers the same directory load as clicking Go.

## Implementation details
- Added an `onKeyDown` handler to the manual path input in `frontend/src/components/dialogs/shared/FolderPickerDialog.tsx`.
- When the key is Enter, it prevents the default and calls the existing `handleManualPathSubmit`, which already invokes `loadDirectory(manualPath)`.
- No changes to the underlying file system API or directory listing logic.

This PR was written using [Vibe Kanban](https://vibekanban.com)