### PR TITLE
fix: show variant selector for sessions without configured coding agent (Vibe Kanban)

### DIFF
--- a/frontend/src/components/ui-new/containers/SessionChatBoxContainer.tsx
+++ b/frontend/src/components/ui-new/containers/SessionChatBoxContainer.tsx
@@ -332,7 +332,6 @@ export function SessionChatBoxContainer(props: SessionChatBoxContainerProps) {
   } = useExecutorSelection({
     profiles,
     latestProfileId,
-    isNewSessionMode,
     scratchVariant: scratchData?.executor_profile_id?.variant,
     configExecutorProfile: config?.executor_profile,
   });

--- a/frontend/src/hooks/useExecutorSelection.ts
+++ b/frontend/src/hooks/useExecutorSelection.ts
@@ -11,7 +11,6 @@ interface ExecutorProfileId {
 interface UseExecutorSelectionOptions {
   profiles: Record<string, ExecutorConfig> | null;
   latestProfileId: ExecutorProfileId | null;
-  isNewSessionMode: boolean;
   scratchVariant: string | null | undefined;
   /** User's saved executor preference from config */
   configExecutorProfile?: ExecutorProfileId | null;
@@ -40,7 +39,6 @@ interface UseExecutorSelectionResult {
 export function useExecutorSelection({
   profiles,
   latestProfileId,
-  isNewSessionMode,
   scratchVariant,
   configExecutorProfile,
 }: UseExecutorSelectionOptions): UseExecutorSelectionResult {
@@ -68,12 +66,8 @@ export function useExecutorSelection({
   );
 
   const variantOptions = useMemo(
-    () =>
-      getVariantOptions(
-        isNewSessionMode ? effectiveExecutor : latestProfileId?.executor,
-        profiles
-      ),
-    [isNewSessionMode, effectiveExecutor, latestProfileId?.executor, profiles]
+    () => getVariantOptions(effectiveExecutor, profiles),
+    [effectiveExecutor, profiles]
   );
 
   const { selectedVariant, setSelectedVariant } = useVariant({


### PR DESCRIPTION
## Summary

Fixed a bug where the variant selector was not appearing when a workspace had a session but no coding agent configured on that session.

## Problem

When viewing a workspace with a session that has no coding agent configured:
- The executor/agent dropdown **was** shown (user could select an agent) ✓
- The variant selector **was not** shown ✗

## Root Cause

In `useExecutorSelection.ts`, `variantOptions` was computed using:

```typescript
isNewSessionMode ? effectiveExecutor : latestProfileId?.executor
```

When `isNewSessionMode` was `false` but `latestProfileId?.executor` was `null` (session exists but no agent configured), the variant options would be empty `[]`, so the variant selector never rendered.

## Solution

Simplified the logic to always use `effectiveExecutor`:

```typescript
getVariantOptions(effectiveExecutor, profiles)
```

This works because `effectiveExecutor` already has the correct fallback chain:
1. `selectedExecutor` (user's explicit selection)
2. `latestProfileId?.executor` (from existing processes)
3. `configExecutorProfile?.executor` (user's saved preference)
4. `executorOptions[0]` (first available)

## Changes

- `frontend/src/hooks/useExecutorSelection.ts` - Simplified `variantOptions` computation, removed unused `isNewSessionMode` parameter
- `frontend/src/components/ui-new/containers/SessionChatBoxContainer.tsx` - Removed `isNewSessionMode` from hook call

---

- [x] tested

This PR was written using [Vibe Kanban](https://vibekanban.com)