### PR TITLE
feat: opencode rename mode to agent

### DIFF
--- a/crates/executors/src/executors/opencode.rs
+++ b/crates/executors/src/executors/opencode.rs
@@ -41,8 +41,8 @@ pub struct Opencode {
     pub model: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub variant: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none", alias = "agent")]
-    pub mode: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none", alias = "mode")]
+    pub agent: Option<String>,
     /// Auto-approve agent actions
     #[serde(default = "default_to_true")]
     pub auto_approve: bool,
@@ -168,7 +168,7 @@ impl Opencode {
         };
         let model = self.model.clone();
         let model_variant = self.variant.clone();
-        let agent = self.mode.clone();
+        let agent = self.agent.clone();
         let auto_approve = self.auto_approve;
         let resume_session_id = resume_session.map(|s| s.to_string());
         let models_cache_key = self.compute_models_cache_key();

--- a/shared/schemas/opencode.json
+++ b/shared/schemas/opencode.json
@@ -23,7 +23,7 @@
         "null"
       ]
     },
-    "mode": {
+    "agent": {
       "type": [
         "string",
         "null"

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -481,7 +481,7 @@ export type CursorAgent = { append_prompt: AppendPrompt, force?: boolean | null,
 
 export type Copilot = { append_prompt: AppendPrompt, model?: string | null, allow_all_tools?: boolean | null, allow_tool?: string | null, deny_tool?: string | null, add_dir?: Array<string> | null, disable_mcp_server?: Array<string> | null, base_command_override?: string | null, additional_params?: Array<string> | null, env?: { [key in string]?: string } | null, };
 
-export type Opencode = { append_prompt: AppendPrompt, model?: string | null, variant?: string | null, mode?: string | null, 
+export type Opencode = { append_prompt: AppendPrompt, model?: string | null, variant?: string | null, agent?: string | null, 
 /**
  * Auto-approve agent actions
  */


### PR DESCRIPTION
Be consistent with Opencode terminology to avoid generating confusion about "agent" support in Vibe Kanban.

Resolves #1921
Supersedes #1967