### PR TITLE
Settings Fix

### DIFF
--- a/frontend/src/components/ui-new/containers/CreateChatBoxContainer.tsx
+++ b/frontend/src/components/ui-new/containers/CreateChatBoxContainer.tsx
@@ -1,5 +1,4 @@
 import { useMemo, useCallback, useState, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useDropzone } from 'react-dropzone';
 import { useCreateMode } from '@/contexts/CreateModeContext';
@@ -10,10 +9,10 @@ import { getVariantOptions, areProfilesEqual } from '@/utils/executor';
 import { splitMessageToTitleDescription } from '@/utils/string';
 import type { ExecutorProfileId, BaseCodingAgent } from 'shared/types';
 import { CreateChatBox } from '../primitives/CreateChatBox';
+import { SettingsDialog } from '../dialogs/SettingsDialog';
 
 export function CreateChatBoxContainer() {
   const { t } = useTranslation('common');
-  const navigate = useNavigate();
   const { profiles, config, updateAndSaveConfig } = useUserSystem();
   const {
     repos,
@@ -125,10 +124,10 @@ export function CreateChatBoxContainer() {
     [effectiveProfile, setSelectedProfile]
   );
 
-  // Navigate to agent settings to customise variants
+  // Open settings modal to agent settings section
   const handleCustomise = useCallback(() => {
-    navigate('/settings/agents');
-  }, [navigate]);
+    SettingsDialog.show({ initialSection: 'agents' });
+  }, []);
 
   // Handle executor change - use saved variant if switching to default executor
   const handleExecutorChange = useCallback(


### PR DESCRIPTION
**Summary of changes made:**

In `frontend/src/components/ui-new/containers/CreateChatBoxContainer.tsx`:

1. **Removed** the unused `useNavigate` import from `react-router-dom`
2. **Added** import for `SettingsDialog` from `../dialogs/SettingsDialog`
3. **Changed** `handleCustomise` to open the new settings modal with the agents section pre-selected:
   - **Before:** `navigate('/settings/agents')` (navigated to old settings page)
   - **After:** `SettingsDialog.show({ initialSection: 'agents' })` (opens new modal with agents section)

Now when you press the "Customize" button in the agent select dropdown on the workspaces create page, it will open the new settings modal (same as pressing G then S) and automatically highlight/navigate to the Agents settings section.