### PR TITLE
fix: add auth check to migration routes (vibe-kanban)

### DIFF
--- a/crates/services/src/services/remote_client.rs
+++ b/crates/services/src/services/remote_client.rs
@@ -610,8 +610,13 @@ impl RemoteClient {
         &self,
         request: CreateWorkspaceRequest,
     ) -> Result<(), RemoteClientError> {
-        self.send(reqwest::Method::POST, "/v1/workspaces", true, Some(&request))
-            .await?;
+        self.send(
+            reqwest::Method::POST,
+            "/v1/workspaces",
+            true,
+            Some(&request),
+        )
+        .await?;
         Ok(())
     }
 


### PR DESCRIPTION
## Summary
- add authorization checks for migration routes for projects, issues, pull requests, and workspaces
- enforce membership/project/issue access before bulk migration runs
- keep remote client behavior unchanged (format-only refactor)

## Why
Migration endpoints were missing access checks, allowing users to migrate data without verifying membership or resource access. This closes that gap and aligns migrations with existing auth rules.

## Details
- thread RequestContext through migration handlers and include it in tracing
- dedupe IDs with HashSet to avoid redundant checks
- reuse ensure_member_access / ensure_project_access / ensure_issue_access helpers
- no API shape changes; only authorization is added

This PR was written using [Vibe Kanban](https://vibekanban.com)
