### PR TITLE
fix(remote): use single transaction for bulk issue updates (Vibe Kanban)

### DIFF
--- a/crates/remote/src/routes/issues.rs
+++ b/crates/remote/src/routes/issues.rs
@@ -134,8 +134,13 @@ async fn update_issue(
 
     ensure_project_access(state.pool(), ctx.user.id, issue.project_id).await?;
 
-    let response = IssueRepository::update(
-        state.pool(),
+    let mut tx = state.pool().begin().await.map_err(|error| {
+        tracing::error!(?error, "failed to begin transaction");
+        ErrorResponse::new(StatusCode::INTERNAL_SERVER_ERROR, "internal server error")
+    })?;
+
+    let data = IssueRepository::update(
+        &mut *tx,
         issue_id,
         payload.status_id,
         payload.title,
@@ -155,7 +160,17 @@ async fn update_issue(
         ErrorResponse::new(StatusCode::INTERNAL_SERVER_ERROR, "internal server error")
     })?;
 
-    Ok(Json(response))
+    let txid = get_txid(&mut *tx).await.map_err(|error| {
+        tracing::error!(?error, "failed to get txid");
+        ErrorResponse::new(StatusCode::INTERNAL_SERVER_ERROR, "internal server error")
+    })?;
+
+    tx.commit().await.map_err(|error| {
+        tracing::error!(?error, "failed to commit transaction");
+        ErrorResponse::new(StatusCode::INTERNAL_SERVER_ERROR, "internal server error")
+    })?;
+
+    Ok(Json(MutationResponse { data, txid }))
 }
 
 #[instrument(
@@ -248,7 +263,7 @@ async fn bulk_update_issues(
 
     for item in payload.updates {
         // Verify issue belongs to the same project
-        let issue = IssueRepository::find_by_id(state.pool(), item.id)
+        let issue = IssueRepository::find_by_id(&mut *tx, item.id)
             .await
             .map_err(|error| {
                 tracing::error!(?error, issue_id = %item.id, "failed to find issue");
@@ -265,7 +280,7 @@ async fn bulk_update_issues(
 
         // Update the issue
         let updated = IssueRepository::update(
-            state.pool(),
+            &mut *tx,
             item.id,
             item.changes.status_id,
             item.changes.title,
@@ -285,7 +300,7 @@ async fn bulk_update_issues(
             ErrorResponse::new(StatusCode::INTERNAL_SERVER_ERROR, "failed to update issue")
         })?;
 
-        results.push(updated.data);
+        results.push(updated);
     }
 
     let txid = get_txid(&mut *tx).await.map_err(|error| {


### PR DESCRIPTION
## Summary

- Make `IssueRepository::find_by_id` and `IssueRepository::update` generic over SQLx's `Executor` trait
- Update `bulk_update_issues` to use a single transaction for all updates
- Update `update_issue` handler to manage its own transaction

## Problem

The `bulk_update_issues` endpoint was creating a transaction but then calling `IssueRepository::update(state.pool(), ...)` for each issue. Since `IssueRepository::update` previously created its own internal transaction, the outer transaction was effectively empty:

1. Each issue update ran in its own separate transaction and committed immediately
2. The returned `txid` came from an empty outer transaction, not the actual data changes
3. If an update failed partway through, earlier updates would already be committed (no atomicity)

## Solution

Made the repository methods generic over the executor type using SQLx's `Executor` trait. This pattern is already used by `ProjectRepository` and `NotificationRepository` in this codebase.

**Changes to `IssueRepository`:**
- `find_by_id` now accepts any `Executor<'e, Database = Postgres>` instead of just `&PgPool`
- `update` now accepts any `Executor` and returns `Issue` directly (no `MutationResponse` wrapper)

**Changes to route handlers:**
- `update_issue`: Creates transaction, calls `update(&mut *tx, ...)`, gets txid, commits
- `bulk_update_issues`: Uses `&mut *tx` for all `find_by_id` and `update` calls within the loop

This ensures all updates in a bulk operation are atomic and the returned `txid` correctly represents all changes for Electric sync coordination.

---

This PR was written using [Vibe Kanban](https://vibekanban.com)