### PR TITLE
partial fix: Handle replace ops as upserts in patch streams

### DIFF
--- a/frontend/src/hooks/useJsonPatchWsStream.ts
+++ b/frontend/src/hooks/useJsonPatchWsStream.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState, useRef } from 'react';
 import { produce } from 'immer';
-import { applyPatch } from 'rfc6902';
 import type { Operation } from 'rfc6902';
+import { applyUpsertPatch } from '@/utils/jsonPatch';
 
 type WsJsonPatchMsg = { JsonPatch: Operation[] };
 type WsReadyMsg = { Ready: true };
@@ -127,7 +127,7 @@ export const useJsonPatchWsStream = <T extends object>(
 
             // Use Immer for structural sharing - only modified parts get new references
             const next = produce(current, (draft) => {
-              applyPatch(draft, filtered);
+              applyUpsertPatch(draft, filtered);
             });
 
             dataRef.current = next;

--- a/frontend/src/utils/jsonPatch.ts
+++ b/frontend/src/utils/jsonPatch.ts
@@ -1,0 +1,11 @@
+import { applyPatch, type Operation } from 'rfc6902';
+
+export function applyUpsertPatch(target: object, ops: Operation[]): void {
+  ops.forEach((op) => {
+    const [error] = applyPatch(target, [op]);
+
+    if (op.op === 'replace' && error?.name === 'MissingError') {
+      applyPatch(target, [{ ...op, op: 'add' }]);
+    }
+  });
+}

--- a/frontend/src/utils/streamJsonPatchEntries.ts
+++ b/frontend/src/utils/streamJsonPatchEntries.ts
@@ -1,5 +1,6 @@
 // streamJsonPatchEntries.ts - WebSocket JSON patch streaming utility
-import { applyPatch, type Operation } from 'rfc6902';
+import type { Operation } from 'rfc6902';
+import { applyUpsertPatch } from '@/utils/jsonPatch';
 
 type PatchContainer<E = unknown> = { entries: E[] };
 
@@ -70,7 +71,7 @@ export function streamJsonPatchEntries<E = unknown>(
 
         // Apply to a working copy (applyPatch mutates)
         const next = structuredClone(snapshot);
-        applyPatch(next as unknown as object, ops);
+        applyUpsertPatch(next, ops);
 
         snapshot = next;
         notify();


### PR DESCRIPTION
Fixed conversation history tearing issues.

- [x] tested

Before

<img width="880" height="717" alt="before" src="https://github.com/user-attachments/assets/c868e131-0a02-4295-8d3e-a8ef0c0ac86c" />


After

<img width="880" height="832" alt="after" src="https://github.com/user-attachments/assets/a3689127-1656-4a87-94e7-12fcce8f53b8" />


