### PR TITLE
Fix rebase dialog showing wrong target branch when switching workspaces (Vibe Kanban)

### DIFF
--- a/frontend/src/components/ui-new/dialogs/RebaseDialog.tsx
+++ b/frontend/src/components/ui-new/dialogs/RebaseDialog.tsx
@@ -86,6 +86,11 @@ function RebaseDialogContent({ attemptId, repoId }: RebaseDialogContentProps) {
     modal,
   ]);
 
+  // Reset initialization flag when attemptId or repoId changes
+  useEffect(() => {
+    setHasInitializedBranches(false);
+  }, [attemptId, repoId]);
+
   // Initialize branch selection once data is loaded
   useEffect(() => {
     if (!hasInitializedBranches && initialTargetBranch && !isInitialLoading) {


### PR DESCRIPTION
## Summary

Fixes a bug where the rebase dialog would display the wrong target branch when switching between workspaces that share the same repository but have different target branches.

## Changes

- Added a `useEffect` hook in `RebaseDialog.tsx` that resets the `hasInitializedBranches` flag when `attemptId` or `repoId` changes

## Root Cause

The `hasInitializedBranches` state was used to ensure branch selection only initializes once when data loads. However, when switching workspaces, this flag remained `true` from the previous workspace, preventing the dialog from re-initializing with the correct target branch for the new workspace.

## Fix

By resetting `hasInitializedBranches` to `false` whenever the workspace (`attemptId`) or repository (`repoId`) changes, the dialog now correctly re-initializes with the appropriate target branch for each workspace.

---

This PR was written using [Vibe Kanban](https://vibekanban.com)