### PR TITLE
Display coding agent icon next to session titles in session dropdown (Vibe Kanban)

### DIFF
--- a/frontend/src/components/ui-new/primitives/SessionChatBox.tsx
+++ b/frontend/src/components/ui-new/primitives/SessionChatBox.tsx
@@ -658,9 +658,15 @@ export function SessionChatBox({
                     }
                     onClick={() => onSelectSession(s.id)}
                   >
-                    {index === 0
-                      ? t('conversation.sessions.latest')
-                      : formatDateShortWithTime(s.created_at)}
+                    <span className="flex items-center gap-1.5">
+                      <AgentIcon
+                        agent={s.executor as BaseCodingAgent}
+                        className="size-icon shrink-0"
+                      />
+                      {index === 0
+                        ? t('conversation.sessions.latest')
+                        : formatDateShortWithTime(s.created_at)}
+                    </span>
                   </DropdownMenuItem>
                 ))}
               </>


### PR DESCRIPTION
## Summary

This PR adds the coding agent icon (Claude, AMP, Gemini, Codex, etc.) next to each session title in the session dropdown menu within the workspaces UI.

## Changes Made

- Modified `frontend/src/components/ui-new/primitives/SessionChatBox.tsx` to display the `AgentIcon` component alongside session labels in the dropdown
- Each session now shows its associated coding agent's icon based on the session's `executor` field
- Used flex layout with `gap-1.5` for proper spacing between the icon and text
- Applied `size-icon` and `shrink-0` classes for consistent icon sizing that doesn't compress

## Why

Previously, users could only see the session timestamp or "Latest" label when switching between sessions. With multiple coding agents available (Claude Code, AMP, Gemini, etc.), it wasn't immediately clear which agent was used for each session. Adding the agent icon provides visual context at a glance, making it easier to identify and switch between sessions run by different agents.

## Implementation Details

- The `AgentIcon` component already existed and handles theme-aware icon rendering (light/dark modes)
- The session's `executor` field (a string like "CLAUDE_CODE", "AMP") is cast to `BaseCodingAgent` enum for the icon lookup
- If a session has no executor set, `AgentIcon` gracefully returns null (no icon displayed)

---

This PR was written using [Vibe Kanban](https://vibekanban.com)