### PR TITLE
fix: use ScriptContext to determine run_reason for chained scripts

### DIFF
--- a/crates/services/src/services/container.rs
+++ b/crates/services/src/services/container.rs
@@ -1209,8 +1209,13 @@ pub trait ContainerService {
 
         // Determine the run reason of the next action
         let next_run_reason = match (action.typ(), next_action.typ()) {
-            (ExecutorActionType::ScriptRequest(_), ExecutorActionType::ScriptRequest(_)) => {
-                ExecutionProcessRunReason::SetupScript
+            (ExecutorActionType::ScriptRequest(_), ExecutorActionType::ScriptRequest(next_script)) => {
+                match next_script.context {
+                    ScriptContext::CleanupScript => ExecutionProcessRunReason::CleanupScript,
+                    ScriptContext::SetupScript => ExecutionProcessRunReason::SetupScript,
+                    ScriptContext::DevServer => ExecutionProcessRunReason::DevServer,
+                    ScriptContext::ToolInstallScript => ExecutionProcessRunReason::SetupScript,
+                }
             }
             (
                 ExecutorActionType::CodingAgentInitialRequest(_)


### PR DESCRIPTION
## Summary
- Fix multi-repo project tasks getting stuck in 'in progress' status instead of transitioning to 'in review' after prompt completion
- When cleanup scripts chain to other cleanup scripts, the run_reason is now correctly set based on `ScriptContext` instead of always using `SetupScript`

## Test plan
- [x] Verified manually with multi-repo project having cleanup scripts
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)