### PR TITLE
fix: scroll to bottom on Accept and Request Changes actions (Vibe Kanban)

### DIFF
--- a/frontend/src/components/ui-new/containers/SessionChatBoxContainer.tsx
+++ b/frontend/src/components/ui-new/containers/SessionChatBoxContainer.tsx
@@ -604,7 +604,13 @@ export function SessionChatBoxContainer(props: SessionChatBoxContainerProps) {
     } catch {
       // Error is handled by mutation
     }
-  }, [pendingApproval, feedbackContext, approveAsync, queryClient, onScrollToBottom]);
+  }, [
+    pendingApproval,
+    feedbackContext,
+    approveAsync,
+    queryClient,
+    onScrollToBottom,
+  ]);
 
   // Handle request changes (deny with feedback)
   const handleRequestChanges = useCallback(async () => {


### PR DESCRIPTION
## Summary

This PR adds scroll-to-bottom behavior when users click **Accept** or **Request Changes** buttons in the chat interface, matching the existing behavior of the **Send** action.

## Changes

- Added `onScrollToBottom()` call to `handleApprove` handler after successful approval
- Added `onScrollToBottom()` call to `handleRequestChanges` handler after successful deny with feedback
- Updated dependency arrays for both callbacks to include `onScrollToBottom`

## Why

Previously, only the Send action scrolled the conversation to the bottom after execution. This created an inconsistent UX where:
- Sending a message → conversation scrolls to bottom ✓
- Accepting an approval → no scroll ✗
- Requesting changes → no scroll ✗

Now all three actions scroll to the bottom for a consistent user experience.

## File Modified

- `frontend/src/components/ui-new/containers/SessionChatBoxContainer.tsx`

---

This PR was written using [Vibe Kanban](https://vibekanban.com)