### PR TITLE
fix: reset isDeleting state when dialogs are reused (Vibe Kanban)

### DIFF
--- a/frontend/src/components/dialogs/org/DeleteRemoteProjectDialog.tsx
+++ b/frontend/src/components/dialogs/org/DeleteRemoteProjectDialog.tsx
@@ -42,6 +42,7 @@ const DeleteRemoteProjectDialogImpl =
             'Failed to delete project. Please try again.'
           )
         );
+      } finally {
         setIsDeleting(false);
       }
     };

--- a/frontend/src/components/dialogs/settings/DeleteConfigurationDialog.tsx
+++ b/frontend/src/components/dialogs/settings/DeleteConfigurationDialog.tsx
@@ -35,8 +35,9 @@ const DeleteConfigurationDialogImpl =
           // Resolve with 'deleted' to let parent handle the deletion
           modal.resolve('deleted' as DeleteConfigurationResult);
           modal.hide();
-        } catch (error) {
+        } catch {
           setError('Failed to delete configuration. Please try again.');
+        } finally {
           setIsDeleting(false);
         }
       };


### PR DESCRIPTION
## Summary
Fixes a bug where delete confirmation dialogs would show a spinner and disabled button on second use, preventing users from clicking the Delete CTA.

## Changes
- **DeleteRemoteProjectDialog.tsx**: Moved `setIsDeleting(false)` from catch block to finally block
- **DeleteConfigurationDialog.tsx**: Applied the same fix

## Root Cause
When using `@ebay/nice-modal-react`, component instances are reused between `show()` calls. The `isDeleting` state was set to `true` on delete but never reset in the success path (only in the error catch block). This caused the stale `isDeleting=true` state to persist when the dialog was opened again.

## Solution
Using a `finally` block ensures the state is always reset regardless of success or failure, matching the pattern used in other dialogs like `DeleteTaskConfirmationDialog.tsx`.

## Test Plan
- [ ] Open DeleteRemoteProjectDialog
- [ ] Click "Delete" to close it
- [ ] Open the dialog again
- [ ] Verify the Delete button is clickable (no spinner)
- [ ] Repeat for DeleteConfigurationDialog

---

This PR was written using [Vibe Kanban](https://vibekanban.com)