### PR TITLE
fix: Stop Claude Code turn on approval timeout instead of looping (Vibe Kanban)

### DIFF
--- a/crates/executors/src/executors/claude/client.rs
+++ b/crates/executors/src/executors/claude/client.rs
@@ -119,7 +119,7 @@ impl ClaudeAgentClient {
             }),
             ApprovalStatus::TimedOut => Ok(PermissionResult::Deny {
                 message: "Approval request timed out".to_string(),
-                interrupt: Some(false),
+                interrupt: Some(true),
             }),
             ApprovalStatus::Pending => Ok(PermissionResult::Deny {
                 message: "Approval still pending (unexpected)".to_string(),

--- a/crates/utils/src/approvals.rs
+++ b/crates/utils/src/approvals.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use ts_rs::TS;
 use uuid::Uuid;
 
-pub const APPROVAL_TIMEOUT_SECONDS: i64 = 3600; // 1 hour
+pub const APPROVAL_TIMEOUT_SECONDS: i64 = 36000; // 10 hours
 
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
 pub struct ApprovalRequest {


### PR DESCRIPTION
## Summary
- Fix approval timeout loop where Claude Code would repeatedly ask for approval after timeout
- Increase default approval timeout from 1 hour to 10 hours

## Changes

### Fix timeout loop behavior
When a plan approval request times out, Claude Code was responding with `interrupt: Some(false)`, which caused the agent to continue processing and ask for approval again—creating an infinite loop.

Changed to `interrupt: Some(true)` so that timeouts properly stop the turn.

**File:** `crates/executors/src/executors/claude/client.rs`

### Increase default timeout
Increased `APPROVAL_TIMEOUT_SECONDS` from 3600 (1 hour) to 36000 (10 hours) to accommodate longer planning sessions where users may step away.

**File:** `crates/utils/src/approvals.rs`

## Test plan
- [x] tested

---

This PR was written using [Vibe Kanban](https://vibekanban.com)