### PR TITLE
fix: prevent version downgrade in CI when repo is ahead of npm (Vibe Kanban)

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -73,9 +73,25 @@ jobs:
           latest_npm_version=$(npm view vibe-kanban version 2>/dev/null || echo "0.0.0")
           echo "Latest npm version: $latest_npm_version"
 
+          # Get current repo version
+          current_repo_version=$(node -p "require('./package.json').version")
+          echo "Current repo version: $current_repo_version"
+
+          # Use the higher of the two versions as the base (prevents downgrade errors with cargo set-version)
+          base_version=$(node -e "
+            const npm = '$latest_npm_version'.split('.').map(Number);
+            const repo = '$current_repo_version'.split('.').map(Number);
+            for (let i = 0; i < 3; i++) {
+              if ((npm[i] || 0) > (repo[i] || 0)) { console.log('$latest_npm_version'); process.exit(); }
+              if ((npm[i] || 0) < (repo[i] || 0)) { console.log('$current_repo_version'); process.exit(); }
+            }
+            console.log('$current_repo_version');
+          ")
+          echo "Base version for bump: $base_version"
+
           timestamp=$(date +%Y%m%d%H%M%S)
 
-          # Update root package.json based on npm version, not current package.json
+          # Update root package.json based on base version
           if [[ "${{ github.event.inputs.version_type }}" == "prerelease" ]]; then
             # For prerelease, use current package.json version and add branch suffix
             npm version prerelease --preid="${{ steps.branch.outputs.suffix }}" --no-git-tag-version
@@ -83,8 +99,8 @@ jobs:
             new_version=$(node -p "require('./package.json').version")
             new_tag="v${new_version}.${timestamp}"
           else
-            # For regular releases, use npm version and bump it
-            npm version $latest_npm_version --no-git-tag-version --allow-same-version
+            # For regular releases, use base version and bump it
+            npm version $base_version --no-git-tag-version --allow-same-version
             npm version ${{ github.event.inputs.version_type }} --no-git-tag-version
 
             new_version=$(node -p "require('./package.json').version")


### PR DESCRIPTION
## Summary

Fixes CI pre-release workflow failing with `Cannot downgrade from 0.1.0 to 0.0.169` when the repo version has been manually bumped ahead of the npm registry version.

## Problem

The pre-release workflow always used the npm registry version as the base for version bumping:
1. Fetch latest npm version (`0.0.168`)
2. Set local `package.json` to that version
3. Bump it (→ `0.0.169`)
4. Run `cargo set-version --workspace "0.0.169"`

When the repo was manually bumped to `0.1.0`, `cargo-edit` refused to downgrade from `0.1.0` to `0.0.169`.

## Solution

The workflow now compares the npm registry version with the current repo version and uses the **higher** of the two as the base for version bumping. This ensures versions can only move forward, preventing downgrade errors.

## Changes

- Added logic to read current repo version from `package.json`
- Added semver comparison to pick `max(npm_version, repo_version)` as the base
- Updated version bump to use the computed base version instead of always using npm version

---

This PR was written using [Vibe Kanban](https://vibekanban.com)