### PR TITLE
Remove keychain token storage to avoid unlock prompts (Vibe Kanban)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6266,7 +6266,6 @@ dependencies = [
  "reqwest",
  "rust-embed",
  "secrecy",
- "security-framework 2.11.1",
  "serde",
  "serde_json",
  "sha2",

--- a/crates/services/Cargo.toml
+++ b/crates/services/Cargo.toml
@@ -54,6 +54,3 @@ sha2 = "0.10"
 fst = "0.4"
 secrecy = "0.10.3"
 moka = { version = "0.12", features = ["future"] }
-
-[target.'cfg(target_os = "macos")'.dependencies]
-security-framework = "2"


### PR DESCRIPTION
## Summary

This PR removes the macOS keychain integration for storing OAuth refresh tokens. The application now uses file-based storage exclusively on all platforms.

## Problem

On macOS release builds, the application was storing OAuth refresh tokens in the system keychain. This caused unnecessary prompts for users to unlock their keychain when starting the application or logging in, which was disruptive to the user experience.

## Changes

### `crates/services/src/services/oauth_credentials.rs`
- Removed the `Backend` enum that switched between file and keychain storage
- Removed the `KeychainBackend` struct and all keychain-related methods
- Removed the `StoreBackend` trait (no longer needed with single backend)
- Removed all `#[cfg(target_os = "macos")]` conditional compilation for keychain
- Simplified `OAuthCredentials` to directly use file-based storage with inline methods

### `crates/services/Cargo.toml`
- Removed the macOS-specific `security-framework` dependency

## Implementation Details

Credentials are now stored in a JSON file at the platform-specific data directory:
- **macOS**: `~/Library/Application Support/vibe-kanban/credentials.json`
- **Linux**: `~/.local/share/vibe-kanban/credentials.json`
- **Windows**: `%APPDATA%\bloop\vibe-kanban\credentials.json`

The file is created with secure permissions (mode 0600 on Unix) to protect the refresh token.

---

This PR was written using [Vibe Kanban](https://vibekanban.com)