### PR TITLE
fix: skip PR comments fetch when no PR is attached (Vibe Kanban)

### DIFF
--- a/frontend/src/contexts/WorkspaceContext.tsx
+++ b/frontend/src/contexts/WorkspaceContext.tsx
@@ -129,6 +129,12 @@ export function WorkspaceProvider({ children }: WorkspaceProviderProps) {
   // TODO: Support multiple repos - currently only fetches comments from the primary repo.
   const primaryRepoId = repos[0]?.id;
 
+  // Check if current workspace has a PR attached (from workspace summaries)
+  const currentWorkspaceSummary = activeWorkspaces.find(
+    (w) => w.id === workspaceId
+  );
+  const hasPrAttached = !!currentWorkspaceSummary?.prStatus;
+
   // GitHub comments hook (fetching, normalization, and helpers)
   const {
     gitHubComments,
@@ -142,7 +148,7 @@ export function WorkspaceProvider({ children }: WorkspaceProviderProps) {
   } = useGitHubComments({
     workspaceId,
     repoId: primaryRepoId,
-    enabled: !isCreateMode,
+    enabled: !isCreateMode && hasPrAttached,
   });
 
   // Stream diffs for the current workspace


### PR DESCRIPTION
## Summary

- Skip fetching PR comments when workspace has no PR attached
- Eliminates unnecessary `[API Error with data] {type: "no_pr_attached"}` console errors on workspace load

## Problem

When loading any workspace, `WorkspaceContext` unconditionally fetched PR comments via `useGitHubComments`. For workspaces without a PR attached, this caused:
1. An unnecessary API call to `/api/task-attempts/{id}/pr/comments`
2. A structured error response `{type: "no_pr_attached"}` from the backend
3. A noisy `[API Error with data]` console error logged by the frontend

## Solution

The PR status is already available in `WorkspaceContext` via the `activeWorkspaces` array (from workspace summaries). The fix:
1. Looks up the current workspace's `prStatus` from `activeWorkspaces`
2. Only enables the PR comments fetch when `hasPrAttached` is true

This is a minimal change (~5 lines) that leverages existing data, requiring no additional API calls.

## Test plan

- [ ] Open a workspace that has **no PR attached** - should NOT see `[API Error with data]` in console
- [ ] Check Network tab - should NOT see request to `/api/task-attempts/{id}/pr/comments`
- [ ] Open a workspace that **has a PR attached** - PR comments should still load correctly
- [ ] Verify the GitHub comments toggle in the diff view still works

---

This PR was written using [Vibe Kanban](https://vibekanban.com)