### PR TITLE
fix: suppress expected abort signal errors in Electric sync (Vibe Kanban)

### DIFF
--- a/frontend/src/lib/electric/collections.ts
+++ b/frontend/src/lib/electric/collections.ts
@@ -169,9 +169,13 @@ function getAuthenticatedShapeOptions(
     // Custom fetch wrapper to catch network-level errors
     fetchClient: createErrorHandlingFetch(errorHandler, reportError),
     // Electric's onError callback (for non-network errors like 4xx/5xx responses)
-    onError: (error: { status?: number; message?: string }) => {
+    onError: (error: { status?: number; message?: string; name?: string }) => {
       // Ignore errors while paused (expected during token refresh)
       if (isPaused) return;
+
+      // Ignore abort errors - these are expected during navigation/unmounting
+      // DOMException with name 'AbortError' is thrown when fetch() is aborted
+      if (error.name === 'AbortError') return;
 
       const status = error.status;
       const message = error.message || String(error);


### PR DESCRIPTION
## Summary

Fixes spurious `Electric sync error: {message: 'signal is aborted without reason'}` errors appearing in the browser console during normal app usage.

## Changes

- Added a check to ignore `AbortError` in the Electric sync `onError` callback
- Uses `error.name === 'AbortError'` for precise detection (standard DOMException name for aborted fetch operations)

## Why

When navigating between pages, unmounting components, or switching tabs, React/TanStack aborts in-flight Electric sync requests. The browser throws a `DOMException` with `name: 'AbortError'` for these aborted fetches, which was being logged as an error even though it's expected behavior.

These errors were:
- Cluttering the console during normal navigation
- Causing confusion since they appeared as sync failures
- Not actual problems - just cleanup of stale requests

## Implementation Details

The fix checks `error.name === 'AbortError'` rather than string matching on the message because:
- `'AbortError'` is the standard DOMException name for aborted fetches
- More precise than `message.includes('abort')` which could match unrelated errors
- Follows browser API conventions

---

This PR was written using [Vibe Kanban](https://vibekanban.com)