### PR TITLE
feat: Set API base URL in local-build.sh for remote features (Vibe Kanban)

### DIFF
--- a/local-build.sh
+++ b/local-build.sh
@@ -41,6 +41,11 @@ fi
 
 echo "🔍 Detected platform: $PLATFORM"
 echo "🔧 Using target directory: $CARGO_TARGET_DIR"
+
+# Set API base URL for remote features
+export VK_SHARED_API_BASE="https://api.vibekanban.com"
+export VITE_VK_SHARED_API_BASE="https://api.vibekanban.com"
+
 echo "🧹 Cleaning previous builds..."
 rm -rf npx-cli/dist
 mkdir -p npx-cli/dist/$PLATFORM


### PR DESCRIPTION
## Summary

- Set `VK_SHARED_API_BASE` and `VITE_VK_SHARED_API_BASE` environment variables to `https://api.vibekanban.com` in `local-build.sh`

## Why

The local build script was missing the API base URL configuration that CI builds receive from secrets. This meant locally built binaries wouldn't have remote features (like shared workspaces) properly configured.

By hardcoding the production API URL in the local build script, developers can now create local builds that connect to the production Vibe Kanban API, matching the behavior of CI-built releases.

## Implementation Details

- Added environment variable exports after platform detection, before the build steps
- Both `VK_SHARED_API_BASE` (used by Rust backend via `build.rs`) and `VITE_VK_SHARED_API_BASE` (used by frontend via Vite) are set
- The URL `https://api.vibekanban.com` matches what CI uses from secrets

---

This PR was written using [Vibe Kanban](https://vibekanban.com)