### PR TITLE
feat: persist linked issue to scratch storage (Vibe Kanban)

### DIFF
--- a/crates/db/src/models/scratch.rs
+++ b/crates/db/src/models/scratch.rs
@@ -42,6 +42,15 @@ pub struct WorkspaceNotesData {
     pub content: String,
 }
 
+/// Linked issue data for draft workspace scratch
+#[derive(Debug, Clone, Serialize, Deserialize, TS)]
+pub struct DraftWorkspaceLinkedIssue {
+    pub issue_id: String,
+    pub simple_id: String,
+    pub title: String,
+    pub remote_project_id: String,
+}
+
 /// Data for a draft workspace scratch (new workspace creation)
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
 pub struct DraftWorkspaceData {
@@ -52,6 +61,8 @@ pub struct DraftWorkspaceData {
     pub repos: Vec<DraftWorkspaceRepo>,
     #[serde(default)]
     pub selected_profile: Option<ExecutorProfileId>,
+    #[serde(default)]
+    pub linked_issue: Option<DraftWorkspaceLinkedIssue>,
 }
 
 /// Repository entry in a draft workspace

--- a/crates/server/src/bin/generate_types.rs
+++ b/crates/server/src/bin/generate_types.rs
@@ -34,6 +34,7 @@ fn generate_types_content() -> String {
         db::models::task::UpdateTask::decl(),
         db::models::scratch::DraftFollowUpData::decl(),
         db::models::scratch::DraftWorkspaceData::decl(),
+        db::models::scratch::DraftWorkspaceLinkedIssue::decl(),
         db::models::scratch::DraftWorkspaceRepo::decl(),
         db::models::scratch::PreviewSettingsData::decl(),
         db::models::scratch::WorkspaceNotesData::decl(),

--- a/frontend/src/hooks/useCreateModeState.ts
+++ b/frontend/src/hooks/useCreateModeState.ts
@@ -354,6 +354,14 @@ export function useCreateModeState({
         target_branch: r.targetBranch ?? '',
       })),
       selected_profile: state.profile,
+      linked_issue: state.linkedIssue
+        ? {
+            issue_id: state.linkedIssue.issueId,
+            simple_id: state.linkedIssue.simpleId,
+            title: state.linkedIssue.title,
+            remote_project_id: state.linkedIssue.remoteProjectId,
+          }
+        : null,
     });
   }, [
     state.phase,
@@ -361,6 +369,7 @@ export function useCreateModeState({
     state.projectId,
     state.repos,
     state.profile,
+    state.linkedIssue,
     debouncedSave,
   ]);
 
@@ -593,6 +602,16 @@ async function initializeState({
         if (restoredRepos.length > 0) {
           restoredData.repos = restoredRepos;
         }
+      }
+
+      // Restore linked issue
+      if (scratchData.linked_issue) {
+        restoredData.linkedIssue = {
+          issueId: scratchData.linked_issue.issue_id,
+          simpleId: scratchData.linked_issue.simple_id,
+          title: scratchData.linked_issue.title,
+          remoteProjectId: scratchData.linked_issue.remote_project_id,
+        };
       }
 
       dispatch({ type: 'INIT_COMPLETE', data: restoredData });

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -52,7 +52,9 @@ export type UpdateTask = { title: string | null, description: string | null, sta
 
 export type DraftFollowUpData = { message: string, executor_profile_id: ExecutorProfileId, };
 
-export type DraftWorkspaceData = { message: string, project_id: string | null, repos: Array<DraftWorkspaceRepo>, selected_profile: ExecutorProfileId | null, };
+export type DraftWorkspaceData = { message: string, project_id: string | null, repos: Array<DraftWorkspaceRepo>, selected_profile: ExecutorProfileId | null, linked_issue: DraftWorkspaceLinkedIssue | null, };
+
+export type DraftWorkspaceLinkedIssue = { issue_id: string, simple_id: string, title: string, remote_project_id: string, };
 
 export type DraftWorkspaceRepo = { repo_id: string, target_branch: string, };
 


### PR DESCRIPTION
## Summary

When creating a workspace from a linked kanban issue, the linked issue information is now persisted to scratch storage. This ensures that if the user refreshes the page or navigates away, the linked issue association is preserved and restored when they return.

## Changes

- **Rust**: Added `DraftWorkspaceLinkedIssue` struct to store linked issue data (issue ID, simple ID, title, remote project ID)
- **Rust**: Added `linked_issue` field to `DraftWorkspaceData` for scratch persistence
- **TypeScript**: Updated `useCreateModeState.ts` to save linked issue to scratch on state changes
- **TypeScript**: Updated restore logic to hydrate linked issue from scratch data on page load

## Implementation Details

The linked issue data flows through the system as follows:
1. When navigating from a kanban issue to create workspace, the `linkedIssue` is passed via navigation state
2. The `useCreateModeState` hook now includes `linked_issue` in the debounced save to scratch storage
3. On initialization, if scratch data contains a `linked_issue`, it is restored to the component state
4. The field names are transformed between camelCase (TypeScript) and snake_case (Rust) during serialization

## Test Plan

- [ ] Navigate to create workspace from a kanban issue
- [ ] Verify linked issue badge appears in the form
- [ ] Refresh the page
- [ ] Verify linked issue badge is still present after refresh
- [ ] Clear the draft and verify linked issue is removed

---

This PR was written using [Vibe Kanban](https://vibekanban.com)