### PR TITLE
docs: add AdaL CLI to supported coding agents

### DIFF
--- a/docs/agents/adal-cli.mdx
+++ b/docs/agents/adal-cli.mdx
@@ -1,7 +1,7 @@
 ---
 title: "AdaL CLI"
 description: "Set up AdaL CLI - Self-evolving Coding Agent"
-icon: https://sylph.ai/adal-face-logo.svg
+icon: https://sylph.ai/adal-face-logo.png
 ---
 
 <Steps>
@@ -13,10 +13,10 @@ icon: https://sylph.ai/adal-face-logo.svg
 
 <Step title="Authenticate">
   ```bash
-  adal auth
+  adal
   ```
   
-  Complete the authentication flow as prompted. For more details, see the [AdaL CLI documentation](https://docs.sylph.ai/).
+  Follow the authentication flow when prompted. For more details, see the [AdaL CLI documentation](https://docs.sylph.ai/).
 </Step>
 
 <Step title="Start Vibe Kanban">

--- a/docs/agents/adal-cli.mdx
+++ b/docs/agents/adal-cli.mdx
@@ -1,13 +1,13 @@
 ---
 title: "AdaL CLI"
 description: "Set up AdaL CLI - Self-evolving Coding Agent"
-icon: https://sylph.ai/favicon.ico
+icon: https://sylph.ai/adal-face-logo.svg
 ---
 
 <Steps>
 <Step title="Install AdaL CLI">
   ```bash
-  npm install -g @anthropic-ai/adal
+  npm i -g @sylphai/adal-cli
   ```
 </Step>
 

--- a/docs/agents/adal-cli.mdx
+++ b/docs/agents/adal-cli.mdx
@@ -1,0 +1,43 @@
+---
+title: "AdaL CLI"
+description: "Set up AdaL CLI - Self-evolving Coding Agent"
+icon: https://sylph.ai/favicon.ico
+---
+
+<Steps>
+<Step title="Install AdaL CLI">
+  ```bash
+  npm install -g @anthropic-ai/adal
+  ```
+</Step>
+
+<Step title="Authenticate">
+  ```bash
+  adal auth
+  ```
+  
+  Complete the authentication flow as prompted. For more details, see the [AdaL CLI documentation](https://docs.sylph.ai/).
+</Step>
+
+<Step title="Start Vibe Kanban">
+  Once authenticated, launch Vibe Kanban:
+
+  ```bash
+  npx vibe-kanban
+  ```
+
+  You can now select AdaL CLI when creating task attempts.
+</Step>
+</Steps>
+
+## About AdaL CLI
+
+AdaL CLI is a self-evolving coding agent from [SylphAI](https://sylph.ai/). It's fully compatible with Claude Code skills and offers advanced features for AI-assisted development.
+
+**Key Features:**
+- Compatible with Claude Code skills and plugins
+- Self-evolving capabilities
+- Advanced context management
+- Multi-model support
+
+For more information, visit the [AdaL CLI homepage](https://sylph.ai/) or [documentation](https://docs.sylph.ai/).

--- a/docs/supported-coding-agents.mdx
+++ b/docs/supported-coding-agents.mdx
@@ -48,7 +48,7 @@ Claude Code Router - orchestrate multiple models
 Qwen Code CLI
 </Card>
 
-<Card title="AdaL CLI" icon="https://sylph.ai/favicon.ico" href="/agents/adal-cli">
+<Card title="AdaL CLI" icon="https://sylph.ai/adal-face-logo.svg" href="/agents/adal-cli">
 Self-evolving Coding Agent
 </Card>
 </CardGroup>

--- a/docs/supported-coding-agents.mdx
+++ b/docs/supported-coding-agents.mdx
@@ -49,6 +49,6 @@ Qwen Code CLI
 </Card>
 
 <Card title="AdaL CLI" icon="https://sylph.ai/adal-face-logo.svg" href="/agents/adal-cli">
-Self-evolving Coding Agent
+AdaL CLI
 </Card>
 </CardGroup>

--- a/docs/supported-coding-agents.mdx
+++ b/docs/supported-coding-agents.mdx
@@ -47,4 +47,8 @@ Claude Code Router - orchestrate multiple models
 <Card title="Qwen Code" icon="https://www.vibekanban.com/images/logos/qwen-logo.png#" href="/agents/qwen-code">
 Qwen Code CLI
 </Card>
+
+<Card title="AdaL CLI" icon="https://sylph.ai/favicon.ico" href="/agents/adal-cli">
+Self-evolving Coding Agent
+</Card>
 </CardGroup>

--- a/docs/supported-coding-agents.mdx
+++ b/docs/supported-coding-agents.mdx
@@ -48,7 +48,7 @@ Claude Code Router - orchestrate multiple models
 Qwen Code CLI
 </Card>
 
-<Card title="AdaL CLI" icon="https://sylph.ai/adal-face-logo.svg" href="/agents/adal-cli">
+<Card title="AdaL CLI" icon="https://sylph.ai/adal-face-logo.png" href="/agents/adal-cli">
 AdaL CLI
 </Card>
 </CardGroup>


### PR DESCRIPTION
## Summary

Add AdaL CLI to the list of supported coding agents.

## Changes

- Add AdaL CLI card to `docs/supported-coding-agents.mdx`
- Create `docs/agents/adal-cli.mdx` with setup instructions

## About AdaL CLI

[AdaL CLI](https://sylph.ai/) is a self-evolving coding agent from SylphAI. It is fully compatible with Claude Code skills and plugins.

- Homepage: https://sylph.ai/
- Documentation: https://docs.sylph.ai/

🌸 Generated with [AdaL](https://github.com/adal-cli/)