### PR TITLE
chore: bump claude-code to 2.1.31 (Vibe Kanban)

### DIFF
--- a/crates/executors/src/executors/claude.rs
+++ b/crates/executors/src/executors/claude.rs
@@ -53,7 +53,7 @@ fn base_command(claude_code_router: bool) -> &'static str {
     if claude_code_router {
         "npx -y @musistudio/claude-code-router@1.0.66 code"
     } else {
-        "npx -y @anthropic-ai/claude-code@2.1.22"
+        "npx -y @anthropic-ai/claude-code@2.1.31"
     }
 }
 


### PR DESCRIPTION
## Summary

Bumps the Claude Code executor version from 2.1.22 to 2.1.31.

## Changes

- Updated `@anthropic-ai/claude-code` package version in the executor base command from `2.1.22` to `2.1.31`

## Why

Keeps the Claude Code executor up to date with the latest version to benefit from bug fixes, performance improvements, and new features in the Claude Code CLI.

## Files Changed

- `crates/executors/src/executors/claude.rs` - Updated version string in `base_command` function

---

- [x] tested

---

This PR was written using [Vibe Kanban](https://vibekanban.com)