### PR TITLE
fix: remove broken "Open in Old UI" button from workspace navbar (Vibe Kanban)

### DIFF
--- a/frontend/src/components/ui-new/actions/index.ts
+++ b/frontend/src/components/ui-new/actions/index.ts
@@ -780,41 +780,6 @@ export const Actions = {
     },
   },
 
-  // === Navigation Actions ===
-  OpenInOldUI: {
-    id: 'open-in-old-ui',
-    label: 'Open in Old UI',
-    icon: SignOutIcon,
-    requiresTarget: ActionTargetType.NONE,
-    isVisible: (ctx) => ctx.layoutMode === 'workspaces',
-    execute: async (ctx) => {
-      // If no workspace is selected, navigate to root
-      if (!ctx.currentWorkspaceId) {
-        ctx.navigate('/');
-        return;
-      }
-
-      const workspace = await getWorkspace(
-        ctx.queryClient,
-        ctx.currentWorkspaceId
-      );
-      if (!workspace?.task_id) {
-        ctx.navigate('/');
-        return;
-      }
-
-      // Fetch task lazily to get project_id
-      const task = await tasksApi.getById(workspace.task_id);
-      if (task?.project_id) {
-        ctx.navigate(
-          `/local-projects/${task.project_id}/tasks/${workspace.task_id}/attempts/${ctx.currentWorkspaceId}`
-        );
-      } else {
-        ctx.navigate('/');
-      }
-    },
-  },
-
   // === Diff Actions for Navbar ===
   ToggleAllDiffs: {
     id: 'toggle-all-diffs',
@@ -1467,7 +1432,7 @@ export type NavbarItem = ActionDefinition | typeof NavbarDivider;
 
 // Navbar action groups define which actions appear in each section
 export const NavbarActionGroups = {
-  left: [Actions.ArchiveWorkspace, Actions.OpenInOldUI] as NavbarItem[],
+  left: [Actions.ArchiveWorkspace] as NavbarItem[],
   right: [
     Actions.ToggleDiffViewMode,
     Actions.ToggleAllDiffs,

--- a/frontend/src/components/ui-new/actions/pages.ts
+++ b/frontend/src/components/ui-new/actions/pages.ts
@@ -98,7 +98,7 @@ export const Pages: Record<StaticPageId, CommandBarPage> = {
           { type: 'action', action: Actions.CopyWorkspacePath },
           { type: 'action', action: Actions.CopyRawLogs },
           { type: 'action', action: Actions.ToggleDevServer },
-          { type: 'action', action: Actions.OpenInOldUI },
+
           { type: 'childPages', id: 'workspaceActions' },
           { type: 'childPages', id: 'repoActions' },
           { type: 'childPages', id: 'issueActions' },


### PR DESCRIPTION
## Summary

Remove the "Open in Old UI" (`OpenInOldUI`) action from the workspace navbar and command bar. With beta workspaces enabled, clicking this button navigates to the old task attempt page (`/local-projects/.../attempts/...`), which immediately redirects back to the workspace view (`/workspaces/...`) — creating an infinite redirect loop that makes the button unusable.

## Changes

- **Removed the `OpenInOldUI` action definition** from the `Actions` object in `frontend/src/components/ui-new/actions/index.ts`
- **Removed the button from the navbar** left action group in `NavbarActionGroups`
- **Removed the action from the command bar** actions page in `frontend/src/components/ui-new/actions/pages.ts`

## Why

When `beta_workspaces` is enabled, the old task attempt page (`TaskPanel.tsx`) detects the flag and redirects to the new workspace UI. This means the "Open in Old UI" button sends the user to a page that instantly sends them back — an infinite loop. Since beta workspaces is the intended path forward, the correct fix is to remove the button entirely rather than try to work around the redirect.

---

This PR was written using [Vibe Kanban](https://vibekanban.com)