### PR TITLE
Bump claude-code to 2.1.32 (Vibe Kanban)

### DIFF
--- a/crates/executors/src/executors/claude.rs
+++ b/crates/executors/src/executors/claude.rs
@@ -53,7 +53,7 @@ fn base_command(claude_code_router: bool) -> &'static str {
     if claude_code_router {
         "npx -y @musistudio/claude-code-router@1.0.66 code"
     } else {
-        "npx -y @anthropic-ai/claude-code@2.1.31"
+        "npx -y @anthropic-ai/claude-code@2.1.32"
     }
 }
 


### PR DESCRIPTION
## Summary

Bumps the `@anthropic-ai/claude-code` package version from `2.1.31` to `2.1.32` in the Claude Code executor.

## Changes

- Updated the pinned version of `@anthropic-ai/claude-code` in `crates/executors/src/executors/claude.rs` from `2.1.31` to `2.1.32`

## Why

Keeps the Claude Code executor up to date with the latest release to pick up bug fixes and improvements in the CLI.

- [x] tested

---

This PR was written using [Vibe Kanban](https://vibekanban.com)