### PR TITLE
Custom HOST during handoff

### DIFF
--- a/crates/remote/src/auth/handoff.rs
+++ b/crates/remote/src/auth/handoff.rs
@@ -491,7 +491,8 @@ fn is_valid_challenge(challenge: &str) -> bool {
 }
 
 fn is_allowed_return_to(url: &Url, public_origin: &str) -> bool {
-    if url.scheme() == "http" && matches!(url.host_str(), Some("127.0.0.1" | "localhost" | "[::1]"))
+    let host = std::env::var("HOST").unwrap_or_else(|_| "127.0.0.1".to_string());
+    if url.scheme() == "http" && matches!(url.host_str(), Some(host | "localhost" | "[::1]"))
     {
         return true;
     }


### PR DESCRIPTION
Consider custom HOST instead of hardcoded 127.0.0.1 during handoff.