### PR TITLE
chore: remove 23 unused crate dependencies across workspace (Vibe Kanban)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2275,10 +2275,8 @@ version = "0.1.7"
 dependencies = [
  "agent-client-protocol",
  "async-trait",
- "axum",
  "base64",
  "bon",
- "bytes",
  "chrono",
  "codex-app-server-protocol",
  "codex-core",
@@ -2286,11 +2284,9 @@ dependencies = [
  "command-group",
  "convert_case 0.6.0",
  "derivative",
- "directories",
  "dirs 5.0.1",
  "enum_dispatch",
  "eventsource-stream",
- "fork_stream",
  "futures",
  "futures-io",
  "git",
@@ -2301,7 +2297,6 @@ dependencies = [
  "rand 0.8.5",
  "regex",
  "reqwest",
- "rustls",
  "schemars 1.2.1",
  "serde",
  "serde_json",
@@ -2495,16 +2490,6 @@ name = "foreign-types-shared"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
-name = "fork_stream"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc54cf296aa5a82dfffcc911fc7a37b0dcba605725bbb4db486f7b24d7667f9d"
-dependencies = [
- "futures",
- "pin-project",
-]
 
 [[package]]
 name = "form_urlencoded"
@@ -3758,7 +3743,6 @@ version = "0.1.7"
 dependencies = [
  "anyhow",
  "async-trait",
- "bytes",
  "command-group",
  "db",
  "deployment",
@@ -3766,11 +3750,7 @@ dependencies = [
  "futures",
  "git",
  "globwalk",
- "json-patch",
- "nix 0.29.0",
  "portable-pty 0.8.1",
- "reqwest",
- "sentry",
  "serde_json",
  "services",
  "sqlx",
@@ -3924,9 +3904,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memoffset"
@@ -5517,7 +5497,6 @@ name = "review"
 version = "0.1.7"
 dependencies = [
  "anyhow",
- "chrono",
  "clap",
  "dialoguer",
  "dirs 5.0.1",
@@ -5817,9 +5796,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -5971,15 +5950,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae55de56877481d112a559bbc12667635fdaf5e005712fd4e2b2fa50ffc884"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "secrecy"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
-dependencies = [
- "zeroize",
 ]
 
 [[package]]
@@ -6363,10 +6333,8 @@ dependencies = [
  "futures-util",
  "git",
  "git2",
- "ignore",
  "local-deployment",
  "mime_guess",
- "nix 0.29.0",
  "os_info",
  "rand 0.8.5",
  "regex",
@@ -6375,7 +6343,6 @@ dependencies = [
  "rust-embed",
  "rustls",
  "schemars 1.2.1",
- "secrecy",
  "sentry",
  "serde",
  "serde_json",
@@ -6384,7 +6351,6 @@ dependencies = [
  "shlex",
  "sqlx",
  "strip-ansi-escapes",
- "strum",
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
@@ -6403,9 +6369,7 @@ version = "0.1.7"
 dependencies = [
  "anyhow",
  "async-trait",
- "axum",
  "backon",
- "base64",
  "chrono",
  "dashmap",
  "db",
@@ -6415,7 +6379,6 @@ dependencies = [
  "executors",
  "fst",
  "futures",
- "futures-util",
  "git",
  "git2",
  "ignore",
@@ -6426,10 +6389,8 @@ dependencies = [
  "notify-rust",
  "once_cell",
  "os_info",
- "regex",
  "reqwest",
  "rust-embed",
- "secrecy",
  "serde",
  "serde_json",
  "sha2",
@@ -7884,9 +7845,9 @@ checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "537dd038a89878be9b64dd4bd1b260315c1bb94f4d784956b81e27a088d9a09e"
 
 [[package]]
 name = "unicode-normalization"
@@ -7987,14 +7948,12 @@ dependencies = [
  "directories",
  "dirs 5.0.1",
  "futures",
- "futures-util",
  "git2",
  "json-patch",
  "jsonwebtoken",
  "nix 0.29.0",
  "open",
  "regex",
- "reqwest",
  "rust-embed",
  "sentry",
  "sentry-tracing",
@@ -8011,7 +7970,6 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "ts-rs 11.0.1",
- "url",
  "uuid",
  "which",
  "windows-sys 0.61.2",
@@ -8192,9 +8150,9 @@ dependencies = [
 
 [[package]]
 name = "webbrowser"
-version = "1.0.6"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00f1243ef785213e3a32fa0396093424a3a6ea566f9948497e5a2309261a4c97"
+checksum = "3f00bb839c1cf1e3036066614cbdcd035ecf215206691ea646aa3c60a24f68f2"
 dependencies = [
  "core-foundation 0.10.1",
  "jni",
@@ -9231,9 +9189,9 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff05f8caa9038894637571ae6b9e29466c1f4f829d26c9b28f869a29cbe3445"
+checksum = "4de98dfa5d5b7fef4ee834d0073d560c9ca7b6c46a71d058c48db7960f8cfaf7"
 
 [[package]]
 name = "zopfli"

--- a/crates/executors/Cargo.toml
+++ b/crates/executors/Cargo.toml
@@ -8,7 +8,6 @@ workspace_utils = { path = "../utils", package = "utils" }
 git = { path = "../git" }
 tokio = { workspace = true }
 tokio-util = { version = "0.7", features = ["io", "compat", "rt"] }
-bytes = "1.0"
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tracing = { workspace = true }
@@ -20,7 +19,6 @@ schemars = { workspace = true }
 dirs = "5.0"
 xdg = "3.0"
 async-trait = { workspace = true } 
-directories = "6.0.0"
 command-group = { version = "5.0", features = ["with-tokio"] }
 regex = "1.11.1"
 json-patch = "2.0"
@@ -30,14 +28,12 @@ futures-io = "0.3.31"
 tokio-stream = { version = "0.1.17", features = ["io-util"] }
 futures = "0.3.31"
 bon = "3.6"
-fork_stream = "0.1.0"
 os_pipe = "1.2"
 strip-ansi-escapes = "0.2.1"
 strum = "0.27.2"
 strum_macros = "0.27.2"
 convert_case = "0.6"
 sqlx = "0.8.6"
-axum = { workspace = true }
 shlex = "1.3.0"
 agent-client-protocol = { version = "0.8", features = ["unstable"] }
 codex-protocol = { git = "https://github.com/openai/codex.git", package = "codex-protocol", tag = "rust-v0.98.0" }
@@ -46,7 +42,6 @@ codex-core = { git = "https://github.com/openai/codex.git", package = "codex-cor
 sha2 = "0.10"
 derivative = "2.2.0"
 reqwest = { workspace = true }
-rustls = { workspace = true }
 eventsource-stream = "0.2"
 walkdir = "2"
 rand = "0.8"

--- a/crates/local-deployment/Cargo.toml
+++ b/crates/local-deployment/Cargo.toml
@@ -11,7 +11,6 @@ services = { path = "../services" }
 utils = { path = "../utils" }
 git = { path = "../git" }
 tokio-util = { version = "0.7", features = ["io"] }
-bytes = "1.0"
 serde_json = { workspace = true }
 anyhow = { workspace = true }
 tracing = { workspace = true }
@@ -20,11 +19,7 @@ uuid = { version = "1.0", features = ["v4", "serde"] }
 async-trait = { workspace = true }
 thiserror = { workspace = true }
 command-group = { version = "5.0", features = ["with-tokio"] }
-nix = { version = "0.29", features = ["signal", "process"] }
-reqwest = { workspace = true }
-sentry = { version = "0.41.0", default-features = false, features = ["anyhow", "backtrace", "panic", "debug-images", "reqwest"] }
 futures = "0.3"
-json-patch = "2.0"
 tokio = { workspace = true }
 globwalk = "0.9"
 portable-pty = "0.8"

--- a/crates/review/Cargo.toml
+++ b/crates/review/Cargo.toml
@@ -21,7 +21,6 @@ indicatif = "0.17"
 anyhow = { workspace = true }
 thiserror = { workspace = true }
 uuid = { version = "1.0", features = ["v4", "serde"] }
-chrono = { version = "0.4", features = ["serde"] }
 tempfile = "3.8"
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -29,10 +29,8 @@ chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1.0", features = ["v4", "serde"] }
 ts-rs = { workspace = true }
 tower-http = { workspace = true }
-nix = { version = "0.29", features = ["signal", "process"] }
 rmcp = { version = "0.5.0", features = ["server", "transport-io"] }
 schemars = { workspace = true }
-secrecy = "0.10.3"
 sentry = { version = "0.41.0", default-features = false, features = ["anyhow", "backtrace", "panic", "debug-images", "reqwest"] }
 reqwest = { workspace = true }
 rustls = { workspace = true }
@@ -41,14 +39,12 @@ thiserror = { workspace = true }
 os_info = "3.12.0"
 futures-util = "0.3"
 base64 = "0.22"
-ignore = "0.4"
 git2 = { workspace = true }
 mime_guess = "2.0"
 rust-embed = "8.2"
 url = "2.5"
 rand = { version = "0.8", features = ["std"] }
 sha2 = "0.10"
-strum = "0.27.2"
 regex = "1"
 
 [build-dependencies]

--- a/crates/services/Cargo.toml
+++ b/crates/services/Cargo.toml
@@ -15,7 +15,6 @@ executors = { path = "../executors" }
 db = { path = "../db" }
 tokio = { workspace = true }
 tokio-util = { version = "0.7", features = ["io"] }
-axum = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 url = "2.5"
@@ -32,14 +31,11 @@ async-trait = { workspace = true }
 enum_dispatch = "0.3.13"
 rust-embed = "8.2"
 ignore = "0.4"
-regex = "1.11.1"
 notify-rust = "4.11"
 os_info = "3.12.0"
 reqwest = { workspace = true }
-futures-util = "0.3"
 json-patch = "2.0"
 backon = "1.5.1"
-base64 = "0.22"
 thiserror = { workspace = true }
 futures = "0.3.31"
 tokio-stream = "0.1.17"
@@ -52,5 +48,4 @@ dashmap = "6.1"
 once_cell = "1.20"
 sha2 = "0.10"
 fst = "0.4"
-secrecy = "0.10.3"
 moka = { version = "0.12", features = ["future"] }

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -21,7 +21,6 @@ open = "5.3.2"
 regex = "1.11.1"
 sentry = { version = "0.41.0", default-features = false, features = ["anyhow", "backtrace", "panic", "debug-images", "reqwest"] }
 sentry-tracing = { version = "0.41.0", default-features = false, features = ["backtrace"] }
-futures-util = "0.3"
 json-patch = "2.0"
 jsonwebtoken = { version = "10.2.0", features = ["rust_crypto"] }
 tokio = { workspace = true }
@@ -34,8 +33,6 @@ git2 = { workspace = true }
 dirs = "5.0"
 thiserror = { workspace = true }
 command-group = { version = "5.0", features = ["with-tokio"] }
-url = "2.5"
-reqwest = { workspace = true }
 sqlx = { version = "0.8.6", default-features = false, features = ["postgres", "uuid", "chrono", "derive"] }
 
 [target.'cfg(unix)'.dependencies]


### PR DESCRIPTION
## Summary

Removes 23 unused crate dependencies across 6 workspace crates, reducing build times and the dependency tree.

## Changes

Dependencies were identified as unused using `cargo-machete` (with `--with-metadata` for accuracy) and verified against source code to avoid false positives.

### Removed dependencies by crate

- **server**: `ignore`, `nix`, `secrecy`, `strum`
- **utils**: `futures-util`, `reqwest`, `url`
- **local-deployment**: `bytes`, `json-patch`, `nix`, `reqwest`, `sentry`
- **executors**: `axum`, `bytes`, `directories`, `fork_stream`, `rustls`
- **services**: `axum`, `base64`, `futures-util`, `regex`, `secrecy`
- **review**: `chrono`

## Why

These dependencies were declared in `Cargo.toml` files but never imported or used in the corresponding crate source code. Removing them:
- Reduces compile times (fewer crates to resolve and build)
- Shrinks the dependency tree and final binary size
- Makes the actual dependency graph more accurate and easier to audit

## Verification

- `cargo check --workspace` passes
- `cargo test --workspace` passes (191 tests, 0 failures)

---

This PR was written using [Vibe Kanban](https://vibekanban.com)