### PR TITLE
fix: stop running dev servers when workspace is archived (Vibe Kanban)

### DIFF
--- a/crates/server/src/routes/task_attempts/pr.rs
+++ b/crates/server/src/routes/task_attempts/pr.rs
@@ -506,19 +506,10 @@ pub async fn attach_existing_pr(
         // If PR is merged, mark task as done and archive workspace
         if matches!(pr_info.status, MergeStatus::Merged) {
             Task::update_status(pool, task.id, TaskStatus::Done).await?;
-            if !workspace.pinned {
-                Workspace::set_archived(pool, workspace.id, true).await?;
-                if let Err(e) = deployment
-                    .container()
-                    .try_run_archive_script(workspace.id)
-                    .await
-                {
-                    tracing::error!(
-                        "Failed to run archive script for workspace {}: {}",
-                        workspace.id,
-                        e
-                    );
-                }
+            if !workspace.pinned
+                && let Err(e) = deployment.container().archive_workspace(workspace.id).await
+            {
+                tracing::error!("Failed to archive workspace {}: {}", workspace.id, e);
             }
         }
 

--- a/crates/services/src/services/pr_monitor.rs
+++ b/crates/services/src/services/pr_monitor.rs
@@ -134,14 +134,10 @@ impl<C: ContainerService + Send + Sync + 'static> PrMonitorService<C> {
                     pr_merge.pr_info.number, workspace.task_id
                 );
                 Task::update_status(&self.db.pool, workspace.task_id, TaskStatus::Done).await?;
-                if !workspace.pinned {
-                    Workspace::set_archived(&self.db.pool, workspace.id, true).await?;
-                    if let Err(e) = self.container.try_run_archive_script(workspace.id).await {
-                        error!(
-                            "Failed to run archive script for workspace {}: {}",
-                            workspace.id, e
-                        );
-                    }
+                if !workspace.pinned
+                    && let Err(e) = self.container.archive_workspace(workspace.id).await
+                {
+                    error!("Failed to archive workspace {}: {}", workspace.id, e);
                 }
 
                 // Track analytics event


### PR DESCRIPTION
## Summary

When a workspace is archived, any running dev servers are now stopped automatically. Previously, archiving a workspace via the UI or PR detection left dev servers running, wasting resources.

## Changes

- **New `archive_workspace` method on `ContainerService`** (`crates/services/src/services/container.rs`) — Encapsulates the full archive lifecycle: set archived flag in DB, stop running dev servers, and run archive script. This eliminates duplicated archive logic across the codebase.

- **Simplified all 4 archive code paths** to call `archive_workspace()`:
  - `update_workspace()` — user archives via UI
  - `merge_task_attempt()` — direct merge completion
  - PR monitor — background service detects external PR merge
  - `attach_existing_pr()` — attaching an already-merged PR

- **Bug fix in merge flow** — dev servers were previously stopped outside the `!workspace.pinned` guard, meaning they'd be stopped even when the workspace wasn't being archived. Now correctly scoped.

---

This PR was written using [Vibe Kanban](https://vibekanban.com)