### PR TITLE
feat: load remote api base at runtime

### DIFF
--- a/crates/server/src/routes/frontend.rs
+++ b/crates/server/src/routes/frontend.rs
@@ -5,6 +5,7 @@ use axum::{
 };
 use reqwest::{StatusCode, header};
 use rust_embed::RustEmbed;
+use serde_json;
 
 #[derive(RustEmbed)]
 #[folder = "../../frontend/dist"]
@@ -17,6 +18,29 @@ pub async fn serve_frontend(uri: axum::extract::Path<String>) -> impl IntoRespon
 
 pub async fn serve_frontend_root() -> impl IntoResponse {
     serve_file("index.html").await
+}
+
+pub async fn serve_runtime_config() -> impl IntoResponse {
+    let api_base = std::env::var("VK_SHARED_API_BASE")
+        .or_else(|_| std::env::var("VITE_VK_SHARED_API_BASE"))
+        .ok();
+
+    let body = match api_base {
+        Some(value) => {
+            let json_value = serde_json::to_string(&value).unwrap_or_else(|_| "null".to_string());
+            format!("window.__VK_CONFIG__ = {{ sharedApiBase: {} }};", json_value)
+        }
+        None => "window.__VK_CONFIG__ = window.__VK_CONFIG__ || {};".to_string(),
+    };
+
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(
+            header::CONTENT_TYPE,
+            HeaderValue::from_static("application/javascript"),
+        )
+        .body(Body::from(body))
+        .unwrap()
 }
 
 async fn serve_file(path: &str) -> impl IntoResponse + use<> {

--- a/crates/server/src/routes/mod.rs
+++ b/crates/server/src/routes/mod.rs
@@ -59,6 +59,7 @@ pub fn router(deployment: DeploymentImpl) -> IntoMakeService<Router> {
 
     Router::new()
         .route("/", get(frontend::serve_frontend_root))
+        .route("/runtime-config.js", get(frontend::serve_runtime_config))
         .route("/{*path}", get(frontend::serve_frontend))
         .nest("/api", base_routes)
         .into_make_service()

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -13,6 +13,7 @@
 
 <body>
     <div id="root"></div>
+    <script src="/runtime-config.js"></script>
     <script type="module" src="/src/main.tsx"></script>
 </body>
 

--- a/frontend/public/runtime-config.js
+++ b/frontend/public/runtime-config.js
@@ -1,0 +1,2 @@
+// Populated at runtime by the backend when available.
+window.__VK_CONFIG__ = window.__VK_CONFIG__ || {};

--- a/frontend/src/components/dialogs/org/InviteMemberDialog.tsx
+++ b/frontend/src/components/dialogs/org/InviteMemberDialog.tsx
@@ -25,7 +25,7 @@ import { MemberRole } from 'shared/types';
 import { useTranslation } from 'react-i18next';
 import { defineModal } from '@/lib/modals';
 import { ApiError } from '@/lib/api';
-import { REMOTE_API_URL } from '@/lib/remoteApi';
+import { getRemoteApiUrl } from '@/lib/remoteApi';
 import { ArrowSquareOut } from '@phosphor-icons/react';
 
 export type InviteMemberResult = {
@@ -41,6 +41,7 @@ const InviteMemberDialogImpl = NiceModal.create<InviteMemberDialogProps>(
     const modal = useModal();
     const { organizationId } = props;
     const { t } = useTranslation('organization');
+    const remoteApiUrl = getRemoteApiUrl();
     const [email, setEmail] = useState('');
     const [role, setRole] = useState<MemberRole>(MemberRole.MEMBER);
     const [error, setError] = useState<string | null>(null);
@@ -181,7 +182,7 @@ const InviteMemberDialogImpl = NiceModal.create<InviteMemberDialogProps>(
               >
                 <AlertDescription>
                   {error}
-                  {isSubscriptionRequired && REMOTE_API_URL && (
+                  {isSubscriptionRequired && remoteApiUrl && (
                     <div className="mt-2">
                       <p className="text-sm text-muted-foreground mb-2">
                         {t('inviteDialog.upgradePrompt')}
@@ -189,7 +190,7 @@ const InviteMemberDialogImpl = NiceModal.create<InviteMemberDialogProps>(
                       <PrimaryButton
                         onClick={() =>
                           window.open(
-                            `${REMOTE_API_URL}/upgrade?org_id=${organizationId}`,
+                            `${remoteApiUrl}/upgrade?org_id=${organizationId}`,
                             '_blank'
                           )
                         }

--- a/frontend/src/components/ui-new/dialogs/settings/OrganizationsSettingsSection.tsx
+++ b/frontend/src/components/ui-new/dialogs/settings/OrganizationsSettingsSection.tsx
@@ -28,7 +28,7 @@ import { PendingInvitationItem } from '@/components/org/PendingInvitationItem';
 import type { MemberRole } from 'shared/types';
 import { MemberRole as MemberRoleEnum } from 'shared/types';
 import { cn } from '@/lib/utils';
-import { REMOTE_API_URL } from '@/lib/remoteApi';
+import { getRemoteApiUrl } from '@/lib/remoteApi';
 import { PrimaryButton } from '../../primitives/PrimaryButton';
 import {
   DropdownMenu,
@@ -43,6 +43,7 @@ export function OrganizationsSettingsSection() {
   const { t } = useTranslation('organization');
   const { loginStatus } = useUserSystem();
   const { isSignedIn, isLoaded } = useAuth();
+  const remoteApiUrl = getRemoteApiUrl();
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
 
@@ -426,7 +427,7 @@ export function OrganizationsSettingsSection() {
       )}
 
       {/* Billing Link (admin only, non-personal orgs, when remote URL is configured) */}
-      {selectedOrg && isAdmin && !isPersonalOrg && REMOTE_API_URL && (
+      {selectedOrg && isAdmin && !isPersonalOrg && remoteApiUrl && (
         <SettingsCard
           title={t('billing.title')}
           description={t('billing.description')}
@@ -434,7 +435,7 @@ export function OrganizationsSettingsSection() {
           <div className="flex items-center justify-between">
             <p className="text-sm text-low">{t('billing.openInBrowser')}</p>
             <a
-              href={`${REMOTE_API_URL}/account/organizations/${selectedOrgId}`}
+              href={`${remoteApiUrl}/account/organizations/${selectedOrgId}`}
               target="_blank"
               rel="noopener noreferrer"
               className={cn(

--- a/frontend/src/lib/electric/collections.ts
+++ b/frontend/src/lib/electric/collections.ts
@@ -2,7 +2,7 @@ import { electricCollectionOptions } from '@tanstack/electric-db-collection';
 import { createCollection } from '@tanstack/react-db';
 
 import { tokenManager } from '../auth/tokenManager';
-import { makeRequest, REMOTE_API_URL } from '@/lib/remoteApi';
+import { getRemoteApiUrl, makeRequest } from '@/lib/remoteApi';
 import type { MutationDefinition, ShapeDefinition } from 'shared/remote-types';
 import type { CollectionConfig, SyncError } from './types';
 
@@ -122,6 +122,7 @@ function getAuthenticatedShapeOptions(
   config?: CollectionConfig
 ) {
   const url = buildUrl(shape.url, params);
+  const remoteApiUrl = getRemoteApiUrl();
 
   // Create error handler for this shape's lifecycle
   const errorHandler = new ErrorHandler();
@@ -155,7 +156,7 @@ function getAuthenticatedShapeOptions(
   };
 
   return {
-    url: `${REMOTE_API_URL}${url}`,
+    url: `${remoteApiUrl}${url}`,
     params,
     headers: {
       Authorization: async () => {

--- a/frontend/src/lib/remoteApi.ts
+++ b/frontend/src/lib/remoteApi.ts
@@ -3,14 +3,16 @@ import type {
   UpdateProjectStatusRequest,
 } from 'shared/remote-types';
 import { tokenManager } from './auth/tokenManager';
+import { getRemoteApiBaseUrl } from './runtimeConfig';
 
-export const REMOTE_API_URL = import.meta.env.VITE_VK_SHARED_API_BASE || '';
+export const getRemoteApiUrl = (): string => getRemoteApiBaseUrl();
 
 export const makeRequest = async (
   path: string,
   options: RequestInit = {},
   retryOn401 = true
 ): Promise<Response> => {
+  const remoteApiUrl = getRemoteApiUrl();
   const token = await tokenManager.getToken();
   if (!token) {
     throw new Error('Not authenticated');
@@ -24,7 +26,7 @@ export const makeRequest = async (
   headers.set('X-Client-Version', __APP_VERSION__);
   headers.set('X-Client-Type', 'frontend');
 
-  const response = await fetch(`${REMOTE_API_URL}${path}`, {
+  const response = await fetch(`${remoteApiUrl}${path}`, {
     ...options,
     headers,
     credentials: 'include',
@@ -36,7 +38,7 @@ export const makeRequest = async (
     if (newToken) {
       // Retry the request with the new token
       headers.set('Authorization', `Bearer ${newToken}`);
-      return fetch(`${REMOTE_API_URL}${path}`, {
+      return fetch(`${remoteApiUrl}${path}`, {
         ...options,
         headers,
         credentials: 'include',

--- a/frontend/src/lib/runtimeConfig.ts
+++ b/frontend/src/lib/runtimeConfig.ts
@@ -1,0 +1,22 @@
+type RuntimeConfig = {
+  sharedApiBase?: string;
+};
+
+function readRuntimeConfig(): RuntimeConfig | undefined {
+  if (typeof window === 'undefined') return undefined;
+
+  const config = window.__VK_CONFIG__;
+  if (!config || typeof config !== 'object') return undefined;
+
+  return config;
+}
+
+export function getRemoteApiBaseUrl(): string {
+  const config = readRuntimeConfig();
+
+  if (config && Object.prototype.hasOwnProperty.call(config, 'sharedApiBase')) {
+    return config.sharedApiBase ?? '';
+  }
+
+  return import.meta.env.VITE_VK_SHARED_API_BASE || '';
+}

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,3 +1,9 @@
 /// <reference types="vite/client" />
 
 declare const __APP_VERSION__: string;
+
+interface Window {
+  __VK_CONFIG__?: {
+    sharedApiBase?: string;
+  };
+}


### PR DESCRIPTION
This PR allows the npx command to accept and use the environment variable for API base URL (`VK_SHARED_API_BASE`) so that we can use our own deployed remote server with the Frontend.