### PR TITLE
Include unseen activity workspaces in Accordion Needs Attention section (Vibe Kanban)

### DIFF
--- a/frontend/src/components/ui-new/views/WorkspacesSidebar.tsx
+++ b/frontend/src/components/ui-new/views/WorkspacesSidebar.tsx
@@ -135,16 +135,18 @@ export function WorkspacesSidebar({
           : Infinity;
         return aTime - bTime;
       };
+      const needsAttention = (ws: Workspace) =>
+        ws.hasPendingApproval || ws.hasUnseenActivity;
 
       return {
         raisedHandWorkspaces: workspaces
-          .filter((ws) => ws.hasPendingApproval)
+          .filter((ws) => needsAttention(ws))
           .sort(sortByCompletedAt),
         idleWorkspaces: workspaces
-          .filter((ws) => !ws.isRunning && !ws.hasPendingApproval)
+          .filter((ws) => !ws.isRunning && !needsAttention(ws))
           .sort(sortByCompletedAt),
         runningWorkspaces: workspaces
-          .filter((ws) => ws.isRunning && !ws.hasPendingApproval)
+          .filter((ws) => ws.isRunning && !needsAttention(ws))
           .sort(sortByCompletedAt),
       };
     }, [workspaces]);


### PR DESCRIPTION
## What changed
- Updated accordion workspace categorization in `frontend/src/components/ui-new/views/WorkspacesSidebar.tsx`.
- Added a shared `needsAttention` predicate that treats a workspace as needing attention when it has:
  - pending approval (`hasPendingApproval`), or
  - unread/unseen activity (`hasUnseenActivity`).
- Reused that predicate across all accordion groups:
  - **Needs attention** now includes both pending-approval and unread/unseen workspaces.
  - **Idle** and **Running** now explicitly exclude all workspaces in needs-attention.

## Why
The task required unread/unseen workspaces to appear in the accordion **Needs attention** section. Before this change, only pending-approval workspaces were surfaced there, so unseen activity could be missed in other sections.

## Implementation details
- The change centralizes section membership logic in a single helper (`needsAttention`) to keep grouping consistent.
- This also prevents duplicate display across sections by using the same predicate for inclusion/exclusion.
- Scope is intentionally limited to accordion grouping behavior; flat/archive rendering remains unchanged.

This PR was written using [Vibe Kanban](https://vibekanban.com)
