### PR TITLE
Fix Accordion Grouping for Running Workspaces with Unseen Activity (Vibe Kanban)

### DIFF
--- a/frontend/src/components/ui-new/views/WorkspacesSidebar.tsx
+++ b/frontend/src/components/ui-new/views/WorkspacesSidebar.tsx
@@ -135,8 +135,9 @@ export function WorkspacesSidebar({
           : Infinity;
         return aTime - bTime;
       };
+      // Running workspaces should stay in the "Running" section even if unseen.
       const needsAttention = (ws: Workspace) =>
-        ws.hasPendingApproval || ws.hasUnseenActivity;
+        ws.hasPendingApproval || (ws.hasUnseenActivity && !ws.isRunning);
 
       return {
         raisedHandWorkspaces: workspaces


### PR DESCRIPTION
## What changed
- Updated accordion workspace categorization in `frontend/src/components/ui-new/views/WorkspacesSidebar.tsx`.
- Adjusted `needsAttention` logic so `hasUnseenActivity` only contributes to "Needs attention" when the workspace is **not** running.
- Added an inline comment clarifying that running workspaces should remain in the "Running" section even if they have unseen activity.

## Why
- In accordion mode, a workspace can be both running and unseen.
- The previous logic prioritized unseen activity in `needsAttention`, which moved running workspaces into "Needs attention".
- The expected behavior is for actively running workspaces to appear in "Running" to reflect current runtime state.

## Implementation details
- `needsAttention` changed from:
  - `ws.hasPendingApproval || ws.hasUnseenActivity`
- to:
  - `ws.hasPendingApproval || (ws.hasUnseenActivity && !ws.isRunning)`
- This preserves pending approvals as attention-worthy while giving running status precedence over unseen activity.

This PR was written using [Vibe Kanban](https://vibekanban.com)
