### PR TITLE
fix(settings): ensure ESC close exits settings

### DIFF
--- a/frontend/src/hooks/usePreviousPath.ts
+++ b/frontend/src/hooks/usePreviousPath.ts
@@ -2,6 +2,18 @@ import { useCallback, useEffect } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 const globalVisited: string[] = [];
+const skipReturnToPaths = new Set([
+  // Legacy alias routes that immediately redirect back into settings.
+  // Returning to them makes the "close settings" button appear broken.
+  '/mcp-servers',
+]);
+
+function normalizePath(pathname: string) {
+  if (pathname.length > 1 && pathname.endsWith('/')) {
+    return pathname.replace(/\/+$/, '');
+  }
+  return pathname;
+}
 
 export function usePreviousPath() {
   const navigate = useNavigate();
@@ -9,8 +21,9 @@ export function usePreviousPath() {
 
   // Track pathnames as user navigates
   useEffect(() => {
-    if (globalVisited[globalVisited.length - 1] !== location.pathname) {
-      globalVisited.push(location.pathname);
+    const pathname = normalizePath(location.pathname);
+    if (globalVisited[globalVisited.length - 1] !== pathname) {
+      globalVisited.push(pathname);
       // Keep only last 50 entries to prevent memory bloat
       if (globalVisited.length > 50) {
         globalVisited.splice(0, globalVisited.length - 50);
@@ -22,7 +35,9 @@ export function usePreviousPath() {
     // Find last non-settings route in history
     const lastNonSettingsPath = [...globalVisited]
       .reverse()
-      .find((p) => !p.startsWith('/settings'));
+      .find(
+        (p) => !p.startsWith('/settings') && !skipReturnToPaths.has(p)
+      );
     navigate(lastNonSettingsPath || '/');
   }, [navigate]);
 }


### PR DESCRIPTION
## Summary
Fixes a settings-exit edge case where clicking the top-right `ESC` close button can navigate to an alias route (e.g. `/mcp-servers`) that redirects back into `/settings/mcp`, making close behave like “back” instead of a true exit.

## What changed
- Updated previous-path resolution to skip redirect/alias routes that route back into settings.
- Normalized tracked pathnames (trailing slash handling) for more stable history matching.

## Why
The close action should return users to the last meaningful non-settings page in one action.  
Previously, `/mcp-servers` could be selected as “previous”, causing an immediate redirect back to settings.

## Files changed
- `frontend/src/hooks/usePreviousPath.ts`

## Repro (before)
1. Enter settings via a flow that ends up at `/settings/mcp` (e.g. through `/mcp-servers`).
2. Switch between settings tabs.
3. Click top-right `ESC`.
4. App may return to `/mcp-servers` and immediately redirect back into settings.

## Expected / after
- Clicking `ESC` exits `/settings/*` directly to the last meaningful non-settings route (or `/` as fallback).

## Verification
- Manual e2e tested locally: **passed**.
- `frontend:check`: passed
- `frontend:lint`: passed
- `cargo check`: passed

Fixes #2598
