### PR TITLE
Normalize parent issue button text size in IssuePropertyRow (Vibe Kanban)

### DIFF
--- a/frontend/src/components/ui-new/views/IssuePropertyRow.tsx
+++ b/frontend/src/components/ui-new/views/IssuePropertyRow.tsx
@@ -112,7 +112,7 @@ export function IssuePropertyRow({
             variant="tertiary"
             onClick={onParentIssueClick}
             disabled={disabled}
-            className="whitespace-nowrap"
+            className="whitespace-nowrap text-sm"
           >
             <span className="text-low">
               {t('kanban.parentIssue', 'Parent')}:


### PR DESCRIPTION
## What Changed
- Updated the parent issue `PrimaryButton` styling in `frontend/src/components/ui-new/views/IssuePropertyRow.tsx`.
- Added `text-sm` to the button class list (`whitespace-nowrap` -> `whitespace-nowrap text-sm`).
- No logic or behavior changes were introduced; this is a visual consistency adjustment only.

## Why
- In the issue property row, the parent issue button text appeared larger than adjacent controls in the same section.
- This created a typography mismatch and made that control visually inconsistent with the surrounding status/priority/assignee actions.
- The change normalizes the parent button text size so the row reads as a cohesive set of controls.

## Implementation Details
- Scope is intentionally narrow: one class change on the parent issue button in `IssuePropertyRow`.
- Existing interaction behavior (`onParentIssueClick`, `disabled`, remove-parent action) remains unchanged.
- The update relies on existing Tailwind sizing tokens already used across the UI (`text-sm`), avoiding any new design token or component API changes.

This PR was written using [Vibe Kanban](https://vibekanban.com)
