### PR TITLE
Add three-dot issue actions trigger to Kanban cards (Vibe Kanban)

### DIFF
--- a/frontend/src/components/ui-new/containers/KanbanContainer.tsx
+++ b/frontend/src/components/ui-new/containers/KanbanContainer.tsx
@@ -663,6 +663,7 @@ export function KanbanContainer() {
                             id={issue.id}
                             name={issue.title}
                             index={index}
+                            className="group"
                             onClick={() => handleCardClick(issue.id)}
                             isOpen={selectedKanbanIssueId === issue.id}
                           >

--- a/frontend/src/components/ui-new/views/KanbanCardContent.tsx
+++ b/frontend/src/components/ui-new/views/KanbanCardContent.tsx
@@ -98,7 +98,11 @@ export const KanbanCardContent = ({
               e.stopPropagation();
               onMoreActionsClick();
             }}
-            className="p-half -m-half rounded-sm text-low hover:text-normal hover:bg-secondary transition-colors shrink-0"
+            className={cn(
+              'p-half -m-half rounded-sm text-low hover:text-normal hover:bg-secondary shrink-0',
+              'invisible opacity-0 group-hover:visible group-hover:opacity-100',
+              'transition-[opacity,color,background-color]'
+            )}
             aria-label="More actions"
             title="More actions"
           >


### PR DESCRIPTION
## What changed
- Added a top-right three-dot (`DotsThreeIcon`) actions button to `KanbanCardContent`.
- Extended `KanbanCardContent` with an optional `onMoreActionsClick` prop.
- Updated the card header row layout to support right-aligned actions while keeping existing ID/sub-issue/loading content intact.
- Wired the new callback in `KanbanContainer` to open the command bar issue actions page for the clicked issue:
  - `CommandBarDialog.show({ page: 'issueActions', projectId, issueIds: [issueId] })`

## Why
This change implements the requested UX: add a three-dot menu in the top-right of Kanban cards that opens issue actions through the command bar, so users can trigger issue-level actions directly from the board without opening the issue panel first.

## Important implementation details
- The new button only renders when `onMoreActionsClick` is provided, so existing usages remain safe.
- The button calls `e.stopPropagation()` before opening the command bar to avoid triggering the card’s default click handler.
- The command bar is opened with the current `projectId` and the specific issue id (`issueIds: [issueId]`) to scope actions correctly.
- Files updated:
  - `frontend/src/components/ui-new/views/KanbanCardContent.tsx`
  - `frontend/src/components/ui-new/containers/KanbanContainer.tsx`
- Validation run during implementation:
  - `pnpm -s run check`
  - `pnpm -s run frontend:lint`

This PR was written using [Vibe Kanban](https://vibekanban.com)
