### PR TITLE
Add hover-only issue actions menu to Kanban cards (Vibe Kanban)

### DIFF
--- a/frontend/src/components/ui-new/containers/KanbanContainer.tsx
+++ b/frontend/src/components/ui-new/containers/KanbanContainer.tsx
@@ -663,6 +663,7 @@ export function KanbanContainer() {
                             id={issue.id}
                             name={issue.title}
                             index={index}
+                            className="group"
                             onClick={() => handleCardClick(issue.id)}
                             isOpen={selectedKanbanIssueId === issue.id}
                           >

--- a/frontend/src/components/ui-new/views/KanbanCardContent.tsx
+++ b/frontend/src/components/ui-new/views/KanbanCardContent.tsx
@@ -98,7 +98,11 @@ export const KanbanCardContent = ({
               e.stopPropagation();
               onMoreActionsClick();
             }}
-            className="p-half -m-half rounded-sm text-low hover:text-normal hover:bg-secondary transition-colors shrink-0"
+            className={cn(
+              'p-half -m-half rounded-sm text-low hover:text-normal hover:bg-secondary shrink-0',
+              'invisible opacity-0 group-hover:visible group-hover:opacity-100',
+              'transition-[opacity,color,background-color]'
+            )}
             aria-label="More actions"
             title="More actions"
           >


### PR DESCRIPTION
## What changes were made
- Added a three-dot actions trigger to the top-right of Kanban cards in `KanbanCardContent`.
- Introduced a new optional `onMoreActionsClick` prop on `KanbanCardContent` so parent containers can supply issue-specific action behavior.
- Wired the trigger in `KanbanContainer` to open issue actions in the command bar:
  - `CommandBarDialog.show({ page: 'issueActions', projectId, issueIds: [issueId] })`
- Updated visibility behavior so the three-dot trigger is only shown when hovering the card.
  - Added `className="group"` to the card container.
  - Applied `group-hover` visibility/opacity classes on the trigger button.

## Why these changes were made
The task was to expose issue actions directly from each Kanban card using a top-right three-dot control, then refine the interaction so the control only appears on hover. This improves quick access to issue actions while keeping the card UI visually cleaner when not interacting with it.

## Important implementation details
- The actions button calls `e.stopPropagation()` before invoking `onMoreActionsClick` so clicking it does not trigger the card’s main click/open behavior.
- The command bar is opened with the current project context and a single selected issue id to ensure actions are scoped correctly.
- The hover-only behavior is implemented using existing Tailwind group semantics (`group` + `group-hover:*`) without adding additional state logic.
- Files updated:
  - `frontend/src/components/ui-new/views/KanbanCardContent.tsx`
  - `frontend/src/components/ui-new/containers/KanbanContainer.tsx`

This PR was written using [Vibe Kanban](https://vibekanban.com)
