### PR TITLE
Deduplicate kanban issue PR badges when workspace cards are visible (Vibe Kanban)

### DIFF
--- a/frontend/src/components/ui-new/containers/KanbanContainer.tsx
+++ b/frontend/src/components/ui-new/containers/KanbanContainer.tsx
@@ -644,6 +644,20 @@ export function KanbanContainer() {
                         if (!issue) return null;
                         const issueWorkspaces =
                           workspacesByIssueId.get(issue.id) ?? [];
+                        const workspaceIdsShownOnCard = new Set(
+                          issueWorkspaces.map((workspace) => workspace.id)
+                        );
+                        const issueCardPullRequests = getPullRequestsForIssue(
+                          issue.id
+                        ).filter((pr) => {
+                          if (!pr.workspace_id) {
+                            return true;
+                          }
+
+                          // If this PR is already visible under a workspace card,
+                          // do not render it again at the issue level.
+                          return !workspaceIdsShownOnCard.has(pr.workspace_id);
+                        });
 
                         return (
                           <KanbanCard
@@ -661,7 +675,7 @@ export function KanbanContainer() {
                               priority={issue.priority}
                               tags={getTagObjectsForIssue(issue.id)}
                               assignees={issueAssigneesMap[issue.id] ?? []}
-                              pullRequests={getPullRequestsForIssue(issue.id)}
+                              pullRequests={issueCardPullRequests}
                               relationships={resolveRelationshipsForIssue(
                                 issue.id,
                                 getRelationshipsForIssue(issue.id),


### PR DESCRIPTION
## What changed
- Updated `frontend/src/components/ui-new/containers/KanbanContainer.tsx` to prevent duplicate PR badges on kanban cards when workspace cards are visible.
- In the issue card render path, the code now builds a set of workspace IDs currently shown for that issue.
- Added `issueCardPullRequests`, which filters `getPullRequestsForIssue(issue.id)` so that:
  - PRs with no `workspace_id` are still shown at the issue level.
  - PRs whose `workspace_id` matches a displayed workspace card are excluded from the issue-level PR badges.
- `KanbanCardContent` now receives this filtered PR list.

## Why
When workspaces are shown on a kanban card, the same GitHub PR could appear twice:
- once in the issue-level PR badge area, and
- again inside the workspace section for the same issue.

This change removes that duplication so PRs are represented once in the most relevant place, improving scanability and reducing UI noise.

## Important implementation details
- Deduplication is done in the container (`KanbanContainer`) where both issue-level PRs and displayed workspace cards are known.
- The logic only removes PRs that are already represented by a visible workspace card on that issue.
- Existing behavior is preserved for:
  - issues without visible workspace cards, and
  - PRs not attached to a workspace (`workspace_id === null`).

This PR was written using [Vibe Kanban](https://vibekanban.com)
