### PR TITLE
Disable Cmd+Enter submit while editing issue title and description (Vibe Kanban)

### DIFF
--- a/frontend/src/components/ui-new/containers/KanbanIssuePanelContainer.tsx
+++ b/frontend/src/components/ui-new/containers/KanbanIssuePanelContainer.tsx
@@ -894,7 +894,6 @@ export function KanbanIssuePanelContainer() {
       linkedPrs={linkedPrs}
       onClose={closeKanbanIssuePanel}
       onSubmit={handleSubmit}
-      onCmdEnterSubmit={handleSubmit}
       onCreateTag={handleCreateTag}
       isSubmitting={isSubmitting}
       isLoading={isLoading}


### PR DESCRIPTION
## Summary
This PR updates the Kanban issue panel keyboard behavior so `Cmd+Enter`/`Ctrl+Enter` does not submit when editing the issue title or description.

## What Changed
- Removed the `onCmdEnterSubmit` prop wiring in `frontend/src/components/ui-new/containers/KanbanIssuePanelContainer.tsx`.
- `KanbanIssuePanel` no longer receives a submit handler for editor-level modifier-enter shortcuts from this container.

## Why
The task context identified a UX bug: when users press `Cmd+Enter` while editing the title or description, the panel was closing unexpectedly. In edit mode, submit currently closes the panel, so the shortcut created unintended panel dismissal during text editing.

## Implementation Details
- The change is intentionally minimal and scoped to the container wiring.
- Primary submit behavior (`onSubmit`) is unchanged.
- The create/edit form logic and persistence behavior remain unchanged.
- Effectively, the modifier-enter shortcut is disabled for this panel flow to prevent accidental close while editing content.

This PR was written using [Vibe Kanban](https://vibekanban.com)
