### PR TITLE
Fix Kanban issue panel Cmd/Ctrl+Enter behavior and title caret reset (Vibe Kanban)

### DIFF
--- a/frontend/src/components/ui-new/containers/KanbanIssuePanelContainer.tsx
+++ b/frontend/src/components/ui-new/containers/KanbanIssuePanelContainer.tsx
@@ -243,7 +243,8 @@ export function KanbanIssuePanelContainer() {
           }
         }
         // Auto-focus in create mode after any dialog close focus handling runs.
-        if (mode === 'create') {
+        // Avoid resetting caret while the user is actively editing the title.
+        if (mode === 'create' && document.activeElement !== node) {
           requestAnimationFrame(() => {
             node.focus();
             // Place cursor at end of content (not start)
@@ -821,6 +822,11 @@ export function KanbanIssuePanelContainer() {
     deleteDraftIssueScratch,
   ]);
 
+  const handleCmdEnterSubmit = useCallback(() => {
+    if (mode !== 'create') return;
+    void handleSubmit();
+  }, [mode, handleSubmit]);
+
   const handleDeleteDraft = useCallback(() => {
     cancelDebouncedDraftIssue();
     dispatchFormState({
@@ -894,6 +900,7 @@ export function KanbanIssuePanelContainer() {
       linkedPrs={linkedPrs}
       onClose={closeKanbanIssuePanel}
       onSubmit={handleSubmit}
+      onCmdEnterSubmit={handleCmdEnterSubmit}
       onCreateTag={handleCreateTag}
       isSubmitting={isSubmitting}
       isLoading={isLoading}


### PR DESCRIPTION
## Summary
This PR updates the Kanban issue panel keyboard and focus behavior for title/description editing in create vs edit modes.

## What Changed
- Added a `handleCmdEnterSubmit` callback in `KanbanIssuePanelContainer` and passed it to `KanbanIssuePanel` via `onCmdEnterSubmit`.
- Scoped `Cmd/Ctrl+Enter` submission behavior to create mode only (`mode === 'create'`).
- Updated title auto-focus logic to avoid re-focusing the editable title node while it is already active.

## Why
This implements the requested issue panel behavior fixes:
- In create mode, `Cmd/Ctrl+Enter` from both title and description should trigger **Create Task**.
- In edit mode, `Cmd/Ctrl+Enter` should do nothing.
- Editing title text in the middle should preserve caret position instead of jumping to the end.

## Implementation Details
- The panel view already supports `onCmdEnterSubmit` for both title and description inputs, so the change is centralized in the container.
- `handleCmdEnterSubmit` calls `handleSubmit()` only when `mode` is `create`; in edit mode it returns early.
- The title ref callback now checks `document.activeElement !== node` before applying focus/caret-to-end behavior, preventing caret reset during active typing while keeping initial create-mode focus behavior intact.

This PR was written using [Vibe Kanban](https://vibekanban.com)
