### PR TITLE
Fix Personal view priority ordering and normalize saved sort direction (Vibe Kanban)

### DIFF
--- a/frontend/src/hooks/useUiPreferencesScratch.ts
+++ b/frontend/src/hooks/useUiPreferencesScratch.ts
@@ -10,6 +10,7 @@ import {
 } from 'shared/types';
 import {
   useUiPreferencesStore,
+  KANBAN_PROJECT_VIEW_IDS,
   type RightMainPanelMode,
   type ContextBarPosition,
   type WorkspacePanelState,
@@ -162,6 +163,12 @@ function scratchDataToStore(data: UiPreferencesData): {
         filters && isSortDirection(filters.sort_direction)
           ? filters.sort_direction
           : 'asc';
+      const normalizedSortDirection =
+        view.id === KANBAN_PROJECT_VIEW_IDS.PERSONAL &&
+        sortField === 'priority' &&
+        sortDirection === 'desc'
+          ? 'asc'
+          : sortDirection;
 
       return {
         id: view.id,
@@ -172,7 +179,7 @@ function scratchDataToStore(data: UiPreferencesData): {
           assigneeIds: filters?.assignee_ids ?? [],
           tagIds: filters?.tag_ids ?? [],
           sortField,
-          sortDirection,
+          sortDirection: normalizedSortDirection,
         },
         showSubIssues: view.show_sub_issues ?? true,
         showWorkspaces: view.show_workspaces ?? true,

--- a/frontend/src/stores/useUiPreferencesStore.ts
+++ b/frontend/src/stores/useUiPreferencesStore.ts
@@ -112,7 +112,7 @@ const createDefaultKanbanProjectViewsState = (): KanbanProjectViewsState => ({
         ...cloneKanbanFilters(DEFAULT_KANBAN_FILTER_STATE),
         assigneeIds: [KANBAN_ASSIGNEE_FILTER_VALUES.SELF],
         sortField: 'priority',
-        sortDirection: 'desc',
+        sortDirection: 'asc',
       },
       showSubIssues: true,
       showWorkspaces: true,


### PR DESCRIPTION
## What changed
- Updated the default **Personal** Kanban view filters to keep sorting by `priority` but use `sortDirection: 'asc'` instead of `'desc'`.
- Added a compatibility normalization in UI preferences scratch hydration so previously saved Personal views with `priority + desc` are converted to `priority + asc` when loaded.
- Scoped the normalization to the built-in Personal view only; Team/custom views are not modified.

## Why this was needed
The Personal view is intended to show priority from high to low. In the current priority ranking model (`urgent=0`, `high=1`, `medium=2`, `low=3`), using `desc` inverts the order and shows low-priority work first. This change aligns the Personal view behavior with the intended task context.

## Implementation details
- Default Personal view config updated in `frontend/src/stores/useUiPreferencesStore.ts`.
- Backward-compatible normalization added in `frontend/src/hooks/useUiPreferencesScratch.ts` during scratch-to-store mapping.
- Existing sort comparator logic remains unchanged; this fix corrects the input configuration and persisted state normalization points.
- Validation: `pnpm run check` passed (`frontend` TypeScript check + `backend` cargo check).

This PR was written using [Vibe Kanban](https://vibekanban.com)
