### PR TITLE
Replace vertical margin spacing with padding in ui-new conversation entries (Vibe Kanban)

### DIFF
--- a/frontend/src/components/ui-new/containers/NewDisplayConversationEntry.tsx
+++ b/frontend/src/components/ui-new/containers/NewDisplayConversationEntry.tsx
@@ -1029,7 +1029,7 @@ const NewDisplayConversationEntrySpaced = (props: Props) => {
   return (
     <div
       className={cn(
-        'my-base px-double',
+        'py-base px-double',
         isGreyed && 'opacity-50 pointer-events-none'
       )}
     >

--- a/frontend/src/components/ui-new/primitives/conversation/ChatAggregatedToolEntries.tsx
+++ b/frontend/src/components/ui-new/primitives/conversation/ChatAggregatedToolEntries.tsx
@@ -51,7 +51,7 @@ export function ChatAggregatedToolEntries({
         onClick={onViewContent ? () => onViewContent(0) : undefined}
         role={onViewContent ? 'button' : undefined}
       >
-        <span className="relative shrink-0 mt-0.5">
+        <span className="relative shrink-0 pt-0.5">
           <Icon className="size-icon-base" />
           {entry.status && (
             <ToolStatusDot
@@ -100,7 +100,7 @@ export function ChatAggregatedToolEntries({
         role="button"
         aria-expanded={expanded}
       >
-        <span className="relative shrink-0 mt-0.5">
+        <span className="relative shrink-0 pt-0.5">
           {isHovered ? (
             <CaretRightIcon
               className={cn(
@@ -125,7 +125,7 @@ export function ChatAggregatedToolEntries({
 
       {/* Expanded content */}
       {expanded && (
-        <div className="ml-6 mt-1 flex flex-col gap-0.5">
+        <div className="ml-6 pt-1 flex flex-col gap-0.5">
           {entries.map((entry, index) => (
             <div
               key={entry.expansionKey}
@@ -136,7 +136,7 @@ export function ChatAggregatedToolEntries({
               onClick={onViewContent ? () => onViewContent(index) : undefined}
               role={onViewContent ? 'button' : undefined}
             >
-              <span className="relative shrink-0 mt-0.5">
+              <span className="relative shrink-0 pt-0.5">
                 <Icon className="size-icon-base" />
                 {entry.status && (
                   <ToolStatusDot

--- a/frontend/src/components/ui-new/primitives/conversation/ChatCollapsedThinking.tsx
+++ b/frontend/src/components/ui-new/primitives/conversation/ChatCollapsedThinking.tsx
@@ -47,7 +47,7 @@ export function ChatCollapsedThinking({
         role="button"
         aria-expanded={expanded}
       >
-        <span className="shrink-0 mt-0.5">
+        <span className="shrink-0 pt-0.5">
           {isHovered ? (
             <CaretRightIcon
               className={cn(
@@ -64,7 +64,7 @@ export function ChatCollapsedThinking({
 
       {/* Expanded content */}
       {expanded && (
-        <div className="ml-6 mt-1 flex flex-col gap-base">
+        <div className="ml-6 pt-1 flex flex-col gap-base">
           {entries.map((entry) => (
             <div key={entry.expansionKey} className="text-sm text-low pl-base">
               <ChatMarkdown

--- a/frontend/src/components/ui-new/primitives/conversation/ChatErrorMessage.tsx
+++ b/frontend/src/components/ui-new/primitives/conversation/ChatErrorMessage.tsx
@@ -23,7 +23,7 @@ export function ChatErrorMessage({
       onClick={onToggle}
       role="button"
     >
-      <WarningCircleIcon className="shrink-0 size-icon-base mt-0.5" />
+      <WarningCircleIcon className="shrink-0 size-icon-base pt-0.5" />
       <span
         className={cn(
           !expanded && 'truncate',

--- a/frontend/src/components/ui-new/primitives/conversation/ChatScriptEntry.tsx
+++ b/frontend/src/components/ui-new/primitives/conversation/ChatScriptEntry.tsx
@@ -66,7 +66,7 @@ export function ChatScriptEntry({
         }
       }}
     >
-      <span className="relative shrink-0 mt-0.5">
+      <span className="relative shrink-0 pt-0.5">
         <TerminalIcon className="size-icon-base text-low" />
         <ToolStatusDot
           status={status}

--- a/frontend/src/components/ui-new/primitives/conversation/ChatScriptPlaceholder.tsx
+++ b/frontend/src/components/ui-new/primitives/conversation/ChatScriptPlaceholder.tsx
@@ -34,7 +34,7 @@ export function ChatScriptPlaceholder({
         className
       )}
     >
-      <span className="relative shrink-0 mt-0.5">
+      <span className="relative shrink-0 pt-0.5">
         <TerminalIcon className="size-icon-base text-lowest" />
       </span>
       <div className="flex flex-col min-w-0 flex-1 gap-0.5">

--- a/frontend/src/components/ui-new/primitives/conversation/ChatSubagentEntry.tsx
+++ b/frontend/src/components/ui-new/primitives/conversation/ChatSubagentEntry.tsx
@@ -147,7 +147,7 @@ export function ChatSubagentEntry({
       {/* Expanded content - shows subagent output */}
       {expanded && hasContent && (
         <div className="border-t p-double bg-panel/50">
-          <div className="text-xs font-medium text-low mb-base uppercase tracking-wide">
+          <div className="text-xs font-medium text-low pb-base uppercase tracking-wide">
             {t('conversation.output')}
           </div>
           <div className="prose prose-sm dark:prose-invert max-w-none">

--- a/frontend/src/components/ui-new/primitives/conversation/ChatSystemMessage.tsx
+++ b/frontend/src/components/ui-new/primitives/conversation/ChatSystemMessage.tsx
@@ -23,7 +23,7 @@ export function ChatSystemMessage({
       onClick={onToggle}
       role="button"
     >
-      <InfoIcon className="shrink-0 size-icon-base mt-0.5" />
+      <InfoIcon className="shrink-0 size-icon-base pt-0.5" />
       <span
         className={cn(
           !expanded && 'truncate',

--- a/frontend/src/components/ui-new/primitives/conversation/ChatThinkingMessage.tsx
+++ b/frontend/src/components/ui-new/primitives/conversation/ChatThinkingMessage.tsx
@@ -17,7 +17,7 @@ export function ChatThinkingMessage({
     <div
       className={cn('flex items-start gap-base text-sm text-low', className)}
     >
-      <ChatDotsIcon className="shrink-0 size-icon-base mt-0.5" />
+      <ChatDotsIcon className="shrink-0 size-icon-base pt-0.5" />
       <ChatMarkdown
         content={content}
         workspaceId={taskAttemptId}

--- a/frontend/src/components/ui-new/primitives/conversation/ChatTodoList.tsx
+++ b/frontend/src/components/ui-new/primitives/conversation/ChatTodoList.tsx
@@ -41,13 +41,13 @@ export function ChatTodoList({ todos, expanded, onToggle }: ChatTodoListProps) {
         />
       </div>
       {expanded && todos.length > 0 && (
-        <ul className="mt-base ml-6 space-y-1">
+        <ul className="pt-base ml-6 [&>li+li]:pt-1">
           {todos.map((todo, index) => (
             <li
               key={`${todo.content}-${index}`}
               className="flex items-start gap-2"
             >
-              <span className="mt-0.5 h-4 w-4 flex items-center justify-center shrink-0">
+              <span className="pt-0.5 h-4 w-4 flex items-center justify-center shrink-0">
                 {getStatusIcon(todo.status)}
               </span>
               <span className="leading-5 break-words">

--- a/frontend/src/components/ui-new/primitives/conversation/ChatToolSummary.tsx
+++ b/frontend/src/components/ui-new/primitives/conversation/ChatToolSummary.tsx
@@ -77,7 +77,7 @@ export const ChatToolSummary = forwardRef<
       onClick={isClickable ? handleClick : undefined}
       role={isClickable ? 'button' : undefined}
     >
-      <span className="relative shrink-0 mt-0.5">
+      <span className="relative shrink-0 pt-0.5">
         <Icon className="size-icon-base" />
         {status && (
           <ToolStatusDot

--- a/frontend/src/components/ui-new/primitives/conversation/PierreConversationDiff.tsx
+++ b/frontend/src/components/ui-new/primitives/conversation/PierreConversationDiff.tsx
@@ -28,10 +28,10 @@ import '@/styles/diff-style-overrides.css';
  */
 const PIERRE_DIFFS_THEME_CSS = `
   [data-separator="line-info"][data-separator-first] {
-    margin-top: 4px;
+    padding-top: 4px;
   }
   [data-separator="line-info"][data-separator-last] {
-    margin-bottom: 4px;
+    padding-bottom: 4px;
   }
 
   [data-disable-line-numbers][data-indicators='classic'] [data-column-content] {


### PR DESCRIPTION
## What changed
- Replaced vertical margin-based spacing with padding in the new conversation entry container and its rendered `ui-new` conversation primitives.
- Converted icon/content alignment utilities from `mt-*` to `pt-*` in thinking, system, error, tool summary, script, collapsed thinking, and aggregated tool entry components.
- Updated container-level spacing conversions such as `my-base -> py-base`, `mt-1 -> pt-1`, and `mb-base -> pb-base`.
- Replaced `space-y-1` in `ChatTodoList` with an explicit sibling padding rule (`[&>li+li]:pt-1`) and converted `mt-base -> pt-base`.
- Updated Pierre diff separator styling from `margin-top` / `margin-bottom` to `padding-top` / `padding-bottom`.

## Why
- This implements the task requirement to replace margin usage with padding in `NewDisplayConversationEntry.tsx` and its child components.
- The goal is to remove vertical margin-based spacing while preserving visual spacing behavior.

## Implementation details
- Scope is limited to `frontend/src/components/ui-new/containers/NewDisplayConversationEntry.tsx` and related `frontend/src/components/ui-new/primitives/conversation/*` components used by that container.
- This is a styling-only change (no logic/behavior changes).
- Horizontal margin classes were intentionally not changed as part of this update.

This PR was written using [Vibe Kanban](https://vibekanban.com)
