### PR TITLE
Improve Kanban control wrapping on smaller screens (Vibe Kanban)

### DIFF
--- a/frontend/src/components/ui-new/containers/KanbanContainer.tsx
+++ b/frontend/src/components/ui-new/containers/KanbanContainer.tsx
@@ -608,7 +608,7 @@ export function KanbanContainer() {
           </DropdownMenu>
         </div>
 
-        <div className="flex items-center gap-base flex-wrap">
+        <div className="flex flex-wrap items-start gap-base">
           <ViewNavTabs
             activeView={kanbanViewMode}
             onViewChange={setKanbanViewMode}

--- a/frontend/src/components/ui-new/primitives/ViewNavTabs.tsx
+++ b/frontend/src/components/ui-new/primitives/ViewNavTabs.tsx
@@ -3,6 +3,7 @@
 import { useTranslation } from 'react-i18next';
 import type { ProjectStatus } from 'shared/remote-types';
 import type { KanbanViewMode } from '@/stores/useUiPreferencesStore';
+import { cn } from '@/lib/utils';
 import {
   ButtonGroup,
   ButtonGroupItem,
@@ -30,8 +31,8 @@ export function ViewNavTabs({
   const isAllTab = activeView === 'list' && selectedStatusId === null;
 
   return (
-    <div className="flex items-center gap-base">
-      <ButtonGroup className={className}>
+    <div className="flex min-w-0 flex-wrap items-center gap-base">
+      <ButtonGroup className={cn('flex-wrap', className)}>
         {/* Active (Kanban) tab */}
         <ButtonGroupItem
           active={isActiveTab}

--- a/frontend/src/components/ui-new/views/KanbanFilterBar.tsx
+++ b/frontend/src/components/ui-new/views/KanbanFilterBar.tsx
@@ -73,8 +73,8 @@ export function KanbanFilterBar({
 
   return (
     <>
-      <div className="flex items-center gap-base flex-wrap flex-1 min-w-0">
-        <ButtonGroup>
+      <div className="flex min-w-0 flex-wrap items-center gap-base">
+        <ButtonGroup className="flex-wrap">
           <ButtonGroupItem
             active={activeViewId === KANBAN_PROJECT_VIEW_IDS.TEAM}
             onClick={() =>


### PR DESCRIPTION
## Summary
This PR improves responsive behavior of the Kanban top controls so they wrap cleanly across smaller screen widths instead of compressing into awkward layouts.

## What changed
- Updated the controls row in `KanbanContainer.tsx` to use `items-start` with wrapping, so wrapped rows align naturally.
- Updated `ViewNavTabs.tsx` to allow tab controls to wrap by:
  - making the wrapper flex container wrap-capable with `min-w-0`
  - enabling `flex-wrap` on the underlying `ButtonGroup`
  - merging classes with `cn` so external class overrides still work
- Updated `KanbanFilterBar.tsx` to remove forced growth (`flex-1`) and enable wrapping in its `ButtonGroup`, so filters move to new lines instead of collapsing vertically inside a constrained area.

## Why
The original layout increasingly compressed `ViewNavTabs` and `KanbanFilterBar` as viewport width decreased, which caused controls inside the filter bar to stack in a less usable way. The goal was to make controls gracefully overflow onto additional lines as space shrinks, with minimal and readable changes.

## Implementation details
- No behavior, state, or API changes were introduced.
- The update is purely presentational and limited to Tailwind class adjustments in 3 files.
- Wrapping is now allowed at both container and button-group levels, which prevents one section from monopolizing horizontal space.

This PR was written using [Vibe Kanban](https://vibekanban.com)
