### PR TITLE
Use @sourcegraph/amp@latest in AMP executor (Vibe Kanban)

### DIFF
--- a/crates/executors/src/executors/amp.rs
+++ b/crates/executors/src/executors/amp.rs
@@ -34,7 +34,7 @@ pub struct Amp {
 
 impl Amp {
     fn build_command_builder(&self) -> Result<CommandBuilder, CommandBuildError> {
-        let mut builder = CommandBuilder::new("npx -y @sourcegraph/amp@0.0.1770631794-g51e285")
+        let mut builder = CommandBuilder::new("npx -y @sourcegraph/amp@latest")
             .params(["--execute", "--stream-json"]);
         if self.dangerously_allow_all.unwrap_or(false) {
             builder = builder.extend_params(["--dangerously-allow-all"]);


### PR DESCRIPTION
## What Changed
- Updated the AMP executor command in `crates/executors/src/executors/amp.rs` to use `@sourcegraph/amp@latest` instead of a pinned package version.
- No other files or runtime behaviors were modified.

## Why
- The task for this branch was to set AMP to the latest npm version rather than a fixed build tag.
- Using `latest` ensures the executor pulls the newest published AMP CLI on each run, so this integration stays current without requiring repeated version bump PRs.

## Implementation Details
- In `Amp::build_command_builder`, the command string changed from:
  - `npx -y @sourcegraph/amp@0.0.1770631794-g51e285`
  - to `npx -y @sourcegraph/amp@latest`
- The executor flags and flow are unchanged (`--execute --stream-json`, optional `--dangerously-allow-all`, follow-up thread handling, and log normalization).
- This keeps the change minimal and scoped only to package resolution behavior.

This PR was written using [Vibe Kanban](https://vibekanban.com)
