### PR TITLE
Improve WYSIWYG nested list Tab behavior and marker rendering (Vibe Kanban)

### DIFF
--- a/frontend/src/components/ui/wysiwyg.tsx
+++ b/frontend/src/components/ui/wysiwyg.tsx
@@ -199,6 +199,7 @@ const WYSIWYGEditor = forwardRef<WYSIWYGEditorRef, WysiwygProps>(
             ol: 'my-1 list-decimal list-inside',
             listitem: '',
             nested: {
+              // Hide the structural wrapper marker Lexical adds for nested items.
               listitem: 'list-none pl-4',
             },
           },

--- a/frontend/src/components/ui/wysiwyg/plugins/markdown-sync-plugin.tsx
+++ b/frontend/src/components/ui/wysiwyg/plugins/markdown-sync-plugin.tsx
@@ -7,17 +7,6 @@ import {
 } from '@lexical/markdown';
 import { $getRoot, type EditorState } from 'lexical';
 
-const DEBUG_PREFIX = '[WYSIWYG_DEBUG]';
-
-function debugLog(message: string, payload?: unknown) {
-  if (!import.meta.env.DEV) return;
-  if (payload === undefined) {
-    console.log(DEBUG_PREFIX, message);
-    return;
-  }
-  console.log(DEBUG_PREFIX, message, payload);
-}
-
 type MarkdownSyncPluginProps = {
   value: string;
   onChange?: (markdown: string) => void;
@@ -48,17 +37,7 @@ export function MarkdownSyncPlugin({
 
   // Handle controlled value changes (external → editor)
   useEffect(() => {
-    if (value === lastSerializedRef.current) {
-      debugLog('markdown-sync: skip external->editor (value unchanged)', {
-        valueLength: value.length,
-      });
-      return;
-    }
-
-    debugLog('markdown-sync: begin external->editor', {
-      valueLength: value.length,
-      valuePreview: value.slice(0, 120),
-    });
+    if (value === lastSerializedRef.current) return;
 
     try {
       editor.update(() => {
@@ -78,21 +57,9 @@ export function MarkdownSyncPlugin({
             lastNode.selectEnd();
           }
         }
-
-        const root = $getRoot();
-        debugLog('markdown-sync: applied external->editor update', {
-          rootChildren: root.getChildren().map((node) => ({
-            key: node.getKey(),
-            type: node.getType(),
-            textPreview: node.getTextContent().slice(0, 60),
-          })),
-        });
       });
       lastSerializedRef.current = value;
     } catch (err) {
-      debugLog('markdown-sync: external->editor failed', {
-        error: err instanceof Error ? err.message : String(err),
-      });
       console.error('Failed to parse markdown', err);
     }
   }, [editor, value, transformers]);
@@ -106,17 +73,8 @@ export function MarkdownSyncPlugin({
       const markdown = editorState.read(() =>
         $convertToMarkdownString(transformers)
       );
-      if (markdown === lastSerializedRef.current) {
-        debugLog('markdown-sync: skip editor->external (markdown unchanged)', {
-          markdownLength: markdown.length,
-        });
-        return;
-      }
+      if (markdown === lastSerializedRef.current) return;
 
-      debugLog('markdown-sync: emit editor->external update', {
-        markdownLength: markdown.length,
-        markdownPreview: markdown.slice(0, 120),
-      });
       lastSerializedRef.current = markdown;
       onChange(markdown);
     });


### PR DESCRIPTION
## What Changed
- Added list-specific `Tab` / `Shift+Tab` handling in `frontend/src/components/ui/wysiwyg/plugins/keyboard-commands-plugin.tsx`.
- `Tab` now nests and `Shift+Tab` unnests when the selection is inside list items.
- Multi-node list selections still use Lexical indent/outdent commands.
- Kept existing behavior in non-list contexts and preserved typeahead handling by not intercepting `Tab` when typeahead is open.
- Updated WYSIWYG list theme in `frontend/src/components/ui/wysiwyg.tsx` to use `nested.listitem: 'list-none pl-4'` so Lexical's structural wrapper list item does not render an extra marker.

## Why
This addresses the WYSIWYG nested-list UX request:
- make nested lists easy to create,
- use Google Docs-like keyboard shortcuts,
- and eliminate the confusing extra blank bullet that appeared after nesting.

## Implementation Details
- Registered a `KEY_TAB_COMMAND` handler scoped to list context in `KeyboardCommandsPlugin`.
- For collapsed selections, the plugin resolves the effective list item reliably (including empty list item edge cases) before applying indent/outdent.
- Prevented indenting when there is no previous list-item sibling to better match expected Google Docs behavior.
- The visual extra-bullet fix is a theme-level change, not a markdown/state change: nested wrapper list items are intentionally markerless while retaining indentation.

This PR was written using [Vibe Kanban](https://vibekanban.com)
