### PR TITLE
feat: support custom hostnames in dev preview URL detection

### DIFF
--- a/frontend/src/hooks/useDevserverUrl.ts
+++ b/frontend/src/hooks/useDevserverUrl.ts
@@ -2,7 +2,9 @@ import { useEffect, useRef, useState } from 'react';
 import { stripAnsi } from 'fancy-ansi';
 
 const urlPatterns = [
-  /(https?:\/\/(?:\[[0-9a-f:]+\]|localhost|127\.0\.0\.1|0\.0\.0\.0|\d{1,3}(?:\.\d{1,3}){3})(?::\d{2,5})?(?:\/\S*)?)/i,
+  // Full URL with scheme — matches any hostname (localhost, IPs, FQDNs, Tailscale names, etc.)
+  /(https?:\/\/(?:\[[0-9a-f:]+\]|[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?)*|\d{1,3}(?:\.\d{1,3}){3})(?::\d{2,5})?(?:\/\S*)?)/i,
+  // Bare host:port without scheme — kept restrictive to avoid false positives on non-URL text
   /(?:localhost|127\.0\.0\.1|0\.0\.0\.0|\[[0-9a-f:]+\]|(?:\d{1,3}\.){3}\d{1,3}):(\d{2,5})/i,
 ];
 


### PR DESCRIPTION
## Summary
- Expand the first URL detection regex in `useDevserverUrl.ts` to match any valid DNS hostname, not just `localhost`/`127.0.0.1`/`0.0.0.0`
- Enables the preview panel to auto-detect URLs from dev servers accessed via Tailscale, custom hostnames (e.g. `http://vibe:3500`), or FQDN-based setups (e.g. `https://sc-local-test-gateway.my-tailnet.ts.net:443`)
- The bare `host:port` fallback pattern (without `http://` prefix) is intentionally kept restrictive to avoid false positives

Fixes #2236

## What changed

The first regex pattern in `urlPatterns` was:
```
/(https?:\/\/(?:\[[0-9a-f:]+\]|localhost|127\.0\.0\.1|0\.0\.0\.0|\d{1,3}(?:\.\d{1,3}){3})(?::\d{2,5})?(?:\/\S*)?)/i
```

The hostname group only allowed `localhost`, `127.0.0.1`, `0.0.0.0`, IPv6 brackets, and bare IPv4. This prevented detection of URLs with custom hostnames or FQDNs.

The fix replaces the hostname group with a general DNS hostname pattern (`[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?(.[a-zA-Z0-9]...)*`) while keeping the IPv4 and IPv6 alternatives. Since this pattern requires the `http://` or `https://` prefix, it won't false-positive on random text.

## Test plan
- [x] Verified regex matches all existing cases: `http://localhost:3000`, `http://127.0.0.1:8080`, `http://0.0.0.0:5000`, `https://localhost:443`, IPv6 `http://[::1]:3000`
- [x] Verified regex matches new cases: `http://vibe:3500`, `https://sc-local-test-gateway.my-tailnet.ts.net:443`, `https://my-host.example.com:8443/dashboard`
- [x] Verified no false positives on non-URL text

🤖 Generated with [Claude Code](https://claude.com/claude-code)