### PR TITLE
fix(frontend): improve attempts list visibility & add back navigation

### DIFF
--- a/frontend/src/components/panels/TaskPanel.tsx
+++ b/frontend/src/components/panels/TaskPanel.tsx
@@ -102,7 +102,7 @@ const TaskPanel = ({ task }: TaskPanelProps) => {
   return (
     <>
       <NewCardContent>
-        <div className="p-6 flex flex-col h-full max-h-[calc(100vh-8rem)]">
+        <div className="p-6 flex flex-col h-full min-h-0">
           <div className="space-y-3 overflow-y-auto flex-shrink min-h-0">
             <WYSIWYGEditor value={titleContent} disabled />
             {descriptionContent && (

--- a/frontend/src/components/ui-new/containers/WorkspacesSidebarContainer.tsx
+++ b/frontend/src/components/ui-new/containers/WorkspacesSidebarContainer.tsx
@@ -1,4 +1,5 @@
 import { useState, useMemo, useCallback, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useWorkspaceContext } from '@/contexts/WorkspaceContext';
 import { useUserContext } from '@/contexts/remote/UserContext';
 import { useScratch } from '@/hooks/useScratch';
@@ -144,10 +145,10 @@ export function WorkspacesSidebarContainer({
     value: WorkspacePrFilter;
     label: string;
   }[] = [
-    { value: 'all', label: 'All' },
-    { value: 'has_pr', label: 'Has PR' },
-    { value: 'no_pr', label: 'No PR' },
-  ];
+      { value: 'all', label: 'All' },
+      { value: 'has_pr', label: 'Has PR' },
+      { value: 'no_pr', label: 'No PR' },
+    ];
 
   // Pagination state for infinite scroll
   const [displayLimit, setDisplayLimit] = useState(PAGE_SIZE);
@@ -319,6 +320,26 @@ export function WorkspacesSidebarContainer({
     </div>
   );
 
+  // Back navigation logic
+  const backLinkData = useMemo(() => {
+    // 1. Single project selected
+    if (workspaceFilters.projectIds.length === 1) {
+      const projectId = workspaceFilters.projectIds[0];
+      if (projectId === NO_PROJECT_ID) {
+        return { link: '/', label: 'Back to projects' };
+      }
+      const project = allRemoteProjects.find((p) => p.id === projectId);
+      return {
+        link: `/projects/${projectId}`,
+        label: project ? `Back to ${project.name}` : 'Back to project',
+      };
+    }
+    // 2. Default fallback
+    return { link: '/', label: 'Back to projects' };
+  }, [workspaceFilters.projectIds, allRemoteProjects]);
+
+  const navigate = useNavigate();
+
   return (
     <WorkspacesSidebar
       workspaces={paginatedActiveWorkspaces}
@@ -340,6 +361,9 @@ export function WorkspacesSidebarContainer({
       hasMoreWorkspaces={hasMoreWorkspaces && !isSearching}
       filterBar={filterBar}
       onSearchFocusChange={setIsSearchFocused}
+      backLink={backLinkData.link}
+      backLabel={backLinkData.label}
+      onBack={() => navigate(backLinkData.link)}
     />
   );
 }

--- a/frontend/src/components/ui-new/views/WorkspacesSidebar.tsx
+++ b/frontend/src/components/ui-new/views/WorkspacesSidebar.tsx
@@ -104,7 +104,14 @@ export function WorkspacesSidebar({
   hasMoreWorkspaces = false,
   filterBar,
   onSearchFocusChange,
-}: WorkspacesSidebarProps) {
+  backLink,
+  backLabel,
+  onBack,
+}: WorkspacesSidebarProps & {
+  backLink?: string;
+  backLabel?: string;
+  onBack?: () => void;
+}) {
   const { t } = useTranslation(['tasks', 'common']);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
 
@@ -166,6 +173,19 @@ export function WorkspacesSidebar({
 
   return (
     <div className="w-full h-full bg-secondary flex flex-col">
+      {/* Back Button (if provided) */}
+      {backLink && onBack && (
+        <div className="px-base pt-base -mb-2">
+          <button
+            onClick={onBack}
+            className="flex items-center gap-1.5 text-xs font-medium text-low hover:text-foreground transition-colors group"
+          >
+            <ArrowLeftIcon className="size-3 transition-transform group-hover:-translate-x-0.5" />
+            <span className="truncate max-w-[200px]">{backLabel}</span>
+          </button>
+        </div>
+      )}
+
       {/* Header + Search */}
       <div className="flex flex-col gap-base">
         <CollapsibleSectionHeader

--- a/frontend/src/components/ui/new-card.tsx
+++ b/frontend/src/components/ui/new-card.tsx
@@ -22,7 +22,7 @@ const NewCardHeader = React.forwardRef<HTMLDivElement, NewCardHeaderProps>(
         'relative bg-background text-foreground text-base flex items-center gap-2 px-3 border-b border-dashed',
         // add a solid top line via ::before, except on the first header
         'before:content-[""] before:absolute before:top-0 before:left-0 before:right-0 ' +
-          'before:h-px before:bg-border first:before:hidden',
+        'before:h-px before:bg-border first:before:hidden',
         actions && 'justify-between',
         className
       )}
@@ -47,7 +47,7 @@ const NewCardContent = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn('flex-1 bg-muted text-foreground gap-2', className)}
+    className={cn('flex-1 bg-muted text-foreground gap-2 flex flex-col min-h-0', className)}
     {...props}
   />
 ));


### PR DESCRIPTION
## Changes
1. **Fix Attempts List Visibility:** Removed manual height calculation in TaskPanel to allow the attempts list to be visible and scroll properly.
2. **Add Back Navigation:** Added a 'Back to projects' button in the Workspaces sidebar. When filtered by a project, it navigates back to that project's board; otherwise, to the main list.