### PR TITLE
fix: pass git errors to the frontend with actionable messages (Vibe Kanban)

### DIFF
--- a/crates/server/src/error.rs
+++ b/crates/server/src/error.rs
@@ -343,9 +343,9 @@ impl IntoResponse for ApiError {
                     ),
                 )
             }
-            ApiError::GitService(git::GitServiceError::GitCLI(
-                git::GitCliError::AuthFailed(msg),
-            )) => ErrorInfo::with_status(
+            ApiError::GitService(git::GitServiceError::GitCLI(git::GitCliError::AuthFailed(
+                msg,
+            ))) => ErrorInfo::with_status(
                 StatusCode::UNAUTHORIZED,
                 "GitServiceError",
                 format!(


### PR DESCRIPTION
## Summary

Previously, the `GitServiceError` catch-all in `error.rs` mapped all unhandled git errors to a generic HTTP 500 with the message *"An internal error occurred. Please try again."* — hiding what went wrong and how to fix it.

This PR replaces that catch-all with explicit match arms for errors where we can provide **actionable user guidance**, plus a catch-all that passes through the raw error message for everything else.

## Changes

**File:** `crates/server/src/error.rs`

### Explicit arms with actionable advice:

| Variant | HTTP Status | User-facing message |
|---------|-------------|---------------------|
| `BranchNotFound(branch)` | 404 | *"Branch '{branch}' not found. Try changing the target branch."* |
| `BranchesDiverged(msg)` | 409 | *"{msg} Rebase onto the target branch first, then retry the merge."* |
| `WorktreeDirty(branch, files)` | 409 | *"Branch '{branch}' has uncommitted changes ({files}). Commit or revert them before retrying."* |
| `GitCLI(AuthFailed(msg))` | 401 | *"{msg}. Check your git credentials or SSH keys and try again."* |

### Catch-all for everything else:

All remaining `GitServiceError` variants (e.g. `InvalidRepository`, `CommandFailed`, `NotAvailable`) now pass through their `Display` message via `"Git operation failed: {e}"` instead of returning a generic internal error.

## Why

The frontend already renders the `message` field from error responses verbatim in the git actions dialog. The old catch-all threw away useful information that git was already providing. Now users see what actually went wrong and, for the most common errors, how to fix it.

- [x] tested

This PR was written using [Vibe Kanban](https://vibekanban.com)