### PR TITLE
fix(D847): detect manual worktree branch changes in workspaces mode

### DIFF
--- a/crates/local-deployment/src/container.rs
+++ b/crates/local-deployment/src/container.rs
@@ -1348,7 +1348,11 @@ impl ContainerService for LocalContainerService {
 
         for repo in repositories {
             let worktree_path = workspace_root.join(&repo.name);
-            let branch = &workspace.branch;
+            let branch = self
+                .git()
+                .get_head_info(&worktree_path)
+                .map(|h| h.branch)
+                .unwrap_or_else(|_| workspace.branch.clone());
 
             let Some(target_branch) = target_branches.get(&repo.id) else {
                 tracing::warn!(
@@ -1360,7 +1364,7 @@ impl ContainerService for LocalContainerService {
 
             let base_commit = match self
                 .git()
-                .get_base_commit(&repo.path, branch, target_branch)
+                .get_base_commit(&repo.path, &branch, target_branch)
             {
                 Ok(c) => c,
                 Err(e) => {


### PR DESCRIPTION
## Summary

When manually switching branches in a worktree (`git checkout another-branch`), Vibe Kanban didn't detect the change. The `workspace.branch` DB field was set at creation and never auto-updated, causing all operations (diff stream, branch status, push, PR) to use the stale value and fail with "Branch not found" errors.

## Changes

- **Auto-sync in branch status handler** (`task_attempts.rs`): The handler already called `get_head_info()` but discarded the branch name. Now captures it, uses the actual HEAD branch for status computation, and auto-syncs the DB when a mismatch is detected (with cascade to child workspaces)
- **Diff stream self-healing** (`diff_stream.rs`): Running diff streams froze the branch at creation. Now detects branch changes on `.git/HEAD` change events and resets the stream with the correct branch
- **Robustness in diff stream creation** (`container.rs`): Reads actual worktree HEAD branch instead of trusting the potentially-stale DB value

Detached HEAD state (`git checkout <sha>`) is explicitly skipped to avoid corrupting the DB.

## Test Plan

- `cargo test --workspace` passes (209 tests, 0 failures)
- Manual: create workspace → `git checkout -b other-branch` in worktree → wait ~5s → UI updates branch name, diff stream recovers

## Related Issues

- Closes #2655