### PR TITLE
Bulk-fetch PR statuses to reduce GitHub API calls (Vibe Kanban)

### DIFF
--- a/crates/services/src/services/git_host/github/cli.rs
+++ b/crates/services/src/services/git_host/github/cli.rs
@@ -202,15 +202,6 @@ impl GhCli {
         Self::parse_repo_info_response(&raw)
     }
 
-    /// Get repo info using the git remote of the given directory.
-    pub fn get_repo_info_from_dir(&self, repo_path: &Path) -> Result<GitHubRepoInfo, GhCliError> {
-        let raw = self.run(
-            ["repo", "view", "--json", "owner,name,url"],
-            Some(repo_path),
-        )?;
-        Self::parse_repo_info_response(&raw)
-    }
-
     fn parse_repo_info_response(raw: &str) -> Result<GitHubRepoInfo, GhCliError> {
         let resp: GhRepoViewResponse = serde_json::from_str(raw).map_err(|e| {
             GhCliError::UnexpectedOutput(format!("Failed to parse gh repo view response: {e}"))

--- a/crates/services/src/services/git_host/github/mod.rs
+++ b/crates/services/src/services/git_host/github/mod.rs
@@ -45,21 +45,6 @@ impl GitHubProvider {
             .map_err(Into::into)
     }
 
-    /// Get repo info using the git remote of the given directory.
-    pub async fn get_repo_info_from_dir(
-        &self,
-        repo_path: &Path,
-    ) -> Result<GitHubRepoInfo, GitHostError> {
-        let cli = self.gh_cli.clone();
-        let path = repo_path.to_path_buf();
-        task::spawn_blocking(move || cli.get_repo_info_from_dir(&path))
-            .await
-            .map_err(|err| {
-                GitHostError::Repository(format!("Failed to get repo info from directory: {err}"))
-            })?
-            .map_err(Into::into)
-    }
-
     async fn fetch_general_comments(
         &self,
         cli: &GhCli,

--- a/crates/services/src/services/git_host/github/mod.rs
+++ b/crates/services/src/services/git_host/github/mod.rs
@@ -6,9 +6,8 @@ use std::{collections::HashMap, path::Path, time::Duration};
 
 use async_trait::async_trait;
 use backon::{ExponentialBuilder, Retryable};
-pub use cli::GhCli;
-pub use cli::GitHubRepoInfo;
 use cli::GhCliError;
+pub use cli::{GhCli, GitHubRepoInfo};
 use db::models::merge::PullRequestInfo;
 use tokio::task;
 use tracing::info;
@@ -56,9 +55,7 @@ impl GitHubProvider {
         task::spawn_blocking(move || cli.get_repo_info_from_dir(&path))
             .await
             .map_err(|err| {
-                GitHostError::Repository(format!(
-                    "Failed to get repo info from directory: {err}"
-                ))
+                GitHostError::Repository(format!("Failed to get repo info from directory: {err}"))
             })?
             .map_err(Into::into)
     }

--- a/crates/services/src/services/git_host/github/mod.rs
+++ b/crates/services/src/services/git_host/github/mod.rs
@@ -397,14 +397,12 @@ impl GitHostProvider for GitHubProvider {
     ) -> Result<HashMap<String, PullRequestInfo>, GitHostError> {
         let repo_info = self.get_repo_info(remote_url, repo_path).await?;
 
-        let cli = self.gh_cli.clone();
-        let repo_info_clone = repo_info.clone();
         let limit = pr_urls.len().max(30);
         let url_set: std::collections::HashSet<&str> = pr_urls.iter().map(|u| u.as_str()).collect();
 
         let all_prs = (|| async {
-            let cli = cli.clone();
-            let repo_info = repo_info_clone.clone();
+            let cli = self.gh_cli.clone();
+            let repo_info = repo_info.clone();
 
             let prs = task::spawn_blocking(move || cli.list_prs_for_repo(&repo_info, limit))
                 .await

--- a/crates/services/src/services/git_host/github/mod.rs
+++ b/crates/services/src/services/git_host/github/mod.rs
@@ -125,7 +125,6 @@ impl GitHubProvider {
         })
         .await
     }
-
 }
 
 impl From<GhCliError> for GitHostError {
@@ -401,8 +400,7 @@ impl GitHostProvider for GitHubProvider {
         let cli = self.gh_cli.clone();
         let repo_info_clone = repo_info.clone();
         let limit = pr_urls.len().max(30);
-        let url_set: std::collections::HashSet<&str> =
-            pr_urls.iter().map(|u| u.as_str()).collect();
+        let url_set: std::collections::HashSet<&str> = pr_urls.iter().map(|u| u.as_str()).collect();
 
         let all_prs = (|| async {
             let cli = cli.clone();

--- a/crates/services/src/services/git_host/mod.rs
+++ b/crates/services/src/services/git_host/mod.rs
@@ -4,7 +4,7 @@ mod types;
 pub mod azure;
 pub mod github;
 
-use std::path::Path;
+use std::{collections::HashMap, path::Path};
 
 use async_trait::async_trait;
 use db::models::merge::PullRequestInfo;
@@ -48,6 +48,15 @@ pub trait GitHostProvider: Send + Sync {
         repo_path: &Path,
         remote_url: &str,
     ) -> Result<Vec<OpenPrInfo>, GitHostError>;
+
+    /// Bulk-fetch PR statuses for multiple PRs.
+    /// Returns a map from PR URL to PullRequestInfo.
+    async fn get_pr_statuses(
+        &self,
+        repo_path: &Path,
+        remote_url: &str,
+        pr_urls: &[String],
+    ) -> Result<HashMap<String, PullRequestInfo>, GitHostError>;
 
     fn provider_kind(&self) -> ProviderKind;
 }

--- a/crates/services/src/services/pr_monitor.rs
+++ b/crates/services/src/services/pr_monitor.rs
@@ -133,11 +133,7 @@ impl<C: ContainerService + Send + Sync + 'static> PrMonitorService<C> {
     }
 
     /// Bulk-fetch PR statuses for multiple PRs in a single repo.
-    async fn bulk_check_prs(
-        &self,
-        repo_id: Uuid,
-        prs: &[&PrMerge],
-    ) -> Result<(), PrMonitorError> {
+    async fn bulk_check_prs(&self, repo_id: Uuid, prs: &[&PrMerge]) -> Result<(), PrMonitorError> {
         let repo = Repo::find_by_id(&self.db.pool, repo_id)
             .await?
             .ok_or_else(|| {
@@ -240,8 +236,7 @@ impl<C: ContainerService + Send + Sync + 'static> PrMonitorService<C> {
 
                 // Track analytics event
                 if let Some(analytics) = &self.analytics
-                    && let Ok(Some(task)) =
-                        Task::find_by_id(&self.db.pool, workspace.task_id).await
+                    && let Ok(Some(task)) = Task::find_by_id(&self.db.pool, workspace.task_id).await
                 {
                     analytics.analytics_service.track_event(
                         &analytics.user_id,


### PR DESCRIPTION
## Summary

The PR monitor polls every 60s and previously made one `gh pr view` subprocess call per open PR (N calls for N PRs). This can hit GitHub rate limits when many PRs are open across workspaces.

This PR reduces API calls by:
- **Grouping open PRs by `repo_id`** and bulk-fetching statuses with a single `gh pr list --repo` call per group
- **Single-PR groups skip bulk path** (1 call individually vs 2 for bulk), so there's no regression for the common case
- **Falling back to individual checks** if bulk fetch fails for a group

### Implementation details

- Added `get_pr_statuses` to the `GitHostProvider` trait (via `enum_dispatch`), keeping the git host abstraction intact — the PR monitor never directly instantiates a provider
- **GitHub**: resolves repo info via `gh repo view`, then fetches all recent PRs with `gh pr list --repo owner/repo --state all`, filtering to the requested PR URLs. Cost: 2 calls per repo group instead of N
- **Azure DevOps**: falls back to individual `get_pr_status` calls per PR (no bulk API available)
- Extracted `handle_pr_status_update()` from `check_pr_status()` to share DB update / remote sync / archive logic between individual and bulk paths
- Uses `resolve_remote_for_branch` (same pattern as PR creation in `task_attempts/pr.rs`) to resolve the correct git remote for the target branch

- [x] tested

This PR was written using [Vibe Kanban](https://vibekanban.com)