### PR TITLE
Prevent new-project status race by waiting for create persistence (Vibe Kanban)

### DIFF
--- a/frontend/src/components/dialogs/org/CreateRemoteProjectDialog.tsx
+++ b/frontend/src/components/dialogs/org/CreateRemoteProjectDialog.tsx
@@ -77,7 +77,7 @@ const CreateRemoteProjectDialogImpl =
       return null;
     };
 
-    const handleCreate = () => {
+    const handleCreate = async () => {
       const nameError = validateName(name);
       if (nameError) {
         setError(nameError);
@@ -88,15 +88,17 @@ const CreateRemoteProjectDialogImpl =
       setIsCreating(true);
 
       try {
-        const { data: project } = insert({
+        const { data: project, persisted } = insert({
           organization_id: organizationId,
           name: name.trim(),
           color: color,
         });
 
+        const persistedProject = await persisted;
+
         modal.resolve({
           action: 'created',
-          project,
+          project: persistedProject ?? project,
         } as CreateRemoteProjectResult);
         modal.hide();
       } catch (err) {
@@ -113,6 +115,8 @@ const CreateRemoteProjectDialogImpl =
     };
 
     const handleOpenChange = (open: boolean) => {
+      if (isCreating) return;
+
       if (!open) {
         handleCancel();
       }
@@ -121,7 +125,7 @@ const CreateRemoteProjectDialogImpl =
     const handleKeyDown = (e: React.KeyboardEvent) => {
       if (e.key === 'Enter' && name.trim() && !isCreating) {
         e.preventDefault();
-        handleCreate();
+        void handleCreate();
       }
     };
 


### PR DESCRIPTION
## What changes were made
- Updated the project creation flow in `frontend/src/components/dialogs/org/CreateRemoteProjectDialog.tsx` so `handleCreate` is asynchronous and waits for the mutation persistence promise before resolving success.
- Switched the dialog result to use the persisted project payload (with optimistic data as a fallback).
- Added a guard in `handleOpenChange` to ignore close/cancel actions while creation is in progress.
- Updated Enter-key submit handling to call the async create handler safely.

## Why these changes were made
- Creating a project from the App Bar navigated immediately on optimistic insert.
- In some cases, the project existed before its default statuses were fully available to the kanban subscription, so the new project opened with the misleading empty-state message: "All statuses are hidden...".
- Waiting for persistence before navigation removes this race and ensures the initial project data (including statuses) is ready when the kanban screen loads.

## Important implementation details
- The fix is intentionally scoped to a single frontend file for readability and minimal surface area.
- No API contract, migration, or backend behavior changes were required.
- The UX still disables inputs during creation, but now avoids cancel/resolve races while the request is in flight.

This PR was written using [Vibe Kanban](https://vibekanban.com)
