### PR TITLE
Auto-assign workspace creator to issue when workspace is linked (Vibe Kanban)

### DIFF
--- a/crates/remote/src/routes/workspaces.rs
+++ b/crates/remote/src/routes/workspaces.rs
@@ -80,11 +80,12 @@ async fn create_workspace(
 
     if let Some(issue_id) = payload.issue_id {
         if let Err(error) =
-            IssueRepository::sync_status_from_workspace_created(state.pool(), issue_id).await
+            IssueRepository::sync_issue_from_workspace_created(state.pool(), issue_id, ctx.user.id)
+                .await
         {
             tracing::warn!(
                 ?error,
-                "failed to sync issue status from workspace creation"
+                "failed to sync issue from workspace creation"
             );
         }
 


### PR DESCRIPTION
## Summary

When a workspace is linked to an issue, the creator of that workspace is now automatically added as an assignee to the issue — but only if the issue doesn't already have any assignees.

## Changes

- Renamed `sync_status_from_workspace_created` → `sync_issue_from_workspace_created` to reflect its broader responsibility
- Extended the method to also handle assignee auto-assignment alongside the existing status sync
- Added `user_id` parameter to pass the workspace creator's identity
- The status sync (move to "In progress" on first workspace) is preserved with identical behavior
- The assignee sync runs independently: it checks if the issue has zero assignees and, if so, creates one for the workspace creator

## Implementation details

- The existing early-return control flow was restructured into nested `if let` blocks so that the status sync short-circuit (`workspace_count != 1`) doesn't skip the assignee logic — both concerns run independently
- The DB `UNIQUE(issue_id, user_id)` constraint on `issue_assignees` prevents duplicate assignments even under race conditions
- Errors are logged as warnings and never fail the workspace creation request, matching the existing pattern
- No migration needed — the `issue_assignees` table already exists
- No frontend changes — Electric sync automatically pushes the new assignee to the UI

## Files changed

- `crates/remote/src/db/issues.rs` — Extended sync method with assignee logic, added `IssueAssigneeRepository` import and error variant
- `crates/remote/src/routes/workspaces.rs` — Updated call site to use new method name and pass `ctx.user.id`

---

This PR was written using [Vibe Kanban](https://vibekanban.com)