### PR TITLE
Add UUID compatibility fallback for runtimes without crypto.randomUUID (Vibe Kanban)

### DIFF
--- a/frontend/src/components/ui-new/containers/KanbanDisplaySettingsContainer.tsx
+++ b/frontend/src/components/ui-new/containers/KanbanDisplaySettingsContainer.tsx
@@ -19,6 +19,7 @@ import {
   SlidersHorizontalIcon,
 } from '@phosphor-icons/react';
 import { cn } from '@/lib/utils';
+import { generateUuid } from '@/lib/uuid';
 import { getRandomPresetColor, PRESET_COLORS } from '@/lib/colors';
 import { bulkUpdateProjectStatuses } from '@/lib/remoteApi';
 import {
@@ -399,7 +400,7 @@ export function KanbanDisplaySettingsContainer({
   }, []);
 
   const handleAddColumn = useCallback(() => {
-    const newId = crypto.randomUUID();
+    const newId = generateUuid();
     const maxSortOrder = localStatuses.reduce(
       (max, s) => Math.max(max, s.sort_order),
       0

--- a/frontend/src/components/ui-new/dialogs/settings/RemoteProjectsSettingsSection.tsx
+++ b/frontend/src/components/ui-new/dialogs/settings/RemoteProjectsSettingsSection.tsx
@@ -41,6 +41,7 @@ import { CreateRemoteProjectDialog } from '@/components/dialogs/org/CreateRemote
 import { DeleteRemoteProjectDialog } from '@/components/dialogs/org/DeleteRemoteProjectDialog';
 import { useShape } from '@/lib/electric/hooks';
 import { bulkUpdateProjectStatuses } from '@/lib/remoteApi';
+import { generateUuid } from '@/lib/uuid';
 import {
   PROJECTS_SHAPE,
   PROJECT_MUTATION,
@@ -521,7 +522,7 @@ export function RemoteProjectsSettingsSection({
   }, []);
 
   const handleStatusAdd = useCallback(() => {
-    const newId = crypto.randomUUID();
+    const newId = generateUuid();
     const maxSortOrder = localStatuses.reduce(
       (max, status) => Math.max(max, status.sort_order),
       0

--- a/frontend/src/hooks/useProjectWorkspaceCreateDraft.ts
+++ b/frontend/src/hooks/useProjectWorkspaceCreateDraft.ts
@@ -2,6 +2,7 @@ import { useCallback } from 'react';
 import { ScratchType, type DraftWorkspaceData } from 'shared/types';
 import { useKanbanNavigation } from '@/hooks/useKanbanNavigation';
 import { scratchApi } from '@/lib/api';
+import { generateUuid } from '@/lib/uuid';
 import type { CreateModeInitialState } from '@/hooks/useCreateModeState';
 
 export function useProjectWorkspaceCreateDraft() {
@@ -14,7 +15,7 @@ export function useProjectWorkspaceCreateDraft() {
     ): Promise<string | null> => {
       if (!projectId) return null;
 
-      const draftId = crypto.randomUUID();
+      const draftId = generateUuid();
 
       const draftData: DraftWorkspaceData = {
         message: initialState.initialPrompt ?? '',

--- a/frontend/src/lib/electric/hooks.ts
+++ b/frontend/src/lib/electric/hooks.ts
@@ -2,6 +2,7 @@ import { useState, useMemo, useCallback, useEffect, useRef } from 'react';
 import { useLiveQuery } from '@tanstack/react-db';
 import { createShapeCollection } from './collections';
 import { useSyncErrorContext } from '@/contexts/SyncErrorContext';
+import { generateUuid } from '@/lib/uuid';
 import type { MutationDefinition, ShapeDefinition } from 'shared/remote-types';
 import type { SyncError } from './types';
 
@@ -189,7 +190,7 @@ export function useShape<
   const insert = useCallback(
     (insertData: unknown): InsertResult<T> => {
       const dataWithId = {
-        id: crypto.randomUUID(),
+        id: generateUuid(),
         ...(insertData as Record<string, unknown>),
       };
       if (!typedCollection) {

--- a/frontend/src/lib/uuid.ts
+++ b/frontend/src/lib/uuid.ts
@@ -1,0 +1,34 @@
+function fillBytesWithMathRandom(bytes: Uint8Array): void {
+  for (let i = 0; i < bytes.length; i += 1) {
+    bytes[i] = Math.floor(Math.random() * 256);
+  }
+}
+
+function formatUuid(bytes: Uint8Array): string {
+  const hex = Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0'));
+  return [
+    hex.slice(0, 4).join(''),
+    hex.slice(4, 6).join(''),
+    hex.slice(6, 8).join(''),
+    hex.slice(8, 10).join(''),
+    hex.slice(10, 16).join(''),
+  ].join('-');
+}
+
+export function generateUuid(): string {
+  if (globalThis.crypto?.randomUUID) {
+    return globalThis.crypto.randomUUID();
+  }
+
+  const bytes = new Uint8Array(16);
+  if (globalThis.crypto?.getRandomValues) {
+    globalThis.crypto.getRandomValues(bytes);
+  } else {
+    fillBytesWithMathRandom(bytes);
+  }
+
+  // Force RFC 4122 v4 version and variant bits.
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  return formatUuid(bytes);
+}


### PR DESCRIPTION
## Summary
This PR fixes runtime failures where `crypto.randomUUID` is unavailable by centralizing UUID creation behind a compatibility helper and replacing direct calls in the frontend.

## What changed
- Added `generateUuid()` in `frontend/src/lib/uuid.ts`.
- `generateUuid()` now uses this order:
  - `globalThis.crypto.randomUUID()` when available
  - `globalThis.crypto.getRandomValues()` + RFC4122 v4 formatting when `randomUUID` is missing
  - `Math.random()` byte fill as a final fallback when Web Crypto is unavailable
- Replaced direct `crypto.randomUUID()` usage with `generateUuid()` in:
  - `frontend/src/lib/electric/hooks.ts`
  - `frontend/src/hooks/useProjectWorkspaceCreateDraft.ts`
  - `frontend/src/components/ui-new/containers/KanbanDisplaySettingsContainer.tsx`
  - `frontend/src/components/ui-new/dialogs/settings/RemoteProjectsSettingsSection.tsx`

## Why
The task context reported `crypto.randomUUID` being undefined in some environments. Direct usage caused ID generation to fail in affected runtimes, which can block optimistic inserts, draft creation, and status creation flows. Centralizing UUID generation prevents these runtime errors while keeping UUID behavior consistent.

## Implementation details
- The helper preserves native behavior where supported and only falls back when needed.
- Fallback-generated UUIDs set RFC4122 v4 version and variant bits to keep output format/semantics aligned.
- All remaining UUID call sites now go through the helper so this compatibility logic is maintained in one place.

This PR was written using [Vibe Kanban](https://vibekanban.com)
