### PR TITLE
Delete old binary versions from cache on startup (Vibe Kanban)

### DIFF
--- a/npx-cli/bin/cli.js
+++ b/npx-cli/bin/cli.js
@@ -126,11 +126,6 @@ async function extractAndRun(baseName, launch) {
     }
   }
 
-  // Clean up old cached versions only after current version is secured
-  if (!LOCAL_DEV_MODE) {
-    cleanOldVersions();
-  }
-
   // Extract
   if (!fs.existsSync(binPath)) {
     try {
@@ -149,6 +144,11 @@ async function extractAndRun(baseName, launch) {
     console.error(`Extracted binary not found at: ${binPath}`);
     console.error("This usually indicates a corrupt download. Please try again.");
     process.exit(1);
+  }
+
+  // Clean up old cached versions only after current version is fully ready
+  if (!LOCAL_DEV_MODE) {
+    cleanOldVersions();
   }
 
   // Set permissions (non-Windows)


### PR DESCRIPTION
## Summary

The `npx-cli` package downloads new binary versions into `~/.vibe-kanban/bin/{version}/` but never removes old versions when updating. Over time, this causes unbounded disk usage as each release accumulates a new directory of binaries (ZIPs + extracted executables).

## Changes

- Added a `cleanOldVersions()` function to `npx-cli/bin/cli.js` that scans the binary cache directory (`~/.vibe-kanban/bin/`) and removes any version directories that don't match the current `BINARY_TAG`
- Cleanup runs inside `extractAndRun()` only after the current version's binary has been **fully downloaded, extracted, and verified on disk** — ensuring no failure path leaves the user without a working binary
- Skipped in local dev mode since local builds don't use the versioned cache structure
- Errors during cleanup are silently ignored — it's best-effort and non-critical

## Failure safety

Old versions are preserved if any of these steps fail:
- Download fails → `process.exit(1)` before cleanup
- Extraction fails (e.g. corrupt zip) → `process.exit(1)` before cleanup
- Extracted binary not found → `process.exit(1)` before cleanup

Cleanup only runs once the binary is confirmed ready to launch.

---

This PR was written using [Vibe Kanban](https://vibekanban.com)