### PR TITLE
Truncate task titles to 255 chars during cloud migration (Vibe Kanban)

### DIFF
--- a/crates/services/src/services/migration/mod.rs
+++ b/crates/services/src/services/migration/mod.rs
@@ -264,7 +264,7 @@ impl MigrationService {
                     requests.push(MigrateIssueRequest {
                         project_id,
                         status_name: map_task_status(&task.status),
-                        title: task.title.clone(),
+                        title: task.title.chars().take(255).collect(),
                         description: task.description.clone(),
                         created_at: task.created_at,
                     });


### PR DESCRIPTION
## Summary

When migrating local tasks to the remote cloud, task titles that exceed 255 characters cause a Postgres error (`value too long for type character varying(255)`). The local SQLite database has no such constraint, so titles can be arbitrarily long — particularly agent-generated ones.

## Changes

- Truncate task titles to 255 characters in `migrate_task_batch` before sending them to the remote API
- Uses `chars().take(255)` to ensure correct handling of multi-byte UTF-8 characters

**File:** `crates/services/src/services/migration/mod.rs`

## Why

Users were hitting repeated 500 errors during migration:
```
http 500: {"error":"error returned from database: value too long for type character varying(255)"}
```

This blocked migration entirely for any project containing tasks with long titles.

- [x] tested

---
This PR was written using [Vibe Kanban](https://vibekanban.com)