### PR TITLE
Fix PostHog analytics identity to link local and remote events (Vibe Kanban)

### DIFF
--- a/crates/server/src/routes/oauth.rs
+++ b/crates/server/src/routes/oauth.rs
@@ -201,6 +201,17 @@ async fn handoff_complete(
                 "email": profile.email,
             })),
         );
+
+        // Merge the local machine-based ID with the remote user UUID so all
+        // events (local frontend, local backend, remote backend) resolve to
+        // the same PostHog person.
+        analytics.track_event(
+            &profile.user_id.to_string(),
+            "$create_alias",
+            Some(serde_json::json!({
+                "alias": deployment.user_id(),
+            })),
+        );
     }
 
     Ok(close_window_response(format!(


### PR DESCRIPTION
## Summary

- After OAuth login on the local backend, sends a PostHog `$create_alias` event to merge the local machine-based analytics ID (`npm_user_xxx`) with the remote user UUID

## Why

Users had `issue_created` (from the remote backend) and `remote_onboarding_ui_stage_completed` (from the local frontend) on separate PostHog persons, despite being the same user with the same email. This happened because:

- The local frontend/backend used a machine-based hash (`npm_user_xxx`) as `distinct_id`
- The remote backend used the user's UUID as `distinct_id`
- PostHog doesn't auto-merge persons by email — it requires an explicit alias

## Implementation

Added a single `$create_alias` call in `crates/server/src/routes/oauth.rs` after the existing `$identify` call. On login, this tells PostHog that `npm_user_xxx` and the remote UUID are the same person, merging all past and future events from both IDs.

- [x] tested

This PR was written using [Vibe Kanban](https://vibekanban.com)