### PR TITLE
fix(db): use SQLite WAL journal mode to reduce database lock errors

### DIFF
--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -80,7 +80,7 @@ impl DBService {
         );
         let options = SqliteConnectOptions::from_str(&database_url)?
             .create_if_missing(true)
-            .journal_mode(SqliteJournalMode::Delete);
+            .journal_mode(SqliteJournalMode::Wal);
         let pool = SqlitePool::connect_with(options).await?;
         run_migrations(&pool).await?;
         Ok(DBService { pool })
@@ -116,7 +116,7 @@ impl DBService {
         );
         let options = SqliteConnectOptions::from_str(&database_url)?
             .create_if_missing(true)
-            .journal_mode(SqliteJournalMode::Delete);
+            .journal_mode(SqliteJournalMode::Wal);
 
         let pool = if let Some(hook) = after_connect {
             SqlitePoolOptions::new()


### PR DESCRIPTION
## Summary
Switch SQLite journal mode from Delete to Wal for the local DB connection options in DBService.

## Why
This lock error was observed in release version v0.1.10:
2026-02-11T14:47:10.582775Z ERROR server::middleware::model_loaders: Failed to fetch Workspace 30bf6c45-e157-44f0-834f-72100db05b0b: error returned from database: (code: 5) database is locked

Delete journal mode is more prone to writer/reader blocking. WAL mode improves concurrency by allowing readers to continue while writes are appended to the WAL file.

## Changes
- crates/db/src/lib.rs
- DBService::new: SqliteJournalMode::Delete -> SqliteJournalMode::Wal
- DBService::create_pool: SqliteJournalMode::Delete -> SqliteJournalMode::Wal

## Validation
- Manual code inspection confirms both SQLite connection paths now use WAL.
- Did not run full build/tests in this environment.