### PR TITLE
Fix PostHog identity merge by switching to $merge_dangerously (Vibe Kanban)

### DIFF
--- a/crates/server/src/routes/oauth.rs
+++ b/crates/server/src/routes/oauth.rs
@@ -204,10 +204,12 @@ async fn handoff_complete(
 
         // Merge the local machine-based ID with the remote user UUID so all
         // events (local frontend, local backend, remote backend) resolve to
-        // the same PostHog person.
+        // the same PostHog person. Uses $merge_dangerously because
+        // $create_alias is blocked by PostHog's safeguard when the machine
+        // ID was already used as a distinct_id in a prior identify call.
         analytics.track_event(
             &profile.user_id.to_string(),
-            "$create_alias",
+            "$merge_dangerously",
             Some(serde_json::json!({
                 "alias": deployment.user_id(),
             })),


### PR DESCRIPTION
## Summary

After OAuth login, we send a PostHog event to merge the local machine-based distinct ID (`npm_user_xxx`) with the remote user UUID so that all events across the local frontend, local backend, and remote backend resolve to the same PostHog person.

The previous implementation used `$create_alias` for this merge. However, PostHog's safeguard blocks `$create_alias` when the machine ID has already been used as a `distinct_id` in a prior `$identify` call — which is always the case in our flow since we call `$identify` immediately before the alias.

This PR switches from `$create_alias` to `$merge_dangerously`, which bypasses that safeguard and correctly links the two identities.

## Changes

- `crates/server/src/routes/oauth.rs`: Replace `$create_alias` with `$merge_dangerously` in the post-login analytics event
- Updated the inline comment to explain why `$merge_dangerously` is necessary

## Test plan

- [x] tested

---

This PR was written using [Vibe Kanban](https://vibekanban.com)