### PR TITLE
Make docker-compose URLs and port binding configurable for self-hosting

### DIFF
--- a/crates/remote/docker-compose.yml
+++ b/crates/remote/docker-compose.yml
@@ -1,3 +1,5 @@
+# Self-hosting: set PUBLIC_BASE_URL to your public URL (e.g. https://kanban.example.com)
+# and REMOTE_SERVER_PORTS=0.0.0.0:3000:8081 so the server is reachable from other hosts.
 services:
   remote-db:
     image: postgres:16-alpine
@@ -65,9 +67,9 @@ services:
       VIBEKANBAN_REMOTE_JWT_SECRET: ${VIBEKANBAN_REMOTE_JWT_SECRET:?set in .env.remote}
       # Optional — leave empty to disable invitation emails
       LOOPS_EMAIL_API_KEY: ${LOOPS_EMAIL_API_KEY:-}
-      SERVER_PUBLIC_BASE_URL: http://localhost:3000
-      VITE_APP_BASE_URL: http://localhost:3000
-      VITE_API_BASE_URL: http://localhost:3000
+      SERVER_PUBLIC_BASE_URL: ${PUBLIC_BASE_URL:-http://localhost:3000}
+      VITE_APP_BASE_URL: ${PUBLIC_BASE_URL:-http://localhost:3000}
+      VITE_API_BASE_URL: ${PUBLIC_BASE_URL:-http://localhost:3000}
       ELECTRIC_ROLE_PASSWORD: ${ELECTRIC_ROLE_PASSWORD:-remote}
       R2_ACCESS_KEY_ID: ${R2_ACCESS_KEY_ID:-}
       R2_SECRET_ACCESS_KEY: ${R2_SECRET_ACCESS_KEY:-}
@@ -85,7 +87,7 @@ services:
       STRIPE_FREE_SEAT_LIMIT: ${STRIPE_FREE_SEAT_LIMIT:-1}
 
     ports:
-      - "127.0.0.1:3000:8081"
+      - "${REMOTE_SERVER_PORTS:-127.0.0.1:3000:8081}"
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "wget", "--spider", "-q", "http://127.0.0.1:8081/health"]

--- a/docs/self-hosting/local-development.mdx
+++ b/docs/self-hosting/local-development.mdx
@@ -83,6 +83,8 @@ GOOGLE_OAUTH_CLIENT_SECRET=
 LOOPS_EMAIL_API_KEY=
 ```
 
+For production or self-hosting on a server, add `PUBLIC_BASE_URL` (your public URL, e.g. `https://kanban.example.com`) and `REMOTE_SERVER_PORTS=0.0.0.0:3000:8081` so the server is reachable from other hosts. Defaults keep local dev unchanged.
+
 <Warning>
 Never commit `.env.remote` to version control. It's already in `.gitignore`.
 </Warning>


### PR DESCRIPTION
## Summary
Makes docker-compose base URL and remote-server port binding configurable so self-hosters can use their public URL and bind to `0.0.0.0` for external access.

Closes #2702

## Changes

### 1. Base URL
- **`PUBLIC_BASE_URL`** (default: `http://localhost:3000`) is used for:
  - `SERVER_PUBLIC_BASE_URL`
  - `VITE_APP_BASE_URL`
  - `VITE_API_BASE_URL`

### 2. Port binding
- **`REMOTE_SERVER_PORTS`** (default: `127.0.0.1:3000:8081`) makes the remote-server port mapping configurable.
- Self-hosters can set `REMOTE_SERVER_PORTS=0.0.0.0:3000:8081` (and `PUBLIC_BASE_URL` to their public URL) for production.

### 3. Documentation
- Short comment at the top of `crates/remote/docker-compose.yml` describing the two variables for self-hosting.
- Note in `docs/self-hosting/local-development.mdx` (Step 3) for production/self-hosting.

Local dev behavior is unchanged: defaults preserve current values.