### PR TITLE
Add no-SSH Docker build path for remote-server

### DIFF
--- a/crates/remote/Dockerfile
+++ b/crates/remote/Dockerfile
@@ -61,6 +61,43 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     cargo build ${FEATURES:+--locked} --release --manifest-path crates/remote/Cargo.toml ${FEATURES:+--features ${FEATURES}} \
  && cp crates/remote/target/release/${APP_NAME} /app/bin/${APP_NAME}
 
+FROM rust:1.93-slim-bookworm AS builder-no-ssh
+ARG APP_NAME
+ARG FEATURES
+ARG POSTHOG_API_KEY=""
+ARG POSTHOG_API_ENDPOINT=""
+
+ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
+ENV POSTHOG_API_KEY=${POSTHOG_API_KEY}
+ENV POSTHOG_API_ENDPOINT=${POSTHOG_API_ENDPOINT}
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends pkg-config libssl-dev ca-certificates git openssh-client \
+  && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY rust-toolchain.toml ./
+COPY Cargo.toml Cargo.lock ./
+COPY crates crates
+COPY shared shared
+COPY assets assets
+
+RUN mkdir -p /app/bin
+
+RUN if [ -z "${FEATURES}" ]; then \
+      sed -i '/^billing = {.*vibe-kanban-private.*/d' crates/remote/Cargo.toml; \
+      sed -i '/^# private crate for billing/d' crates/remote/Cargo.toml; \
+      sed -i '/^vk-billing = \["dep:billing"\]/d' crates/remote/Cargo.toml; \
+      rm -f crates/remote/Cargo.lock; \
+    fi
+
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/app/target \
+    cargo build ${FEATURES:+--locked} --release --manifest-path crates/remote/Cargo.toml ${FEATURES:+--features ${FEATURES}} \
+ && cp crates/remote/target/release/${APP_NAME} /app/bin/${APP_NAME}
+
 FROM debian:bookworm-slim AS runtime
 ARG APP_NAME
 
@@ -72,6 +109,31 @@ RUN apt-get update \
 WORKDIR /srv
 
 COPY --from=builder /app/bin/${APP_NAME} /usr/local/bin/${APP_NAME}
+COPY --from=fe-builder /repo/remote-frontend/dist /srv/static
+
+USER appuser
+
+ENV SERVER_LISTEN_ADDR=0.0.0.0:8081 \
+    RUST_LOG=info
+
+EXPOSE 8081
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD ["wget","--spider","-q","http://127.0.0.1:8081/health"]
+
+ENTRYPOINT ["/usr/local/bin/remote"]
+
+FROM debian:bookworm-slim AS runtime-no-ssh
+ARG APP_NAME
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends ca-certificates libssl3 wget git \
+  && rm -rf /var/lib/apt/lists/* \
+  && useradd --system --create-home --uid 10001 appuser
+
+WORKDIR /srv
+
+COPY --from=builder-no-ssh /app/bin/${APP_NAME} /usr/local/bin/${APP_NAME}
 COPY --from=fe-builder /repo/remote-frontend/dist /srv/static
 
 USER appuser

--- a/crates/remote/docker-compose.yml
+++ b/crates/remote/docker-compose.yml
@@ -44,12 +44,11 @@ services:
     build:
       context: ../..
       dockerfile: crates/remote/Dockerfile
+      target: ${REMOTE_SERVER_BUILD_TARGET:-runtime-no-ssh}
       args:
         FEATURES: ${FEATURES:-}
         POSTHOG_API_KEY: ${POSTHOG_API_KEY:-}
         POSTHOG_API_ENDPOINT: ${POSTHOG_API_ENDPOINT:-}
-      ssh:
-        - default
     depends_on:
       remote-db:
         condition: service_healthy

--- a/crates/remote/docker-compose.yml
+++ b/crates/remote/docker-compose.yml
@@ -55,7 +55,7 @@ services:
     environment:
       RUST_LOG: info,remote=info
 
-      SERVER_DATABASE_URL: postgres://remote:remote@remote-db:5432/remote
+      SERVER_DATABASE_URL: ${SERVER_DATABASE_URL:-postgres://remote:remote@remote-db:5432/remote}
       SERVER_LISTEN_ADDR: 0.0.0.0:8081
       ELECTRIC_URL: http://electric:3000
       # OAuth — configure at least one provider (GitHub or Google)


### PR DESCRIPTION
## Summary

Makes the remote-server Docker image buildable without an SSH agent so it works on Dokploy and other environments where `SSH_AUTH_SOCK` is not set.

## What changed

### Dockerfile (`crates/remote/Dockerfile`)

- **`builder-no-ssh`** — New stage with the same setup as `builder` (Rust base, build deps, WORKDIR, COPY of crates/shared/assets, and the RUN that strips the private billing dependency from `Cargo.toml` when `FEATURES` is empty). The final RUN runs the same `cargo build` and `cp`, but **without** `--mount=type=ssh`; only the cache mounts (registry, git, target) are used.
- **`runtime-no-ssh`** — New runtime stage with the same structure as `runtime` (Debian base, ca-certificates, wget, git, appuser, HEALTHCHECK, ENTRYPOINT), but it copies the binary from `builder-no-ssh` and static files from `fe-builder`.

The existing `builder` and `runtime` stages are unchanged so builds that need the private billing crate can still use them with SSH.

### Docker Compose (`crates/remote/docker-compose.yml`)

- **`target: ${REMOTE_SERVER_BUILD_TARGET:-runtime-no-ssh}`** — Default build target is now `runtime-no-ssh`, so `docker compose build` does not require an SSH agent.
- **Removed `ssh: - default`** — The default build no longer forwards the host SSH agent into the build.

## Why

The original Dockerfile used `--mount=type=ssh` so Cargo could clone the private billing crate during the build. That requires an SSH agent (e.g. `ssh-agent` with keys, or Docker BuildKit SSH forwarding). On platforms like Dokploy or in CI where no SSH agent is configured, the build fails. By adding a parallel no-SSH path and making it the default, the image builds out of the box in those environments. When `FEATURES` is empty, the billing dep is already stripped in both builder stages, so the no-SSH builder never needs to access private git.

## Usage

- **Default (no SSH):** `docker compose build` builds the `runtime-no-ssh` image. Use this for self-hosted / Dokploy / environments without SSH.
- **With billing (SSH):** Set `REMOTE_SERVER_BUILD_TARGET=runtime` and build with SSH (e.g. `docker compose build --ssh default`) when you need the private billing dependency.
