### PR TITLE
Use runtime VK_SHARED_API_BASE for frontend remote and shape requests (Vibe Kanban)

### DIFF
--- a/crates/deployment/src/lib.rs
+++ b/crates/deployment/src/lib.rs
@@ -114,6 +114,10 @@ pub trait Deployment: Clone + Send + Sync + 'static {
         Err(RemoteClientNotConfigured)
     }
 
+    fn shared_api_base(&self) -> Option<String> {
+        None
+    }
+
     async fn update_sentry_scope(&self) -> Result<(), DeploymentError> {
         let user_id = self.user_id();
         let config = self.config().read().await;

--- a/crates/local-deployment/src/lib.rs
+++ b/crates/local-deployment/src/lib.rs
@@ -54,6 +54,7 @@ pub struct LocalDeployment {
     approvals: Approvals,
     queued_message_service: QueuedMessageService,
     remote_client: Result<RemoteClient, RemoteClientNotConfigured>,
+    shared_api_base: Option<String>,
     auth_context: AuthContext,
     oauth_handoffs: Arc<RwLock<HashMap<Uuid, PendingHandoff>>>,
     pty: PtyService,
@@ -146,8 +147,8 @@ impl Deployment for LocalDeployment {
             .ok()
             .or_else(|| option_env!("VK_SHARED_API_BASE").map(|s| s.to_string()));
 
-        let remote_client = match api_base {
-            Some(url) => match RemoteClient::new(&url, auth_context.clone()) {
+        let remote_client = match &api_base {
+            Some(url) => match RemoteClient::new(url, auth_context.clone()) {
                 Ok(client) => {
                     tracing::info!("Remote client initialized with URL: {}", url);
                     Ok(client)
@@ -216,6 +217,7 @@ impl Deployment for LocalDeployment {
             approvals,
             queued_message_service,
             remote_client,
+            shared_api_base: api_base,
             auth_context,
             oauth_handoffs,
             pty,
@@ -282,6 +284,10 @@ impl Deployment for LocalDeployment {
 
     fn auth_context(&self) -> &AuthContext {
         &self.auth_context
+    }
+
+    fn shared_api_base(&self) -> Option<String> {
+        self.shared_api_base.clone()
     }
 }
 

--- a/crates/server/src/routes/config.rs
+++ b/crates/server/src/routes/config.rs
@@ -37,8 +37,21 @@ use uuid::Uuid;
 
 use crate::{DeploymentImpl, error::ApiError};
 
+#[derive(Debug, Serialize)]
+pub struct RuntimeConfig {
+    pub shared_api_base: String,
+}
+
+async fn get_runtime_config(
+    State(deployment): State<DeploymentImpl>,
+) -> ResponseJson<ApiResponse<RuntimeConfig>> {
+    let shared_api_base = deployment.shared_api_base().unwrap_or_else(String::new);
+    ResponseJson(ApiResponse::success(RuntimeConfig { shared_api_base }))
+}
+
 pub fn router() -> Router<DeploymentImpl> {
     Router::new()
+        .route("/runtime-config", get(get_runtime_config))
         .route("/info", get(get_user_system_info))
         .route("/config", put(update_config))
         .route("/sounds/{sound}", get(get_sound))

--- a/frontend/src/components/dialogs/org/InviteMemberDialog.tsx
+++ b/frontend/src/components/dialogs/org/InviteMemberDialog.tsx
@@ -25,7 +25,7 @@ import { MemberRole } from 'shared/types';
 import { useTranslation } from 'react-i18next';
 import { defineModal } from '@/lib/modals';
 import { ApiError } from '@/lib/api';
-import { REMOTE_API_URL } from '@/lib/remoteApi';
+import { useRemoteApiBase } from '@/hooks/useRemoteApiBase';
 import { ArrowSquareOut } from '@phosphor-icons/react';
 
 export type InviteMemberResult = {
@@ -37,9 +37,9 @@ export interface InviteMemberDialogProps {
 }
 
 const InviteMemberDialogImpl = NiceModal.create<InviteMemberDialogProps>(
-  (props) => {
+  ({ organizationId }) => {
     const modal = useModal();
-    const { organizationId } = props;
+    const remoteApiBase = useRemoteApiBase();
     const { t } = useTranslation('organization');
     const [email, setEmail] = useState('');
     const [role, setRole] = useState<MemberRole>(MemberRole.MEMBER);
@@ -181,7 +181,7 @@ const InviteMemberDialogImpl = NiceModal.create<InviteMemberDialogProps>(
               >
                 <AlertDescription>
                   {error}
-                  {isSubscriptionRequired && REMOTE_API_URL && (
+                  {isSubscriptionRequired && remoteApiBase && (
                     <div className="mt-2">
                       <p className="text-sm text-muted-foreground mb-2">
                         {t('inviteDialog.upgradePrompt')}
@@ -189,7 +189,7 @@ const InviteMemberDialogImpl = NiceModal.create<InviteMemberDialogProps>(
                       <PrimaryButton
                         onClick={() =>
                           window.open(
-                            `${REMOTE_API_URL}/upgrade?org_id=${organizationId}`,
+                            `${remoteApiBase}/upgrade?org_id=${organizationId}`,
                             '_blank'
                           )
                         }

--- a/frontend/src/components/ui-new/dialogs/settings/OrganizationsSettingsSection.tsx
+++ b/frontend/src/components/ui-new/dialogs/settings/OrganizationsSettingsSection.tsx
@@ -28,7 +28,7 @@ import { PendingInvitationItem } from '@/components/org/PendingInvitationItem';
 import type { MemberRole } from 'shared/types';
 import { MemberRole as MemberRoleEnum } from 'shared/types';
 import { cn } from '@/lib/utils';
-import { REMOTE_API_URL } from '@/lib/remoteApi';
+import { useRemoteApiBase } from '@/hooks/useRemoteApiBase';
 import { PrimaryButton } from '../../primitives/PrimaryButton';
 import {
   DropdownMenu,
@@ -43,6 +43,7 @@ export function OrganizationsSettingsSection() {
   const { t } = useTranslation('organization');
   const { loginStatus } = useUserSystem();
   const { isSignedIn, isLoaded } = useAuth();
+  const remoteApiBase = useRemoteApiBase();
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
 
@@ -426,7 +427,7 @@ export function OrganizationsSettingsSection() {
       )}
 
       {/* Billing Link (admin only, non-personal orgs, when remote URL is configured) */}
-      {selectedOrg && isAdmin && !isPersonalOrg && REMOTE_API_URL && (
+      {selectedOrg && isAdmin && !isPersonalOrg && remoteApiBase && (
         <SettingsCard
           title={t('billing.title')}
           description={t('billing.description')}
@@ -434,7 +435,7 @@ export function OrganizationsSettingsSection() {
           <div className="flex items-center justify-between">
             <p className="text-sm text-low">{t('billing.openInBrowser')}</p>
             <a
-              href={`${REMOTE_API_URL}/account/organizations/${selectedOrgId}`}
+              href={`${remoteApiBase}/account/organizations/${selectedOrgId}`}
               target="_blank"
               rel="noopener noreferrer"
               className={cn(

--- a/frontend/src/hooks/useRemoteApiBase.ts
+++ b/frontend/src/hooks/useRemoteApiBase.ts
@@ -1,0 +1,12 @@
+import { useState, useEffect } from 'react';
+import { getRemoteApiBaseUrl } from '@/lib/remoteApi';
+
+export function useRemoteApiBase(): string | null {
+  const [baseUrl, setBaseUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    getRemoteApiBaseUrl().then(setBaseUrl);
+  }, []);
+
+  return baseUrl;
+}

--- a/frontend/src/lib/firstProjectDestination.ts
+++ b/frontend/src/lib/firstProjectDestination.ts
@@ -44,7 +44,7 @@ function getFirstProject(projects: Project[]): Project | null {
 async function getFirstProjectInOrganization(
   organizationId: string
 ): Promise<Project | null> {
-  const collection = createShapeCollection(PROJECTS_SHAPE, {
+  const collection = await createShapeCollection(PROJECTS_SHAPE, {
     organization_id: organizationId,
   });
 


### PR DESCRIPTION
## What changed

When running the desktop app (`npx vibe-kanban`) with `VK_SHARED_API_BASE` set (e.g. for self-hosted Cloud), the backend already used it at runtime, but the frontend still used a build-time value. All frontend-originated requests to the remote API (including Electric `/v1/shape/*` calls) now use the runtime value when it is set.

### Backend

- **Deployment trait** (`crates/deployment/src/lib.rs`): Added `shared_api_base(&self) -> Option<String>` with a default of `None`.
- **LocalDeployment** (`crates/local-deployment/src/lib.rs`): Store `VK_SHARED_API_BASE` from the environment at startup and implement `shared_api_base()` to return it.
- **Runtime config endpoint** (`crates/server/src/routes/config.rs`): New `GET /api/runtime-config` returning `{ shared_api_base: string }` so the frontend can read the runtime value from the same server.

### Frontend

- **remoteApi** (`frontend/src/lib/remoteApi.ts`): Added `getRemoteApiBaseUrl()` that fetches `/api/runtime-config` once, caches the result, and falls back to the build-time `VITE_VK_SHARED_API_BASE` on failure or when the server returns an empty value. `makeRequest` now uses `await getRemoteApiBaseUrl()` for the base URL so all remote API calls (including retries) use the runtime base.
- **Electric collections** (`frontend/src/lib/electric/collections.ts`): `createShapeCollection` is now async; it awaits `getRemoteApiBaseUrl()` and passes the base into `getAuthenticatedShapeOptions`, so shape URLs (e.g. `/v1/shape/workspaces`, `/v1/shape/projects`) use the runtime base.
- **Callers of `createShapeCollection`**: `firstProjectDestination.ts` awaits it; `useShape` (in `electric/hooks.ts`) uses `useState` + `useEffect` to create the collection asynchronously; `useAllOrganizationProjects` runs an async effect that awaits `createShapeCollection` per org and respects a `cancelled` flag on cleanup.
- **Runtime base in UI**: New hook `useRemoteApiBase()` (`frontend/src/hooks/useRemoteApiBase.ts`) that resolves the base URL once. `OrganizationsSettingsSection` and `InviteMemberDialog` use it for the billing and upgrade links so those URLs also reflect the runtime base.

## Why

The shipped npm binary was built with the remote API defaulting to `https://api.vibekanban.com`. For self-hosted Cloud, users set `VK_SHARED_API_BASE` at runtime; the backend already respected it, but the frontend continued to use the build-time default. That caused `/v1/shape/*` (and other remote) requests to go to the wrong host and return 401. Exposing the runtime value via a small backend endpoint and using it everywhere on the frontend ensures one binary works for both default cloud and self-hosted setups.

## Implementation details

- **Single fetch**: The frontend fetches `/api/runtime-config` once; the result is cached and reused by `getRemoteApiBaseUrl()` and thus by `makeRequest` and all shape collections.
- **Fallback**: If the fetch fails or `shared_api_base` is empty, the frontend uses `VITE_VK_SHARED_API_BASE` (build-time), preserving existing behavior when the env is not set.
- **No auth on config**: `/api/runtime-config` does not require authentication so the base URL is available before any remote API calls.
- **Backward compatibility**: `REMOTE_API_URL` is still exported as the build-time default for any remaining synchronous use; UI that needs the runtime base uses `useRemoteApiBase()`.

---

This PR was written using [Vibe Kanban](https://vibekanban.com).