### PR TITLE
Remove all #[ts(export)] annotations across crates (Vibe Kanban)

### DIFF
--- a/crates/api-types/src/issue.rs
+++ b/crates/api-types/src/issue.rs
@@ -18,7 +18,6 @@ pub enum IssuePriority {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
-#[ts(export)]
 pub struct Issue {
     pub id: Uuid,
     pub project_id: Uuid,

--- a/crates/api-types/src/issue_assignee.rs
+++ b/crates/api-types/src/issue_assignee.rs
@@ -6,7 +6,6 @@ use uuid::Uuid;
 use crate::some_if_present;
 
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
-#[ts(export)]
 pub struct IssueAssignee {
     pub id: Uuid,
     pub issue_id: Uuid,

--- a/crates/api-types/src/issue_comment.rs
+++ b/crates/api-types/src/issue_comment.rs
@@ -6,7 +6,6 @@ use uuid::Uuid;
 use crate::some_if_present;
 
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
-#[ts(export)]
 pub struct IssueComment {
     pub id: Uuid,
     pub issue_id: Uuid,

--- a/crates/api-types/src/issue_comment_reaction.rs
+++ b/crates/api-types/src/issue_comment_reaction.rs
@@ -6,7 +6,6 @@ use uuid::Uuid;
 use crate::some_if_present;
 
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
-#[ts(export)]
 pub struct IssueCommentReaction {
     pub id: Uuid,
     pub comment_id: Uuid,

--- a/crates/api-types/src/issue_follower.rs
+++ b/crates/api-types/src/issue_follower.rs
@@ -5,7 +5,6 @@ use uuid::Uuid;
 use crate::some_if_present;
 
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
-#[ts(export)]
 pub struct IssueFollower {
     pub id: Uuid,
     pub issue_id: Uuid,

--- a/crates/api-types/src/issue_relationship.rs
+++ b/crates/api-types/src/issue_relationship.rs
@@ -16,7 +16,6 @@ pub enum IssueRelationshipType {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
-#[ts(export)]
 pub struct IssueRelationship {
     pub id: Uuid,
     pub issue_id: Uuid,

--- a/crates/api-types/src/issue_tag.rs
+++ b/crates/api-types/src/issue_tag.rs
@@ -5,7 +5,6 @@ use uuid::Uuid;
 use crate::some_if_present;
 
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
-#[ts(export)]
 pub struct IssueTag {
     pub id: Uuid,
     pub issue_id: Uuid,

--- a/crates/api-types/src/notification.rs
+++ b/crates/api-types/src/notification.rs
@@ -9,7 +9,6 @@ use crate::some_if_present;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Type, TS)]
 #[sqlx(type_name = "notification_type", rename_all = "snake_case")]
-#[ts(export)]
 pub enum NotificationType {
     IssueCommentAdded,
     IssueStatusChanged,
@@ -18,7 +17,6 @@ pub enum NotificationType {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
-#[ts(export)]
 pub struct Notification {
     pub id: Uuid,
     pub organization_id: Uuid,

--- a/crates/api-types/src/oauth.rs
+++ b/crates/api-types/src/oauth.rs
@@ -3,7 +3,6 @@ use ts_rs::TS;
 use uuid::Uuid;
 
 #[derive(Debug, Serialize, Deserialize, Clone, TS)]
-#[ts(export)]
 pub struct HandoffInitRequest {
     pub provider: String,
     pub return_to: String,
@@ -11,14 +10,12 @@ pub struct HandoffInitRequest {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, TS)]
-#[ts(export)]
 pub struct HandoffInitResponse {
     pub handoff_id: Uuid,
     pub authorize_url: String,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, TS)]
-#[ts(export)]
 pub struct HandoffRedeemRequest {
     pub handoff_id: Uuid,
     pub app_code: String,
@@ -26,20 +23,17 @@ pub struct HandoffRedeemRequest {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, TS)]
-#[ts(export)]
 pub struct HandoffRedeemResponse {
     pub access_token: String,
     pub refresh_token: String,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, TS)]
-#[ts(export)]
 pub struct TokenRefreshRequest {
     pub refresh_token: String,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, TS)]
-#[ts(export)]
 pub struct TokenRefreshResponse {
     pub access_token: String,
     pub refresh_token: String,

--- a/crates/api-types/src/organization_member.rs
+++ b/crates/api-types/src/organization_member.rs
@@ -7,7 +7,6 @@ use uuid::Uuid;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Type, TS)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 #[sqlx(type_name = "member_role", rename_all = "lowercase")]
-#[ts(export)]
 #[ts(use_ts_enum)]
 #[ts(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum MemberRole {
@@ -18,7 +17,6 @@ pub enum MemberRole {
 /// Organization member as stored in the database / streamed via Electric.
 /// This is the full row type with organization_id for shapes.
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
-#[ts(export)]
 pub struct OrganizationMember {
     pub organization_id: Uuid,
     pub user_id: Uuid,

--- a/crates/api-types/src/organizations.rs
+++ b/crates/api-types/src/organizations.rs
@@ -19,7 +19,6 @@ pub enum InvitationStatus {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow, TS)]
-#[ts(export)]
 pub struct Organization {
     pub id: Uuid,
     pub name: String,
@@ -31,7 +30,6 @@ pub struct Organization {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow, TS)]
-#[ts(export)]
 pub struct OrganizationWithRole {
     pub id: Uuid,
     pub name: String,
@@ -44,33 +42,28 @@ pub struct OrganizationWithRole {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
-#[ts(export)]
 pub struct ListOrganizationsResponse {
     pub organizations: Vec<OrganizationWithRole>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
-#[ts(export)]
 pub struct GetOrganizationResponse {
     pub organization: Organization,
     pub user_role: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
-#[ts(export)]
 pub struct CreateOrganizationRequest {
     pub name: String,
     pub slug: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
-#[ts(export)]
 pub struct CreateOrganizationResponse {
     pub organization: OrganizationWithRole,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
-#[ts(export)]
 pub struct UpdateOrganizationRequest {
     pub name: String,
 }
@@ -78,7 +71,6 @@ pub struct UpdateOrganizationRequest {
 // Invitation types
 
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
-#[ts(export)]
 pub struct Invitation {
     pub id: Uuid,
     pub organization_id: Uuid,
@@ -92,26 +84,22 @@ pub struct Invitation {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
-#[ts(export)]
 pub struct CreateInvitationRequest {
     pub email: String,
     pub role: MemberRole,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
-#[ts(export)]
 pub struct CreateInvitationResponse {
     pub invitation: Invitation,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
-#[ts(export)]
 pub struct ListInvitationsResponse {
     pub invitations: Vec<Invitation>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
-#[ts(export)]
 pub struct GetInvitationResponse {
     pub id: Uuid,
     pub organization_slug: String,
@@ -120,7 +108,6 @@ pub struct GetInvitationResponse {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
-#[ts(export)]
 pub struct AcceptInvitationResponse {
     pub organization_id: String,
     pub organization_slug: String,
@@ -137,7 +124,6 @@ pub struct RevokeInvitationRequest {
 /// Organization member info for API responses (without organization_id).
 /// See also `OrganizationMember` in organization_member.rs for the full DB row type.
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
-#[ts(export)]
 pub struct OrganizationMemberInfo {
     pub user_id: Uuid,
     pub role: MemberRole,
@@ -145,7 +131,6 @@ pub struct OrganizationMemberInfo {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
-#[ts(export)]
 pub struct OrganizationMemberWithProfile {
     pub user_id: Uuid,
     pub role: MemberRole,
@@ -158,19 +143,16 @@ pub struct OrganizationMemberWithProfile {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
-#[ts(export)]
 pub struct ListMembersResponse {
     pub members: Vec<OrganizationMemberWithProfile>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
-#[ts(export)]
 pub struct UpdateMemberRoleRequest {
     pub role: MemberRole,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
-#[ts(export)]
 pub struct UpdateMemberRoleResponse {
     pub user_id: Uuid,
     pub role: MemberRole,

--- a/crates/api-types/src/project.rs
+++ b/crates/api-types/src/project.rs
@@ -6,7 +6,6 @@ use uuid::Uuid;
 use crate::some_if_present;
 
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
-#[ts(export)]
 pub struct Project {
     pub id: Uuid,
     pub organization_id: Uuid,

--- a/crates/api-types/src/project_status.rs
+++ b/crates/api-types/src/project_status.rs
@@ -6,7 +6,6 @@ use uuid::Uuid;
 use crate::some_if_present;
 
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
-#[ts(export)]
 pub struct ProjectStatus {
     pub id: Uuid,
     pub project_id: Uuid,

--- a/crates/api-types/src/pull_request.rs
+++ b/crates/api-types/src/pull_request.rs
@@ -7,7 +7,6 @@ use uuid::Uuid;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Type, TS)]
 #[sqlx(type_name = "pull_request_status", rename_all = "lowercase")]
 #[serde(rename_all = "lowercase")]
-#[ts(export)]
 pub enum PullRequestStatus {
     Open,
     Merged,
@@ -15,7 +14,6 @@ pub enum PullRequestStatus {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
-#[ts(export)]
 pub struct PullRequest {
     pub id: Uuid,
     pub url: String,

--- a/crates/api-types/src/response.rs
+++ b/crates/api-types/src/response.rs
@@ -11,7 +11,6 @@ pub struct MutationResponse<T> {
 
 /// Response wrapper for delete endpoints.
 #[derive(Debug, Serialize, Deserialize, TS)]
-#[ts(export)]
 pub struct DeleteResponse {
     pub txid: i64,
 }

--- a/crates/api-types/src/tag.rs
+++ b/crates/api-types/src/tag.rs
@@ -5,7 +5,6 @@ use uuid::Uuid;
 use crate::some_if_present;
 
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
-#[ts(export)]
 pub struct Tag {
     pub id: Uuid,
     pub project_id: Uuid,

--- a/crates/api-types/src/user.rs
+++ b/crates/api-types/src/user.rs
@@ -4,7 +4,6 @@ use ts_rs::TS;
 use uuid::Uuid;
 
 #[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow, TS)]
-#[ts(export)]
 pub struct User {
     pub id: Uuid,
     pub email: String,
@@ -16,7 +15,6 @@ pub struct User {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
-#[ts(export)]
 pub struct UserData {
     pub user_id: Uuid,
     pub first_name: Option<String>,

--- a/crates/api-types/src/workspace.rs
+++ b/crates/api-types/src/workspace.rs
@@ -5,7 +5,6 @@ use uuid::Uuid;
 
 /// Workspace metadata pushed from local clients
 #[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow, TS)]
-#[ts(export)]
 pub struct Workspace {
     pub id: Uuid,
     pub project_id: Uuid,

--- a/crates/db/src/models/repo.rs
+++ b/crates/db/src/models/repo.rs
@@ -37,7 +37,6 @@ pub struct Repo {
 }
 
 #[derive(Debug, Clone, Deserialize, TS)]
-#[ts(export)]
 pub struct UpdateRepo {
     #[serde(
         default,

--- a/crates/db/src/models/workspace_repo.rs
+++ b/crates/db/src/models/workspace_repo.rs
@@ -27,7 +27,6 @@ pub struct CreateWorkspaceRepo {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
-#[ts(export)]
 pub struct RepoWithTargetBranch {
     #[serde(flatten)]
     pub repo: Repo,

--- a/crates/executors/src/executors/mod.rs
+++ b/crates/executors/src/executors/mod.rs
@@ -200,7 +200,6 @@ impl CodingAgent {
 
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
 #[serde(tag = "type", rename_all = "SCREAMING_SNAKE_CASE")]
-#[ts(export)]
 pub enum AvailabilityInfo {
     LoginDetected { last_auth_timestamp: i64 },
     InstallationFound,

--- a/crates/executors/src/logs/mod.rs
+++ b/crates/executors/src/logs/mod.rs
@@ -9,14 +9,12 @@ pub mod utils;
 
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
 #[serde(tag = "type", rename_all = "snake_case")]
-#[ts(export)]
 pub enum ToolResultValueType {
     Markdown,
     Json,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
-#[ts(export)]
 pub struct ToolResult {
     pub r#type: ToolResultValueType,
     /// For Markdown, this will be a JSON string; for JSON, a structured value
@@ -41,14 +39,12 @@ impl ToolResult {
 
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
 #[serde(tag = "type", rename_all = "snake_case")]
-#[ts(export)]
 pub enum CommandExitStatus {
     ExitCode { code: i32 },
     Success { success: bool },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
-#[ts(export)]
 pub struct CommandRunResult {
     pub exit_status: Option<CommandExitStatus>,
     pub output: Option<String>,
@@ -136,7 +132,6 @@ impl NormalizedEntry {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, TS, Default)]
-#[ts(export)]
 #[serde(tag = "status", rename_all = "snake_case")]
 pub enum ToolStatus {
     #[default]
@@ -168,7 +163,6 @@ impl ToolStatus {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
-#[ts(export)]
 pub struct TodoItem {
     pub content: String,
     pub status: String,
@@ -178,7 +172,6 @@ pub struct TodoItem {
 
 /// Types of tool actions that can be performed
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
-#[ts(export)]
 #[serde(tag = "action", rename_all = "snake_case")]
 pub enum ActionType {
     FileRead {

--- a/crates/server/src/routes/images.rs
+++ b/crates/server/src/routes/images.rs
@@ -62,7 +62,6 @@ pub struct ImageMetadataQuery {
 
 /// Metadata response for image files, used for rendering in WYSIWYG editor
 #[derive(Debug, Serialize, Deserialize, TS)]
-#[ts(export)]
 pub struct ImageMetadata {
     pub exists: bool,
     pub file_name: Option<String>,

--- a/crates/server/src/routes/oauth.rs
+++ b/crates/server/src/routes/oauth.rs
@@ -20,7 +20,6 @@ use crate::{DeploymentImpl, error::ApiError};
 
 /// Response from GET /api/auth/token - returns the current access token
 #[derive(Debug, Serialize, TS)]
-#[ts(export)]
 pub struct TokenResponse {
     pub access_token: String,
     pub expires_at: Option<DateTime<Utc>>,
@@ -28,7 +27,6 @@ pub struct TokenResponse {
 
 /// Response from GET /api/auth/user - returns the current user ID
 #[derive(Debug, Serialize, TS)]
-#[ts(export)]
 pub struct CurrentUserResponse {
     pub user_id: String,
 }

--- a/crates/server/src/routes/repo.rs
+++ b/crates/server/src/routes/repo.rs
@@ -27,21 +27,18 @@ use crate::{
 };
 
 #[derive(Debug, Deserialize, TS)]
-#[ts(export)]
 pub struct RegisterRepoRequest {
     pub path: String,
     pub display_name: Option<String>,
 }
 
 #[derive(Debug, Deserialize, TS)]
-#[ts(export)]
 pub struct InitRepoRequest {
     pub parent_path: String,
     pub folder_name: String,
 }
 
 #[derive(Debug, Deserialize, TS)]
-#[ts(export)]
 pub struct BatchRepoRequest {
     pub ids: Vec<Uuid>,
 }

--- a/crates/services/src/services/config/editor/mod.rs
+++ b/crates/services/src/services/config/editor/mod.rs
@@ -9,7 +9,6 @@ use ts_rs::TS;
 #[derive(Debug, Clone, Serialize, Deserialize, TS, Error)]
 #[serde(tag = "type", rename_all = "snake_case")]
 #[ts(tag = "type", rename_all = "snake_case")]
-#[ts(export)]
 pub enum EditorOpenError {
     #[error("Editor executable '{executable}' not found in PATH")]
     ExecutableNotFound {

--- a/crates/services/src/services/config/versions/v6.rs
+++ b/crates/services/src/services/config/versions/v6.rs
@@ -10,7 +10,6 @@ pub use v5::{EditorConfig, EditorType, GitHubConfig, NotificationConfig, SoundFi
 use crate::services::config::versions::v5;
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, TS, Default)]
-#[ts(export)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum UiLanguage {
     #[default]

--- a/crates/services/src/services/migration/types.rs
+++ b/crates/services/src/services/migration/types.rs
@@ -5,7 +5,6 @@ use ts_rs::TS;
 use uuid::Uuid;
 
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
-#[ts(export)]
 pub struct MigrationRequest {
     pub organization_id: Uuid,
     /// List of local project IDs to migrate.
@@ -20,13 +19,11 @@ impl MigrationRequest {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
-#[ts(export)]
 pub struct MigrationResponse {
     pub report: MigrationReport,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, TS)]
-#[ts(export)]
 pub struct MigrationReport {
     pub projects: EntityReport,
     pub tasks: EntityReport,
@@ -36,7 +33,6 @@ pub struct MigrationReport {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, TS)]
-#[ts(export)]
 pub struct EntityReport {
     pub total: usize,
     pub migrated: usize,
@@ -46,7 +42,6 @@ pub struct EntityReport {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
-#[ts(export)]
 pub struct EntityError {
     pub local_id: Uuid,
     pub error: String,

--- a/crates/services/src/services/queued_message.rs
+++ b/crates/services/src/services/queued_message.rs
@@ -9,7 +9,6 @@ use uuid::Uuid;
 
 /// Represents a queued follow-up message for a session
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
-#[ts(export)]
 pub struct QueuedMessage {
     /// The session this message is queued for
     pub session_id: Uuid,
@@ -22,7 +21,6 @@ pub struct QueuedMessage {
 /// Status of the queue for a session (for frontend display)
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
 #[serde(tag = "status", rename_all = "snake_case")]
-#[ts(export)]
 pub enum QueueStatus {
     /// No message queued
     Empty,

--- a/crates/utils/src/approvals.rs
+++ b/crates/utils/src/approvals.rs
@@ -32,7 +32,6 @@ impl ApprovalRequest {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
-#[ts(export)]
 pub struct CreateApprovalRequest {
     pub tool_name: String,
     pub tool_input: serde_json::Value,
@@ -40,7 +39,6 @@ pub struct CreateApprovalRequest {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
-#[ts(export)]
 #[serde(tag = "status", rename_all = "snake_case")]
 pub enum ApprovalStatus {
     Pending,
@@ -53,7 +51,6 @@ pub enum ApprovalStatus {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
-#[ts(export)]
 pub struct ApprovalResponse {
     pub execution_process_id: Uuid,
     pub status: ApprovalStatus,

--- a/crates/utils/src/diff.rs
+++ b/crates/utils/src/diff.rs
@@ -33,7 +33,6 @@ pub struct Diff {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
-#[ts(export)]
 #[serde(rename_all = "camelCase")]
 pub enum DiffChangeKind {
     Added,


### PR DESCRIPTION
## Summary

Remove all `#[ts(export)]` annotations from Rust types across the workspace. These annotations are no-ops in our repo — we use `ts-rs` for type generation via `generate_types.rs` binaries, not through `#[ts(export)]`, so these attributes add noise without any effect.

## Changes

- Removed 73 `#[ts(export)]` annotations across 31 files in `crates/api-types`, `crates/db`, `crates/executors`, `crates/server`, `crates/services`, and `crates/utils`
- No functional or generated-type changes — `cargo check --workspace` passes cleanly

## Why

The `#[ts(export)]` attribute tells `ts-rs` to auto-export types to files when running tests, but our repo generates TypeScript types through dedicated `generate_types.rs` binaries instead. These annotations were dead code that cluttered type definitions.

- [x] Tested

---

This PR was written using [Vibe Kanban](https://vibekanban.com)