### PR TITLE
refactor: remove Attachment/AttachmentWithBlob re-export from db::attachments (Vibe Kanban)

### DIFF
--- a/crates/remote/src/db/attachments.rs
+++ b/crates/remote/src/db/attachments.rs
@@ -3,9 +3,7 @@ use sqlx::{Executor, PgPool, Postgres};
 use thiserror::Error;
 use uuid::Uuid;
 
-pub use api_types::{Attachment, AttachmentWithBlob};
-
-use api_types::Blob;
+use api_types::{Attachment, AttachmentWithBlob, Blob};
 
 #[derive(Debug, Error)]
 pub enum AttachmentError {

--- a/crates/remote/src/routes/attachments.rs
+++ b/crates/remote/src/routes/attachments.rs
@@ -12,13 +12,13 @@ use ts_rs::TS;
 use uuid::Uuid;
 
 use super::organization_members::{ensure_comment_access, ensure_issue_access, ensure_project_access};
-use api_types::{AttachmentUrlResponse, AttachmentWithUrl, ListAttachmentsResponse};
+use api_types::{AttachmentUrlResponse, AttachmentWithBlob, AttachmentWithUrl, ListAttachmentsResponse};
 
 use crate::{
     AppState,
     auth::RequestContext,
     azure_blob::AzureBlobError,
-    db::attachments::{AttachmentError, AttachmentRepository, AttachmentWithBlob},
+    db::attachments::{AttachmentError, AttachmentRepository},
     db::blobs::{BlobError, BlobRepository},
     db::pending_uploads::{PendingUploadError, PendingUploadRepository},
     attachments::thumbnail::ThumbnailService,

--- a/crates/remote/src/shapes.rs
+++ b/crates/remote/src/shapes.rs
@@ -1,9 +1,8 @@
 //! All shape constant instances for realtime streaming.
 
 use crate::shape_definition::{ShapeDefinition, ShapeExport};
-use crate::db::attachments::Attachment;
 use api_types::{
-    Blob, Issue, IssueAssignee, IssueComment, IssueCommentReaction, IssueFollower,
+    Attachment, Blob, Issue, IssueAssignee, IssueComment, IssueCommentReaction, IssueFollower,
     IssueRelationship, IssueTag, Notification, OrganizationMember, Project, ProjectStatus,
     PullRequest, Tag, User, Workspace,
 };


### PR DESCRIPTION
## Summary

- Removed the `pub use api_types::{Attachment, AttachmentWithBlob}` re-export from `crates/remote/src/db/attachments.rs`
- Updated consumers (`routes/attachments.rs`, `shapes.rs`) to import `Attachment` and `AttachmentWithBlob` directly from `api_types` instead of going through the `db::attachments` module
- Consolidated the `api_types` imports in `db/attachments.rs` into a single `use` statement

## Why

The `db::attachments` module was re-exporting types that originate in `api_types`, creating an unnecessary indirection. Consumers should import types from their canonical source. This aligns with the pattern already used throughout the rest of the codebase, where `api_types` types are imported directly.

## Files changed

- `crates/remote/src/db/attachments.rs` — removed `pub use` re-export, kept types as private imports
- `crates/remote/src/routes/attachments.rs` — moved `AttachmentWithBlob` import from `crate::db::attachments` to `api_types`
- `crates/remote/src/shapes.rs` — replaced `crate::db::attachments::Attachment` with direct `api_types` import

- [x] tested

This PR was written using [Vibe Kanban](https://vibekanban.com)