### PR TITLE
Bump Claude Code to 2.1.41 and filter noisy fast mode stderr warning (Vibe Kanban)

### DIFF
--- a/crates/executors/src/executors/claude.rs
+++ b/crates/executors/src/executors/claude.rs
@@ -9,6 +9,7 @@ use std::{
     path::{Path, PathBuf},
     process::Stdio,
     sync::Arc,
+    time::Duration,
 };
 
 use async_trait::async_trait;
@@ -40,7 +41,7 @@ use crate::{
     logs::{
         ActionType, FileChange, NormalizedEntry, NormalizedEntryError, NormalizedEntryType,
         TodoItem, ToolStatus,
-        stderr_processor::normalize_stderr_logs,
+        plain_text_processor::PlainTextLogProcessor,
         utils::{
             EntryIndexProvider,
             patch::{self, ConversationPatch},
@@ -49,12 +50,49 @@ use crate::{
     stdout_dup::create_stdout_pipe_writer,
 };
 
+const SUPPRESSED_STDERR_PATTERNS: &[&str] = &["[WARN] Fast mode requires the native binary"];
+
 fn base_command(claude_code_router: bool) -> &'static str {
     if claude_code_router {
         "npx -y @musistudio/claude-code-router@1.0.66 code"
     } else {
         "npx -y @anthropic-ai/claude-code@2.1.41"
     }
+}
+
+fn normalize_claude_stderr_logs(
+    msg_store: Arc<MsgStore>,
+    entry_index_provider: EntryIndexProvider,
+) {
+    tokio::spawn(async move {
+        let mut stderr = msg_store.stderr_chunked_stream();
+
+        let mut processor = PlainTextLogProcessor::builder()
+            .normalized_entry_producer(|content: String| NormalizedEntry {
+                timestamp: None,
+                entry_type: NormalizedEntryType::ErrorMessage {
+                    error_type: NormalizedEntryError::Other,
+                },
+                content: strip_ansi_escapes::strip_str(&content),
+                metadata: None,
+            })
+            .time_gap(Duration::from_secs(2))
+            .index_provider(entry_index_provider)
+            .transform_lines(Box::new(|lines: &mut Vec<String>| {
+                lines.retain(|line| {
+                    !SUPPRESSED_STDERR_PATTERNS
+                        .iter()
+                        .any(|pattern| line.contains(pattern))
+                });
+            }))
+            .build();
+
+        while let Some(Ok(chunk)) = stderr.next().await {
+            for patch in processor.process(chunk) {
+                msg_store.push_patch(patch);
+            }
+        }
+    });
 }
 
 use derivative::Derivative;
@@ -235,8 +273,7 @@ impl StandardCodingAgentExecutor for ClaudeCode {
             HistoryStrategy::Default,
         );
 
-        // Process stderr logs using the standard stderr processor
-        normalize_stderr_logs(msg_store, entry_index_provider);
+        normalize_claude_stderr_logs(msg_store, entry_index_provider);
     }
 
     // MCP configuration methods


### PR DESCRIPTION
## Summary

- Bumps the pinned Claude Code version from `2.1.32` to `2.1.41`
- Adds a Claude-specific stderr normalizer (`normalize_claude_stderr_logs`) that filters out the `[WARN] Fast mode requires the native binary` warning, which is not actionable for workspace users running via npx
- Suppressed patterns are defined in a `SUPPRESSED_STDERR_PATTERNS` constant for easy extension

## Implementation Details

Instead of using the shared `normalize_stderr_logs`, the Claude executor now has its own `normalize_claude_stderr_logs` function that uses `PlainTextLogProcessor` with a `transform_lines` callback to filter matching stderr lines via `lines.retain()`. This follows the same pattern used by the Codex executor's stderr normalizer.

- [x] tested

This PR was written using [Vibe Kanban](https://vibekanban.com)