### PR TITLE
修复 list_projects 工具的 organization_id 参数问题

### DIFF
--- a/crates/server/src/mcp/task_server.rs
+++ b/crates/server/src/mcp/task_server.rs
@@ -146,8 +146,8 @@ pub struct ListReposResponse {
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct McpListProjectsRequest {
-    #[schemars(description = "The ID of the organization to list projects from")]
-    pub organization_id: Uuid,
+    #[schemars(description = "The ID of the organization to list projects from. If not provided, lists projects from all organizations.")]
+    pub organization_id: Option<Uuid>,
 }
 
 #[derive(Debug, Serialize, schemars::JsonSchema)]
@@ -837,10 +837,14 @@ impl TaskServer {
         &self,
         Parameters(McpListProjectsRequest { organization_id }): Parameters<McpListProjectsRequest>,
     ) -> Result<CallToolResult, ErrorData> {
-        let url = self.url(&format!(
-            "/api/remote/projects?organization_id={}",
-            organization_id
-        ));
+        let url = if let Some(org_id) = organization_id {
+            self.url(&format!(
+                "/api/remote/projects?organization_id={}",
+                org_id
+            ))
+        } else {
+            self.url("/api/remote/projects")
+        };
         let response: api_types::ListProjectsResponse =
             match self.send_json(self.client.get(&url)).await {
                 Ok(r) => r,


### PR DESCRIPTION
## 问题描述

修复了 GitHub Issue #2744 中报告的 `list_projects` 工具解析错误问题。

## 问题原因

`list_projects` 工具要求必需的 `organization_id` 参数，但在某些情况下调用时没有提供该参数，导致 JSON 解析失败并返回错误：

```
Failed to parse VK API response
error decoding response body
```

## 修复方案

将 `organization_id` 参数从必需改为可选：

1. **修改请求结构体**（`McpListProjectsRequest`）：
   - 将 `organization_id` 字段类型从 `Uuid` 改为 `Option<Uuid>`
   - 更新描述说明该参数为可选

2. **修改实现逻辑**（`list_projects` 函数）：
   - 如果提供了 `organization_id`，则按组织过滤项目
   - 如果未提供 `organization_id`，则列出所有项目

## 修改内容

**文件**: `crates/server/src/mcp/task_server.rs`

- 第 148-151 行：修改 `McpListProjectsRequest` 结构体
- 第 840-847 行：修改 `list_projects` 函数实现

## 测试

修复后，`list_projects` 工具可以在以下两种情况下正常工作：

1. **不提供 `organization_id` 参数**：列出所有组织的所有项目
2. **提供 `organization_id` 参数**：列出指定组织的项目

## 相关 Issue

Fixes #2744

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)