### PR TITLE
fix(ci/remote): Relax remote Cargo.lock to match cargo build --locked

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -163,10 +163,9 @@ jobs:
         with:
           ssh-private-key: ${{ secrets.VK_PRIVATE_DEPLOY_KEY }}
 
-      - name: Check remote Cargo.lock is up to date
+      - name: Check remote Cargo.lock is consistent
         run: |
-          cargo generate-lockfile --manifest-path crates/remote/Cargo.toml
-          git diff --exit-code crates/remote/Cargo.lock || (echo "::error::crates/remote/Cargo.lock is out of date. Run 'cargo generate-lockfile --manifest-path crates/remote/Cargo.toml' and commit the result." && exit 1)
+          cargo metadata --locked --format-version 1 --manifest-path crates/remote/Cargo.toml > /dev/null
 
       - name: Check generated types
         run: npm run remote:generate-types:check


### PR DESCRIPTION
The current cargo lock check makes unnecessary updates to cargo lock.