### PR TITLE
fix(remote): make LOOPS_EMAIL_API_KEY optional for self-hosting (Vibe Kanban)

### DIFF
--- a/crates/remote/src/mail.rs
+++ b/crates/remote/src/mail.rs
@@ -25,6 +25,43 @@ pub trait Mailer: Send + Sync {
     async fn send_review_failed(&self, email: &str, pr_name: &str, review_id: &str);
 }
 
+/// No-op mailer used when `LOOPS_EMAIL_API_KEY` is not configured.
+pub struct NoopMailer;
+
+#[async_trait]
+impl Mailer for NoopMailer {
+    async fn send_org_invitation(
+        &self,
+        org_name: &str,
+        email: &str,
+        _accept_url: &str,
+        _role: MemberRole,
+        _invited_by: Option<&str>,
+    ) {
+        tracing::warn!(
+            email = %email,
+            org_name = %org_name,
+            "Email service not configured — skipping org invitation email. Set LOOPS_EMAIL_API_KEY to enable."
+        );
+    }
+
+    async fn send_review_ready(&self, email: &str, _review_url: &str, pr_name: &str) {
+        tracing::warn!(
+            email = %email,
+            pr_name = %pr_name,
+            "Email service not configured — skipping review ready email. Set LOOPS_EMAIL_API_KEY to enable."
+        );
+    }
+
+    async fn send_review_failed(&self, email: &str, pr_name: &str, _review_id: &str) {
+        tracing::warn!(
+            email = %email,
+            pr_name = %pr_name,
+            "Email service not configured — skipping review failed email. Set LOOPS_EMAIL_API_KEY to enable."
+        );
+    }
+}
+
 pub struct LoopsMailer {
     client: reqwest::Client,
     api_key: String,


### PR DESCRIPTION
## Summary

Makes the `LOOPS_EMAIL_API_KEY` environment variable optional so the remote server can start without configuring the Loops email service. This removes a blocker for self-hosted deployments that don't need email notifications.

## Changes

- **Added `NoopMailer`** (`crates/remote/src/mail.rs`): A no-op implementation of the `Mailer` trait that logs a warning (with context like recipient email and org/PR name) whenever an email would have been sent, along with a hint to set `LOOPS_EMAIL_API_KEY`.
- **Made mailer initialization conditional** (`crates/remote/src/app.rs`): Instead of crashing at startup when the env var is missing, the server now falls back to `NoopMailer` and logs an info message that email notifications are disabled.

## Why

Previously, the remote server required `LOOPS_EMAIL_API_KEY` at startup and would crash without it. This made self-hosting impossible without a Loops account, even though email notifications (org invitations, review status updates) are not critical to core functionality. With this change, the server degrades gracefully — all other features work normally, and any attempted email sends produce a visible warning in logs.

## Implementation details

- The existing `Mailer` trait (`dyn Mailer`) was already used via dynamic dispatch in `AppState`, so adding a second implementation required no changes to call sites in `organization_members.rs` or `review.rs`.
- `NoopMailer` logs at `warn` level per-send (not just at startup) so operators can see exactly which notifications are being skipped.
- Empty string values for `LOOPS_EMAIL_API_KEY` are treated the same as unset.

---

This PR was written using [Vibe Kanban](https://vibekanban.com)