### PR TITLE
Open Repository Settings Action in New Settings Dialog (Vibe Kanban)

### DIFF
--- a/frontend/src/components/ui-new/actions/index.ts
+++ b/frontend/src/components/ui-new/actions/index.ts
@@ -1187,8 +1187,13 @@ export const Actions = {
     icon: GearIcon,
     requiresTarget: ActionTargetType.GIT,
     isVisible: (ctx) => ctx.hasWorkspace && ctx.hasGitRepos,
-    execute: (ctx, _workspaceId, repoId) => {
-      ctx.navigate(`/settings/repos?repoId=${repoId}`);
+    execute: async (_ctx, _workspaceId, repoId) => {
+      await SettingsDialog.show({
+        initialSection: 'repos',
+        initialState: {
+          repoId,
+        },
+      });
     },
   },
 


### PR DESCRIPTION
## Summary
This PR updates the repository-level command action to open the new settings dialog flow instead of navigating to the legacy settings route.

## What Changed
- Updated `RepoSettings` in `frontend/src/components/ui-new/actions/index.ts`.
- Replaced `ctx.navigate(`/settings/repos?repoId=${repoId}`)` with:
  - `SettingsDialog.show({ initialSection: 'repos', initialState: { repoId } })`
- Converted the action executor to `async` and awaited `SettingsDialog.show(...)`.

## Why
The task requires repository settings to open the new dialog-based settings UI (`ReposSettingsSection.tsx`) rather than the old URL-based settings page. This keeps repository settings access consistent with the new UI architecture.

## Important Implementation Details
- `initialSection: 'repos'` ensures the settings dialog opens directly to the Repositories section.
- `initialState: { repoId }` passes the selected repository into the section so the correct repo is preselected.
- This change is scoped to the `repo-settings` action only; no other settings entry points were modified.

This PR was written using [Vibe Kanban](https://vibekanban.com)
