### PR TITLE
feat: use remote issue simple_id in merge commit messages and PR titles (Vibe Kanban)

### DIFF
--- a/frontend/src/components/dialogs/tasks/CreatePRDialog.tsx
+++ b/frontend/src/components/dialogs/tasks/CreatePRDialog.tsx
@@ -39,6 +39,7 @@ interface CreatePRDialogProps {
   task: TaskWithAttemptStatus;
   repoId: string;
   targetBranch?: string;
+  issueIdentifier?: string;
 }
 
 export type CreatePRDialogResult = {
@@ -47,7 +48,7 @@ export type CreatePRDialogResult = {
 };
 
 const CreatePRDialogImpl = NiceModal.create<CreatePRDialogProps>(
-  ({ attempt, task, repoId, targetBranch }) => {
+  ({ attempt, task, repoId, targetBranch, issueIdentifier }) => {
     const modal = useModal();
     const { t } = useTranslation('tasks');
     const { isLoaded } = useAuth();
@@ -81,11 +82,12 @@ const CreatePRDialogImpl = NiceModal.create<CreatePRDialogProps>(
         return;
       }
 
-      setPrTitle(`${task.title} (vibe-kanban)`);
+      const suffix = issueIdentifier ? ` ${issueIdentifier}` : '';
+      setPrTitle(`${task.title} (vibe-kanban${suffix})`);
       setPrBody(task.description || '');
       setError(null);
       setGhCliHelp(null);
-    }, [modal.visible, isLoaded, task]);
+    }, [modal.visible, isLoaded, task, issueIdentifier]);
 
     // Set default base branch when branches are loaded
     useEffect(() => {

--- a/frontend/src/components/tasks/Toolbar/GitOperations.tsx
+++ b/frontend/src/components/tasks/Toolbar/GitOperations.tsx
@@ -39,6 +39,7 @@ interface GitOperationsProps {
   isAttemptRunning: boolean;
   selectedBranch: string | null;
   layout?: 'horizontal' | 'vertical';
+  issueIdentifier?: string;
 }
 
 export type GitOperationsInputs = Omit<GitOperationsProps, 'selectedAttempt'>;
@@ -51,6 +52,7 @@ function GitOperations({
   isAttemptRunning,
   selectedBranch,
   layout = 'horizontal',
+  issueIdentifier,
 }: GitOperationsProps) {
   const { t } = useTranslation('tasks');
 
@@ -257,6 +259,7 @@ function GitOperations({
       task,
       repoId: getSelectedRepoId(),
       targetBranch: getSelectedRepoStatus()?.target_branch_name,
+      issueIdentifier,
     });
   };
 

--- a/frontend/src/pages/ui-new/ProjectKanban.tsx
+++ b/frontend/src/pages/ui-new/ProjectKanban.tsx
@@ -70,6 +70,7 @@ function ProjectMutationsRegistration({ children }: { children: ReactNode }) {
           extension_metadata: issue.extension_metadata,
         });
       },
+      getIssue,
     });
 
     return () => {


### PR DESCRIPTION
## Summary

Merge commit messages and PR titles now use the remote issue's human-readable `simple_id` (e.g., `MCC-42`) instead of a truncated local task UUID.

### Problem

- **Merge commits** used a truncated 8-char local task UUID (e.g., `vibe-kanban 7fd20218`) which was unresolvable — the local task ID has no correlation to the remote issue ID
- **PR titles** included no identifier at all (`(vibe-kanban)`)
- Agents copying these IDs into cross-references couldn't resolve them via `get_issue` or any MCP tool

### Changes

**Backend** (`crates/server/src/routes/task_attempts.rs`):
- Added `resolve_vibe_kanban_identifier()` helper that resolves the best available identifier with graceful fallback chain: remote issue `simple_id` → remote issue UUID → local task UUID
- Uses existing `RemoteClient::get_workspace_by_local_id` and `RemoteClient::get_issue` — each failure silently falls through to the next fallback

**Frontend** (`CreatePRDialog.tsx`, `actions/index.ts`, `GitOperations.tsx`, `ProjectKanban.tsx`):
- Added `issueIdentifier` prop to `CreatePRDialog` and `GitOperations` components
- In the new kanban UI, the `GitCreatePR` action resolves the identifier from the remote workspace's linked issue via `ProjectMutations.getIssue`
- PR title defaults now include the identifier: `My task (vibe-kanban MCC-42)`

### Identifier priority

1. Remote issue `simple_id` (e.g., `MCC-42`) — human-readable and resolvable
2. Remote issue UUID — when `simple_id` is unexpectedly empty
3. Full local task UUID — when no remote connection or no linked issue

Closes #2751

- [x] tested

---
This PR was written using [Vibe Kanban](https://vibekanban.com)