### PR TITLE
feat: un-/archive in IssueWorkspaceCard

### DIFF
--- a/frontend/src/components/ui-new/containers/IssueWorkspacesSectionContainer.tsx
+++ b/frontend/src/components/ui-new/containers/IssueWorkspacesSectionContainer.tsx
@@ -264,6 +264,46 @@ export function IssueWorkspacesSectionContainer({
     [localWorkspacesById, t]
   );
 
+  const handleArchiveWorkspace = useCallback(
+    async (localWorkspaceId: string) => {
+      const localWorkspace = localWorkspacesById.get(localWorkspaceId);
+      if (!localWorkspace) {
+        return;
+      }
+
+      const wasArchived = localWorkspace.isArchived;
+      const action = wasArchived
+        ? t('workspaces.unarchive')
+        : t('workspaces.archive');
+      const result = await ConfirmDialog.show({
+        title: action,
+        message: wasArchived
+          ? t('workspaces.unarchiveConfirmMessage')
+          : t('workspaces.archiveConfirmMessage'),
+        confirmText: action,
+      });
+
+      if (result === 'confirmed') {
+        try {
+          await attemptsApi.update(localWorkspaceId, {
+            archived: !wasArchived,
+          });
+        } catch (error) {
+          ConfirmDialog.show({
+            title: t('common:error'),
+            message:
+              error instanceof Error
+                ? error.message
+                : t('workspaces.archiveError'),
+            confirmText: t('common:ok'),
+            showCancelButton: false,
+          });
+        }
+      }
+    },
+    [localWorkspacesById, t]
+  );
+
   // Actions for the section header
   const actions: SectionAction[] = useMemo(
     () => [
@@ -288,6 +328,7 @@ export function IssueWorkspacesSectionContainer({
       onCreateWorkspace={handleAddWorkspace}
       onUnlinkWorkspace={handleUnlinkWorkspace}
       onDeleteWorkspace={handleDeleteWorkspace}
+      onArchiveWorkspace={handleArchiveWorkspace}
       shouldAnimateCreateButton={shouldAnimateCreateButton}
     />
   );

--- a/frontend/src/components/ui-new/views/IssueWorkspaceCard.tsx
+++ b/frontend/src/components/ui-new/views/IssueWorkspaceCard.tsx
@@ -9,6 +9,7 @@ import {
   HandIcon,
   TriangleIcon,
   CircleIcon,
+  ArchiveIcon,
 } from '@phosphor-icons/react';
 import { UserAvatar } from '@/components/ui-new/primitives/UserAvatar';
 import { RunningDots } from '@/components/ui-new/primitives/RunningDots';
@@ -51,6 +52,7 @@ export interface IssueWorkspaceCardProps {
   onClick?: () => void;
   onUnlink?: () => void;
   onDelete?: () => void;
+  onArchive?: () => void;
   showOwner?: boolean;
   showStatusBadge?: boolean;
   showNoPrText?: boolean;
@@ -113,6 +115,7 @@ export function IssueWorkspaceCard({
   onClick,
   onUnlink,
   onDelete,
+  onArchive,
   showOwner = true,
   showStatusBadge = true,
   showNoPrText = true,
@@ -166,7 +169,7 @@ export function IssueWorkspaceCard({
               className="h-5 w-5 text-[10px] border-2 border-panel"
             />
           )}
-          {(onUnlink || onDelete) && (
+          {(onUnlink || onDelete || onArchive) && (
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <button
@@ -183,13 +186,26 @@ export function IssueWorkspaceCard({
               <DropdownMenuContent align="end">
                 {onUnlink && (
                   <DropdownMenuItem
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      onUnlink();
-                    }}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onUnlink();
+                  }}
                   >
                     <LinkBreakIcon className="size-icon-xs" />
                     {t('workspaces.unlinkFromIssue')}
+                  </DropdownMenuItem>
+                )}
+                {onArchive && (
+                  <DropdownMenuItem
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onArchive();
+                    }}
+                  >
+                    <ArchiveIcon className="size-icon-xs" />
+                    {workspace.archived
+                      ? t('workspaces.unarchiveWorkspace')
+                      : t('workspaces.archiveWorkspace')}
                   </DropdownMenuItem>
                 )}
                 {onDelete && (

--- a/frontend/src/components/ui-new/views/IssueWorkspaceCard.tsx
+++ b/frontend/src/components/ui-new/views/IssueWorkspaceCard.tsx
@@ -186,10 +186,10 @@ export function IssueWorkspaceCard({
               <DropdownMenuContent align="end">
                 {onUnlink && (
                   <DropdownMenuItem
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onUnlink();
-                  }}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onUnlink();
+                    }}
                   >
                     <LinkBreakIcon className="size-icon-xs" />
                     {t('workspaces.unlinkFromIssue')}

--- a/frontend/src/components/ui-new/views/IssueWorkspacesSection.tsx
+++ b/frontend/src/components/ui-new/views/IssueWorkspacesSection.tsx
@@ -18,6 +18,7 @@ export interface IssueWorkspacesSectionProps {
   onCreateWorkspace?: () => void;
   onUnlinkWorkspace?: (localWorkspaceId: string) => void;
   onDeleteWorkspace?: (localWorkspaceId: string) => void;
+  onArchiveWorkspace?: (localWorkspaceId: string) => void;
   shouldAnimateCreateButton?: boolean;
 }
 
@@ -33,6 +34,7 @@ export function IssueWorkspacesSection({
   onCreateWorkspace,
   onUnlinkWorkspace,
   onDeleteWorkspace,
+  onArchiveWorkspace,
   shouldAnimateCreateButton = false,
 }: IssueWorkspacesSectionProps) {
   const { t } = useTranslation('common');
@@ -76,6 +78,11 @@ export function IssueWorkspacesSection({
                   localWorkspaceId &&
                   workspace.isOwnedByCurrentUser
                     ? () => onDeleteWorkspace(localWorkspaceId)
+                    : undefined
+                }
+                onArchive={
+                  onArchiveWorkspace && localWorkspaceId
+                    ? () => onArchiveWorkspace(localWorkspaceId)
                     : undefined
                 }
               />

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -179,6 +179,10 @@
     "pin": "Pin",
     "unpin": "Unpin",
     "archive": "Archive",
+    "unarchive": "Unarchive",
+    "archiveConfirmMessage": "Are you sure you want to archive this workspace? It will be moved to the archived section.",
+    "unarchiveConfirmMessage": "Are you sure you want to unarchive this workspace? It will be moved back to the active section.",
+    "archiveError": "Failed to archive workspace",
     "more": "More actions",
     "rename": {
       "title": "Rename Workspace",
@@ -189,6 +193,8 @@
       "renaming": "Renaming..."
     },
     "unlinkFromIssue": "Unlink from issue",
+    "archiveWorkspace": "Archive workspace",
+    "unarchiveWorkspace": "Unarchive workspace",
     "deleteWorkspace": "Delete workspace",
     "unlink": "Unlink",
     "delete": "Delete",
@@ -398,6 +404,7 @@
       "rename-workspace": "Rename workspace",
       "pin-workspace": "Pin/Unpin workspace",
       "archive-workspace": "Archive workspace",
+      "unarchive-workspace": "Unarchive workspace",
       "delete-workspace": "Delete workspace",
       "toggle-changes-mode": "Toggle Changes panel",
       "toggle-logs-mode": "Toggle Logs panel",

--- a/frontend/src/i18n/locales/es/common.json
+++ b/frontend/src/i18n/locales/es/common.json
@@ -390,6 +390,7 @@
       "rename-workspace": "Renombrar espacio de trabajo",
       "pin-workspace": "Fijar/Desfijar espacio de trabajo",
       "archive-workspace": "Archivar espacio de trabajo",
+      "unarchive-workspace": "Desarchivar espacio de trabajo",
       "delete-workspace": "Eliminar espacio de trabajo",
       "toggle-changes-mode": "Alternar panel de cambios",
       "toggle-logs-mode": "Alternar panel de registros",

--- a/frontend/src/i18n/locales/es/common.json
+++ b/frontend/src/i18n/locales/es/common.json
@@ -165,6 +165,10 @@
     "pin": "Fijar",
     "unpin": "Desfijar",
     "archive": "Archivar",
+    "unarchive": "Desarchivar",
+    "archiveConfirmMessage": "¿Estás seguro de que deseas archivar este espacio de trabajo? Se moverá a la sección de archivados.",
+    "unarchiveConfirmMessage": "¿Estás seguro de que deseas desarchivar este espacio de trabajo? Se moverá de vuelta a la sección de activos.",
+    "archiveError": "Error al archivar el espacio de trabajo",
     "more": "Más acciones",
     "rename": {
       "title": "Renombrar espacio de trabajo",
@@ -175,6 +179,8 @@
       "renaming": "Renombrando..."
     },
     "unlinkFromIssue": "Desvincular del problema",
+    "archiveWorkspace": "Archivar espacio de trabajo",
+    "unarchiveWorkspace": "Desarchivar espacio de trabajo",
     "deleteWorkspace": "Eliminar espacio de trabajo",
     "unlink": "Desvincular",
     "delete": "Eliminar",

--- a/frontend/src/i18n/locales/fr/common.json
+++ b/frontend/src/i18n/locales/fr/common.json
@@ -165,6 +165,10 @@
     "pin": "Épingler",
     "unpin": "Désépingler",
     "archive": "Archiver",
+    "unarchive": "Désarchiver",
+    "archiveConfirmMessage": "Êtes-vous sûr de vouloir archiver cet espace de travail ? Il sera déplacé vers la section des archives.",
+    "unarchiveConfirmMessage": "Êtes-vous sûr de vouloir désarchiver cet espace de travail ? Il sera déplacé vers la section des actifs.",
+    "archiveError": "Échec de l'archivage de l'espace de travail",
     "more": "Plus d'actions",
     "rename": {
       "title": "Renommer l'espace de travail",
@@ -175,6 +179,8 @@
       "renaming": "Renommage..."
     },
     "unlinkFromIssue": "Dissocier du problème",
+    "archiveWorkspace": "Archiver l'espace de travail",
+    "unarchiveWorkspace": "Désarchiver l'espace de travail",
     "deleteWorkspace": "Supprimer l'espace de travail",
     "unlink": "Dissocier",
     "delete": "Supprimer",

--- a/frontend/src/i18n/locales/fr/common.json
+++ b/frontend/src/i18n/locales/fr/common.json
@@ -390,6 +390,7 @@
       "rename-workspace": "Renommer l'espace de travail",
       "pin-workspace": "Épingler/Désépingler l'espace de travail",
       "archive-workspace": "Archiver l'espace de travail",
+      "unarchive-workspace": "Désarchiver l'espace de travail",
       "delete-workspace": "Supprimer l'espace de travail",
       "toggle-changes-mode": "Basculer le panneau Modifications",
       "toggle-logs-mode": "Basculer le panneau Logs",

--- a/frontend/src/i18n/locales/ja/common.json
+++ b/frontend/src/i18n/locales/ja/common.json
@@ -165,6 +165,10 @@
     "pin": "ピン留め",
     "unpin": "ピン留め解除",
     "archive": "アーカイブ",
+    "unarchive": "アーカイブ解除",
+    "archiveConfirmMessage": "このワークスペースをアーカイブしてもよろしいですか？アーカイブセクションに移動されます。",
+    "unarchiveConfirmMessage": "このワークスペースのアーカイブを解除してもよろしいですか？アクティブセクションに戻されます。",
+    "archiveError": "ワークスペースのアーカイブに失敗しました",
     "more": "その他の操作",
     "rename": {
       "title": "ワークスペースの名前を変更",
@@ -175,6 +179,8 @@
       "renaming": "名前を変更中..."
     },
     "unlinkFromIssue": "課題からリンク解除",
+    "archiveWorkspace": "ワークスペースをアーカイブ",
+    "unarchiveWorkspace": "ワークスペースのアーカイブを解除",
     "deleteWorkspace": "ワークスペースを削除",
     "unlink": "リンク解除",
     "delete": "削除",

--- a/frontend/src/i18n/locales/ja/common.json
+++ b/frontend/src/i18n/locales/ja/common.json
@@ -390,6 +390,7 @@
       "rename-workspace": "ワークスペースの名前を変更",
       "pin-workspace": "ワークスペースをピン留め/解除",
       "archive-workspace": "ワークスペースをアーカイブ",
+      "unarchive-workspace": "ワークスペースのアーカイブを解除",
       "delete-workspace": "ワークスペースを削除",
       "toggle-changes-mode": "変更パネルの切り替え",
       "toggle-logs-mode": "ログパネルの切り替え",

--- a/frontend/src/i18n/locales/ko/common.json
+++ b/frontend/src/i18n/locales/ko/common.json
@@ -390,6 +390,7 @@
       "rename-workspace": "워크스페이스 이름 변경",
       "pin-workspace": "워크스페이스 고정/해제",
       "archive-workspace": "워크스페이스 보관",
+      "unarchive-workspace": "워크스페이스 보관 해제",
       "delete-workspace": "워크스페이스 삭제",
       "toggle-changes-mode": "변경사항 패널 전환",
       "toggle-logs-mode": "로그 패널 전환",

--- a/frontend/src/i18n/locales/ko/common.json
+++ b/frontend/src/i18n/locales/ko/common.json
@@ -165,6 +165,10 @@
     "pin": "고정",
     "unpin": "고정 해제",
     "archive": "보관",
+    "unarchive": "보관 해제",
+    "archiveConfirmMessage": "이 워크스페이스를 보관하시겠습니까? 보관 섹션으로 이동됩니다.",
+    "unarchiveConfirmMessage": "이 워크스페이스의 보관을 해제하시겠습니까? 활성 섹션으로 다시 이동됩니다.",
+    "archiveError": "워크스페이스 보관 실패",
     "more": "더 많은 작업",
     "rename": {
       "title": "워크스페이스 이름 변경",
@@ -175,6 +179,8 @@
       "renaming": "이름 변경 중..."
     },
     "unlinkFromIssue": "이슈에서 연결 해제",
+    "archiveWorkspace": "워크스페이스 보관",
+    "unarchiveWorkspace": "워크스페이스 보관 해제",
     "deleteWorkspace": "워크스페이스 삭제",
     "unlink": "연결 해제",
     "delete": "삭제",

--- a/frontend/src/i18n/locales/zh-Hans/common.json
+++ b/frontend/src/i18n/locales/zh-Hans/common.json
@@ -165,6 +165,10 @@
     "pin": "置顶",
     "unpin": "取消置顶",
     "archive": "归档",
+    "unarchive": "取消归档",
+    "archiveConfirmMessage": "确定要归档此工作区吗？它将被移至归档部分。",
+    "unarchiveConfirmMessage": "确定要取消归档此工作区吗？它将被移回活跃部分。",
+    "archiveError": "归档工作区失败",
     "more": "更多操作",
     "rename": {
       "title": "重命名工作区",
@@ -175,6 +179,8 @@
       "renaming": "正在重命名..."
     },
     "unlinkFromIssue": "从问题取消关联",
+    "archiveWorkspace": "归档工作区",
+    "unarchiveWorkspace": "取消归档工作区",
     "deleteWorkspace": "删除工作区",
     "unlink": "取消关联",
     "delete": "删除",

--- a/frontend/src/i18n/locales/zh-Hans/common.json
+++ b/frontend/src/i18n/locales/zh-Hans/common.json
@@ -390,6 +390,7 @@
       "rename-workspace": "重命名工作区",
       "pin-workspace": "置顶/取消置顶工作区",
       "archive-workspace": "归档工作区",
+      "unarchive-workspace": "取消归档工作区",
       "delete-workspace": "删除工作区",
       "toggle-changes-mode": "切换更改面板",
       "toggle-logs-mode": "切换日志面板",

--- a/frontend/src/i18n/locales/zh-Hant/common.json
+++ b/frontend/src/i18n/locales/zh-Hant/common.json
@@ -390,6 +390,7 @@
       "rename-workspace": "重新命名工作區",
       "pin-workspace": "釘選/取消釘選工作區",
       "archive-workspace": "封存工作區",
+      "unarchive-workspace": "取消封存工作區",
       "delete-workspace": "刪除工作區",
       "toggle-changes-mode": "切換變更面板",
       "toggle-logs-mode": "切換日誌面板",

--- a/frontend/src/i18n/locales/zh-Hant/common.json
+++ b/frontend/src/i18n/locales/zh-Hant/common.json
@@ -165,6 +165,10 @@
     "pin": "釘選",
     "unpin": "取消釘選",
     "archive": "封存",
+    "unarchive": "取消封存",
+    "archiveConfirmMessage": "確定要封存此工作區嗎？它將被移至封存區。",
+    "unarchiveConfirmMessage": "確定要取消封存此工作區嗎？它將被移回使用中區域。",
+    "archiveError": "封存工作區失敗",
     "more": "更多操作",
     "rename": {
       "title": "重新命名工作區",
@@ -175,6 +179,8 @@
       "renaming": "正在重新命名..."
     },
     "unlinkFromIssue": "從問題取消關聯",
+    "archiveWorkspace": "封存工作區",
+    "unarchiveWorkspace": "取消封存工作區",
     "deleteWorkspace": "刪除工作區",
     "unlink": "取消關聯",
     "delete": "刪除",


### PR DESCRIPTION
Currently it's only possible to delete workspaces in the IssueWorkspaceCard. This PR adds quick archiving and unarchiving as well.

<img width="468" height="208" alt="image" src="https://github.com/user-attachments/assets/4f40dd26-d064-45dd-97e6-cba8cd040501" />
