### PR TITLE
Fix Copy Raw Logs by removing duplicate LogsPanelProvider (Vibe Kanban)

### DIFF
--- a/frontend/src/components/ui-new/containers/WorkspacesLayout.tsx
+++ b/frontend/src/components/ui-new/containers/WorkspacesLayout.tsx
@@ -6,7 +6,6 @@ import { usePageTitle } from '@/hooks/usePageTitle';
 import { ExecutionProcessesProvider } from '@/contexts/ExecutionProcessesContext';
 import { CreateModeProvider } from '@/contexts/CreateModeContext';
 import { ReviewProvider } from '@/contexts/ReviewProvider';
-import { LogsPanelProvider } from '@/contexts/LogsPanelContext';
 import { ChangesViewProvider } from '@/contexts/ChangesViewContext';
 import { WorkspacesSidebarContainer } from '@/components/ui-new/containers/WorkspacesSidebarContainer';
 import { LogsContentContainer } from '@/components/ui-new/containers/LogsContentContainer';
@@ -122,84 +121,82 @@ export function WorkspacesLayout() {
 
   const mainContent = (
     <ReviewProvider attemptId={selectedWorkspace?.id}>
-      <LogsPanelProvider>
-        <ChangesViewProvider>
-          <div className="flex h-full">
-            <Group
-              orientation="horizontal"
-              className="flex-1 min-w-0 h-full"
-              defaultLayout={defaultLayout}
-              onLayoutChange={onLayoutChange}
-            >
-              {isLeftMainPanelVisible && (
-                <Panel
-                  id="left-main"
-                  minSize="20%"
-                  className="min-w-0 h-full overflow-hidden"
-                >
-                  {isCreateMode ? (
-                    <CreateChatBoxContainer onWorkspaceCreated={null} />
-                  ) : (
-                    <WorkspacesMainContainer
-                      ref={mainContainerRef}
-                      selectedWorkspace={selectedWorkspace ?? null}
-                      selectedSession={selectedSession}
-                      sessions={sessions}
-                      onSelectSession={selectSession}
-                      isLoading={isLoading}
-                      isNewSessionMode={isNewSessionMode}
-                      onStartNewSession={startNewSession}
+      <ChangesViewProvider>
+        <div className="flex h-full">
+          <Group
+            orientation="horizontal"
+            className="flex-1 min-w-0 h-full"
+            defaultLayout={defaultLayout}
+            onLayoutChange={onLayoutChange}
+          >
+            {isLeftMainPanelVisible && (
+              <Panel
+                id="left-main"
+                minSize="20%"
+                className="min-w-0 h-full overflow-hidden"
+              >
+                {isCreateMode ? (
+                  <CreateChatBoxContainer onWorkspaceCreated={null} />
+                ) : (
+                  <WorkspacesMainContainer
+                    ref={mainContainerRef}
+                    selectedWorkspace={selectedWorkspace ?? null}
+                    selectedSession={selectedSession}
+                    sessions={sessions}
+                    onSelectSession={selectSession}
+                    isLoading={isLoading}
+                    isNewSessionMode={isNewSessionMode}
+                    onStartNewSession={startNewSession}
+                  />
+                )}
+              </Panel>
+            )}
+
+            {isLeftMainPanelVisible && rightMainPanelMode !== null && (
+              <Separator
+                id="main-separator"
+                className="w-1 bg-transparent hover:bg-brand/50 transition-colors cursor-col-resize"
+              />
+            )}
+
+            {rightMainPanelMode !== null && (
+              <Panel
+                id="right-main"
+                minSize="20%"
+                className="min-w-0 h-full overflow-hidden"
+              >
+                {rightMainPanelMode === RIGHT_MAIN_PANEL_MODES.CHANGES &&
+                  selectedWorkspace?.id && (
+                    <ChangesPanelContainer
+                      className=""
+                      attemptId={selectedWorkspace.id}
                     />
                   )}
-                </Panel>
-              )}
-
-              {isLeftMainPanelVisible && rightMainPanelMode !== null && (
-                <Separator
-                  id="main-separator"
-                  className="w-1 bg-transparent hover:bg-brand/50 transition-colors cursor-col-resize"
-                />
-              )}
-
-              {rightMainPanelMode !== null && (
-                <Panel
-                  id="right-main"
-                  minSize="20%"
-                  className="min-w-0 h-full overflow-hidden"
-                >
-                  {rightMainPanelMode === RIGHT_MAIN_PANEL_MODES.CHANGES &&
-                    selectedWorkspace?.id && (
-                      <ChangesPanelContainer
-                        className=""
-                        attemptId={selectedWorkspace.id}
-                      />
-                    )}
-                  {rightMainPanelMode === RIGHT_MAIN_PANEL_MODES.LOGS && (
-                    <LogsContentContainer className="" />
+                {rightMainPanelMode === RIGHT_MAIN_PANEL_MODES.LOGS && (
+                  <LogsContentContainer className="" />
+                )}
+                {rightMainPanelMode === RIGHT_MAIN_PANEL_MODES.PREVIEW &&
+                  selectedWorkspace?.id && (
+                    <PreviewBrowserContainer
+                      attemptId={selectedWorkspace.id}
+                      className=""
+                    />
                   )}
-                  {rightMainPanelMode === RIGHT_MAIN_PANEL_MODES.PREVIEW &&
-                    selectedWorkspace?.id && (
-                      <PreviewBrowserContainer
-                        attemptId={selectedWorkspace.id}
-                        className=""
-                      />
-                    )}
-                </Panel>
-              )}
-            </Group>
-
-            {isRightSidebarVisible && !isCreateMode && (
-              <div className="w-[300px] shrink-0 h-full overflow-hidden">
-                <RightSidebar
-                  rightMainPanelMode={rightMainPanelMode}
-                  selectedWorkspace={selectedWorkspace}
-                  repos={repos}
-                />
-              </div>
+              </Panel>
             )}
-          </div>
-        </ChangesViewProvider>
-      </LogsPanelProvider>
+          </Group>
+
+          {isRightSidebarVisible && !isCreateMode && (
+            <div className="w-[300px] shrink-0 h-full overflow-hidden">
+              <RightSidebar
+                rightMainPanelMode={rightMainPanelMode}
+                selectedWorkspace={selectedWorkspace}
+                repos={repos}
+              />
+            </div>
+          )}
+        </div>
+      </ChangesViewProvider>
     </ReviewProvider>
   );
 


### PR DESCRIPTION
## Summary
This PR fixes a context wiring issue that caused **Copy Raw Logs** to fail in the new workspace UI.

## What changed
- Removed a duplicate `LogsPanelProvider` wrapper from `frontend/src/components/ui-new/containers/WorkspacesLayout.tsx`.
- Kept the existing scope-level provider in `NewDesignScope` as the single source of truth for logs panel state.
- No functional logic was added to `CopyRawLogs`; this change fixes state visibility by correcting provider composition.

## Why this was needed
`CopyRawLogs` reads logs state via `ActionsContext`/`useLogsPanel`, but `WorkspacesLayout` also had a nested `LogsPanelProvider`. That split state into two context instances:
- logs UI wrote to the inner provider
- action execution and visibility could read from the outer provider

As a result, `CopyRawLogs` could see empty/null logs even when logs were visible in the panel.

## Implementation details
- The fix is intentionally minimal: remove the inner provider instead of adding workaround logic.
- This ensures all logs-related readers/writers in the workspaces path share one context instance.
- The large diff is mostly JSX indentation/structure movement from removing the wrapper; behavior change is scoped to context wiring.

- [x] tested

This PR was written using [Vibe Kanban](https://vibekanban.com)
