### PR TITLE
fix: suppress codex_core tracing output from server logs (Vibe Kanban)

### DIFF
--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -36,7 +36,7 @@ async fn main() -> Result<(), VibeKanbanError> {
 
     let log_level = std::env::var("RUST_LOG").unwrap_or_else(|_| "info".to_string());
     let filter_string = format!(
-        "warn,server={level},services={level},db={level},executors={level},deployment={level},local_deployment={level},utils={level}",
+        "warn,server={level},services={level},db={level},executors={level},deployment={level},local_deployment={level},utils={level},codex_core=off",
         level = log_level
     );
     let env_filter = EnvFilter::try_new(filter_string).expect("Failed to create tracing filter");


### PR DESCRIPTION
## Summary

- Adds `codex_core=off` directive to the tracing `EnvFilter` in `crates/server/src/main.rs`
- This suppresses all tracing output from the `codex_core` crate, which produces noisy internal logs when the Codex executor runs in-process

## Why

The `codex_core` library emits verbose tracing output that clutters the server logs and makes it harder to read application-level log messages. Since these are internal library logs not actionable by server operators, they are best suppressed entirely.

## Implementation details

The fix appends `codex_core=off` to the existing per-module filter string that already selectively enables logging for first-party crates (`server`, `services`, `db`, `executors`, etc.). The `off` level completely disables all log output from the `codex_core` target.

- [x] Tested

This PR was written using [Vibe Kanban](https://vibekanban.com)