### PR TITLE
Skip repo selection when create-mode defaults are already set (Vibe Kanban)

### DIFF
--- a/frontend/src/components/ui-new/containers/CreateChatBoxContainer.tsx
+++ b/frontend/src/components/ui-new/containers/CreateChatBoxContainer.tsx
@@ -36,6 +36,7 @@ export function CreateChatBoxContainer({
     selectedProjectId,
     clearDraft,
     hasInitialValue,
+    hasResolvedInitialRepoDefaults,
     linkedIssue,
     clearLinkedIssue,
   } = useCreateMode();
@@ -51,9 +52,16 @@ export function CreateChatBoxContainer({
 
   useEffect(() => {
     if (!hasInitialValue || hasInitializedStep) return;
+    if (!hasSelectedRepos && !hasResolvedInitialRepoDefaults) return;
+
     setIsSelectingRepos(!hasSelectedRepos);
     setHasInitializedStep(true);
-  }, [hasInitialValue, hasInitializedStep, hasSelectedRepos]);
+  }, [
+    hasInitialValue,
+    hasInitializedStep,
+    hasSelectedRepos,
+    hasResolvedInitialRepoDefaults,
+  ]);
 
   const showRepoPickerStep = !hasSelectedRepos || isSelectingRepos;
   const showChatStep = hasSelectedRepos && !isSelectingRepos;

--- a/frontend/src/contexts/CreateModeContext.tsx
+++ b/frontend/src/contexts/CreateModeContext.tsx
@@ -25,6 +25,7 @@ interface CreateModeContextValue {
   clearRepos: () => void;
   targetBranches: Record<string, string | null>;
   setTargetBranch: (repoId: string, branch: string) => void;
+  hasResolvedInitialRepoDefaults: boolean;
   preferredExecutorConfig: ExecutorConfig | null;
   message: string;
   setMessage: (message: string) => void;
@@ -96,6 +97,7 @@ export function CreateModeProvider({
       clearRepos: state.clearRepos,
       targetBranches: state.targetBranches,
       setTargetBranch: state.setTargetBranch,
+      hasResolvedInitialRepoDefaults: state.hasResolvedInitialRepoDefaults,
       preferredExecutorConfig: state.preferredExecutorConfig,
       message: state.message,
       setMessage: state.setMessage,
@@ -113,6 +115,7 @@ export function CreateModeProvider({
       state.clearRepos,
       state.targetBranches,
       state.setTargetBranch,
+      state.hasResolvedInitialRepoDefaults,
       state.preferredExecutorConfig,
       state.message,
       state.setMessage,

--- a/frontend/src/hooks/useCreateModeState.ts
+++ b/frontend/src/hooks/useCreateModeState.ts
@@ -219,6 +219,7 @@ interface UseCreateModeStateResult {
   selectedProjectId: string | null;
   repos: Repo[];
   targetBranches: Record<string, string | null>;
+  hasResolvedInitialRepoDefaults: boolean;
   preferredExecutorConfig: ExecutorConfig | null;
   message: string;
   isLoading: boolean;
@@ -338,11 +339,19 @@ export function useCreateModeState({
     !localWorkspacesLoading &&
     (!state.linkedIssue || !remoteWorkspacesLoading);
 
-  const { preferredRepos, preferredExecutorConfig } =
+  const { preferredRepos, preferredExecutorConfig, hasResolvedPreferredRepos } =
     useWorkspaceCreateDefaults({
       sourceWorkspaceId,
       enabled: shouldLoadWorkspaceDefaults,
     });
+
+  const hasResolvedInitialRepoDefaults =
+    (state.phase === 'ready' &&
+      !localWorkspacesLoading &&
+      (!state.linkedIssue || !remoteWorkspacesLoading) &&
+      hasResolvedPreferredRepos &&
+      (preferredRepos.length === 0 || state.repos.length > 0)) ||
+    state.repos.length > 0;
 
   useEffect(() => {
     if (state.phase !== 'ready') return;
@@ -544,6 +553,7 @@ export function useCreateModeState({
     selectedProjectId: state.projectId,
     repos,
     targetBranches,
+    hasResolvedInitialRepoDefaults,
     preferredExecutorConfig,
     message: state.message,
     isLoading: scratchLoading,

--- a/frontend/src/hooks/useWorkspaceCreateDefaults.ts
+++ b/frontend/src/hooks/useWorkspaceCreateDefaults.ts
@@ -19,15 +19,18 @@ interface WorkspaceCreateDefaultsData {
 interface UseWorkspaceCreateDefaultsResult {
   preferredRepos: RepoWithTargetBranch[];
   preferredExecutorConfig: ExecutorConfig | null;
+  hasResolvedPreferredRepos: boolean;
 }
 
 export function useWorkspaceCreateDefaults({
   sourceWorkspaceId,
   enabled,
 }: UseWorkspaceCreateDefaultsOptions): UseWorkspaceCreateDefaultsResult {
-  const { data } = useQuery<WorkspaceCreateDefaultsData>({
+  const queryEnabled = enabled && !!sourceWorkspaceId;
+
+  const { data, status } = useQuery<WorkspaceCreateDefaultsData>({
     queryKey: ['workspaceCreateDefaults', sourceWorkspaceId],
-    enabled: enabled && !!sourceWorkspaceId,
+    enabled: queryEnabled,
     queryFn: async () => {
       const [repos, workspaceWithSession] = await Promise.all([
         attemptsApi.getRepos(sourceWorkspaceId!),
@@ -58,5 +61,6 @@ export function useWorkspaceCreateDefaults({
   return {
     preferredRepos: data?.repos ?? [],
     preferredExecutorConfig,
+    hasResolvedPreferredRepos: !queryEnabled || status !== 'pending',
   };
 }


### PR DESCRIPTION
## Summary
When creating a new workspace, the UI no longer always starts on the repo/branch picker. If default repos + branches are already available, create mode now opens directly on the chat step.

## What changed
- Added a default-repo resolution signal in `useWorkspaceCreateDefaults`:
  - Introduced `hasResolvedPreferredRepos`.
  - Uses React Query state plus `queryEnabled` to indicate when preferred repo loading is settled.
- Added a create-mode initialization gate in `useCreateModeState`:
  - Introduced `hasResolvedInitialRepoDefaults`.
  - Waits until relevant default sources are resolved before the initial step is chosen.
  - Handles both cases: defaults available (repos become populated) and no defaults available.
- Exposed this state through `CreateModeContext`:
  - Added `hasResolvedInitialRepoDefaults` to the context value.
- Updated `CreateChatBoxContainer` initial step logic:
  - Initialization now waits for repo-default resolution when no repos are selected yet.
  - If repos are present after defaults resolve, create mode starts on chat.
  - If not, it starts on repo picker as before.

## Why
The previous flow initialized the step selection too early, before async default repo/branch loading finished. That caused users to be pushed into repo selection even when defaults were already configured. This change aligns behavior with the intended UX: skip repo picking when defaults are ready.

## Implementation details
- The fix is intentionally scoped and readable:
  - No migration logic.
  - No behavioral changes to the repo picker itself.
  - Only the initialization timing and state wiring were adjusted.
- Existing manual "Edit repos" and branch selection behavior remain unchanged.

This PR was written using [Vibe Kanban](https://vibekanban.com)
