### PR TITLE
Default model permission policy to AUTO in selector (Vibe Kanban)

### DIFF
--- a/frontend/src/components/ui-new/containers/ModelSelectorContainer.tsx
+++ b/frontend/src/components/ui-new/containers/ModelSelectorContainer.tsx
@@ -163,11 +163,16 @@ export function ModelSelectorContainer({
 
   const supportsPermissions = (config?.permissions.length ?? 0) > 0;
 
+  const defaultPermissionPolicy = config?.permissions.includes(
+    PermissionPolicy.AUTO
+  )
+    ? PermissionPolicy.AUTO
+    : null;
   const permissionPolicy = supportsPermissions
     ? executorConfig?.permission_policy &&
       config?.permissions.includes(executorConfig.permission_policy)
       ? executorConfig.permission_policy
-      : null
+      : defaultPermissionPolicy
     : null;
 
   // LRU persistence (on popover close)


### PR DESCRIPTION
## Changes
- Updated `frontend/src/components/ui-new/containers/ModelSelectorContainer.tsx` so permission policy selection has an explicit default.
- `permissionPolicy` now resolves to a valid `executorConfig.permission_policy` when present; otherwise it falls back to `PermissionPolicy.AUTO` when supported by the backend config.

## Why
- The previous fallback was effectively `null`, which caused the permissions dropdown to render without an explicit selection.
- This change makes the selector consistently start on Auto by default as requested.

## Implementation details
- Added a `defaultPermissionPolicy` variable that is `PermissionPolicy.AUTO` only if included in `config.permissions`.
- Preserved existing behavior for invalid or unsupported overrides by keeping the same validation path.
- Kept the change scoped to UI state derivation only; no API or type changes were required.

This PR was written using [Vibe Kanban](https://vibekanban.com)
