### PR TITLE
Fix typeahead menu jumping during typing (Vibe Kanban)

### DIFF
--- a/frontend/src/components/ui/wysiwyg/plugins/typeahead-menu-components.tsx
+++ b/frontend/src/components/ui/wysiwyg/plugins/typeahead-menu-components.tsx
@@ -116,9 +116,16 @@ function TypeaheadMenuRoot({
   const syncPlacement = useCallback(() => {
     setPlacement((previous) => {
       const next = getPlacement(anchorEl, previous.side);
+      // Use a tolerance for maxHeight to prevent re-renders from sub-pixel
+      // anchor rect changes. Without this, tiny fluctuations in the anchor
+      // position cause maxHeight to change by 1-2px, triggering a state
+      // update → re-render → @floating-ui reposition cycle that manifests
+      // as the popover visually jumping.
+      const maxHeightStable =
+        Math.abs(next.maxHeight - previous.maxHeight) < 10;
       if (
         next.side === previous.side &&
-        next.maxHeight === previous.maxHeight &&
+        maxHeightStable &&
         next.alignOffset === previous.alignOffset
       ) {
         return previous;


### PR DESCRIPTION
## Summary

Fixes an intermittent bug where the typeahead menu (triggered by `@` or `/`) visually jumps upward briefly during typing before snapping back to its correct position.

## Problem

After the typeahead plugin refactor in #2735, `maxHeight` was moved from a CSS variable on the inner scroll area to an inline style on the `PopoverContent` itself. This created a feedback loop:

1. On each keystroke, `syncPlacement` runs (via an unconditional `useEffect`) and recalculates `maxHeight` from the anchor element's bounding rect
2. Sub-pixel fluctuations in the anchor rect (caused by Lexical repositioning the anchor div) produce tiny `maxHeight` changes (1-2px) after `Math.floor`
3. The exact equality check (`next.maxHeight === previous.maxHeight`) treats these as meaningful changes, triggering a React state update
4. The state update causes a re-render, which updates the `PopoverContent` inline `maxHeight` style
5. `@floating-ui`'s `ResizeObserver` detects the size change on the floating element and calls `computePosition` to reposition the popover
6. This manifests as a visible single-frame "jump" of the menu

## Fix

Added a **10px tolerance** to the `maxHeight` comparison in `syncPlacement`. Small fluctuations (< 10px) no longer trigger state updates, breaking the re-render → reposition cycle. The popover position stays stable during typing while still responding to meaningful layout changes (viewport resize, scrolling, side flips).

## Changes

- `frontend/src/components/ui/wysiwyg/plugins/typeahead-menu-components.tsx`: Replace exact `maxHeight` equality check with a tolerance-based comparison (`Math.abs(delta) < 10`)

---

This PR was written using [Vibe Kanban](https://vibekanban.com)