### PR TITLE
Bump Claude Code to 2.1.45 and handle new message types (Vibe Kanban)

### DIFF
--- a/crates/executors/src/executors/claude.rs
+++ b/crates/executors/src/executors/claude.rs
@@ -1164,7 +1164,7 @@ impl ClaudeLogProcessor {
                             patches.push(add_system_message(status.clone(), entry_index_provider));
                         }
                     }
-                    Some("compact_boundary") => {}
+                    Some("compact_boundary") | Some("task_started") => {}
                     Some(subtype) => {
                         let entry = NormalizedEntry {
                             timestamp: None,


### PR DESCRIPTION
## Summary

Bumps `@anthropic-ai/claude-code` from 2.1.41 to 2.1.45 and handles two new message types introduced in recent Claude Code versions.

## Changes

- **Bump claude-code to 2.1.45** — Updates the NPX package version in the executor command.
- **Handle `rate_limit_event` message type** — Adds a `RateLimitEvent` variant to the `ClaudeJson` enum so these messages are properly parsed and silently ignored, instead of surfacing as noisy "Unrecognized JSON message" entries in the conversation.
- **Silence `task_started` system messages** — Background task notifications (`system` messages with `subtype: "task_started"`) arrive out of order on stdout (after task completion and the assistant's response). Since they add no value — the tool_use entry already shows the task was launched — they are now silently ignored alongside `compact_boundary`.

## Test plan

- [x] tested

---

This PR was written using [Vibe Kanban](https://vibekanban.com)