### PR TITLE
Standardize workspace creation navigation via callback handlers (Vibe Kanban)

### DIFF
--- a/frontend/src/components/ui-new/containers/CreateChatBoxContainer.tsx
+++ b/frontend/src/components/ui-new/containers/CreateChatBoxContainer.tsx
@@ -17,7 +17,13 @@ function getRepoDisplayName(repo: Repo) {
   return repo.display_name || repo.name;
 }
 
-export function CreateChatBoxContainer() {
+interface CreateChatBoxContainerProps {
+  onWorkspaceCreated: (workspaceId: string) => void;
+}
+
+export function CreateChatBoxContainer({
+  onWorkspaceCreated,
+}: CreateChatBoxContainerProps) {
   const { t } = useTranslation('common');
   const { profiles, config } = useUserSystem();
   const {
@@ -209,7 +215,7 @@ export function CreateChatBoxContainer() {
 
     const { title } = splitMessageToTitleDescription(message);
 
-    await createWorkspace.mutateAsync({
+    const result = await createWorkspace.mutateAsync({
       data: {
         executor_profile_id: effectiveProfileId,
         name: title,
@@ -233,6 +239,10 @@ export function CreateChatBoxContainer() {
         : undefined,
     });
 
+    if (result.workspace) {
+      onWorkspaceCreated(result.workspace.id);
+    }
+
     // Clear attachments and draft after successful creation
     clearAttachments();
     await clearDraft();
@@ -244,6 +254,7 @@ export function CreateChatBoxContainer() {
     repos,
     targetBranches,
     createWorkspace,
+    onWorkspaceCreated,
     clearAttachments,
     clearDraft,
     linkedIssue,

--- a/frontend/src/components/ui-new/containers/ProjectRightSidebarContainer.tsx
+++ b/frontend/src/components/ui-new/containers/ProjectRightSidebarContainer.tsx
@@ -273,6 +273,7 @@ function WorkspaceSessionPanel({
 }
 
 export function ProjectRightSidebarContainer() {
+  const navigate = useNavigate();
   const { getIssue } = useProjectContext();
   const {
     issueId,
@@ -280,6 +281,7 @@ export function ProjectRightSidebarContainer() {
     draftId,
     isWorkspaceCreateMode,
     openIssue,
+    openIssueWorkspace,
     closePanel,
   } = useKanbanNavigation();
 
@@ -288,6 +290,18 @@ export function ProjectRightSidebarContainer() {
       openIssue(targetIssueId);
     },
     [openIssue]
+  );
+
+  const handleWorkspaceCreated = useCallback(
+    (createdWorkspaceId: string) => {
+      if (issueId) {
+        openIssueWorkspace(issueId, createdWorkspaceId);
+        return;
+      }
+
+      navigate(`/workspaces/${createdWorkspaceId}`);
+    },
+    [issueId, openIssueWorkspace, navigate]
   );
 
   if (isWorkspaceCreateMode && draftId) {
@@ -304,7 +318,7 @@ export function ProjectRightSidebarContainer() {
         onClose={closePanel}
       >
         <CreateModeProvider key={draftId} draftId={draftId}>
-          <CreateChatBoxContainer />
+          <CreateChatBoxContainer onWorkspaceCreated={handleWorkspaceCreated} />
         </CreateModeProvider>
       </WorkspaceCreatePanel>
     );

--- a/frontend/src/components/ui-new/containers/WorkspacesLayout.tsx
+++ b/frontend/src/components/ui-new/containers/WorkspacesLayout.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
 import { Group, Layout, Panel, Separator } from 'react-resizable-panels';
 import { useWorkspaceContext } from '@/contexts/WorkspaceContext';
 import { usePageTitle } from '@/hooks/usePageTitle';
@@ -30,6 +31,7 @@ import {
 const WORKSPACES_GUIDE_ID = 'workspaces-guide';
 
 export function WorkspacesLayout() {
+  const navigate = useNavigate();
   const {
     workspaceId,
     workspace: selectedWorkspace,
@@ -54,6 +56,13 @@ export function WorkspacesLayout() {
   const handleScrollToBottom = useCallback(() => {
     mainContainerRef.current?.scrollToBottom();
   }, []);
+
+  const handleWorkspaceCreated = useCallback(
+    (workspaceId: string) => {
+      navigate(`/workspaces/${workspaceId}`);
+    },
+    [navigate]
+  );
 
   // Use workspace-specific panel state (pass undefined when in create mode)
   const {
@@ -136,7 +145,9 @@ export function WorkspacesLayout() {
                 className="min-w-0 h-full overflow-hidden"
               >
                 {isCreateMode ? (
-                  <CreateChatBoxContainer />
+                  <CreateChatBoxContainer
+                    onWorkspaceCreated={handleWorkspaceCreated}
+                  />
                 ) : (
                   <WorkspacesMainContainer
                     ref={mainContainerRef}

--- a/frontend/src/hooks/useCreateWorkspace.ts
+++ b/frontend/src/hooks/useCreateWorkspace.ts
@@ -1,5 +1,4 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { useNavigate } from 'react-router-dom';
 import { attemptsApi } from '@/lib/api';
 import { workspaceSummaryKeys } from '@/components/ui-new/hooks/useWorkspaces';
 import type { CreateAndStartWorkspaceRequest } from 'shared/types';
@@ -14,7 +13,6 @@ interface CreateWorkspaceParams {
 
 export function useCreateWorkspace() {
   const queryClient = useQueryClient();
-  const navigate = useNavigate();
 
   const createWorkspace = useMutation({
     mutationFn: async ({ data, linkToIssue }: CreateWorkspaceParams) => {
@@ -31,14 +29,9 @@ export function useCreateWorkspace() {
 
       return { workspace };
     },
-    onSuccess: ({ workspace }) => {
+    onSuccess: () => {
       // Invalidate workspace summaries so they refresh with the new workspace included
       queryClient.invalidateQueries({ queryKey: workspaceSummaryKeys.all });
-
-      // Navigate to the new workspace (or let caller handle in project sidebar)
-      if (workspace) {
-        navigate(`/workspaces/${workspace.id}`);
-      }
     },
     onError: (err) => {
       console.error('Failed to create workspace:', err);


### PR DESCRIPTION
## What changed
- Removed direct navigation from `useCreateWorkspace` so workspace creation is now a pure action layer: it creates (and optionally links) the workspace, then only refreshes workspace-summary cache.
- Added a required `onWorkspaceCreated` callback to `CreateChatBoxContainer` and invoked it after successful creation with the new workspace ID.
- Updated `WorkspacesLayout` to pass a callback that navigates to `/workspaces/{workspaceId}` in the standard workspaces flow.
- Updated `ProjectRightSidebarContainer` to pass a callback that keeps creation in-sidebar by navigating to the linked issue workspace route using `openIssueWorkspace(issueId, workspaceId)`, with a fallback to `/workspaces/{workspaceId}` when `issueId` is unavailable.

## Why
The task was to avoid navigating away from the project right sidebar when creating a workspace there and instead keep users in the sidebar view. The previous implementation mixed UI navigation with data creation logic and used route-specific behavior in the hook. This PR makes navigation ownership explicit at the caller level so behavior stays aligned with context.

## Implementation details
- Introduced a reusable callback-based post-create pattern to avoid one-size-fits-all routing.
- Kept the global workspaces create path behavior unchanged (`WorkspacesLayout`) while adding sidebar-specific navigation in `ProjectRightSidebarContainer`.
- Kept existing query invalidation behavior intact so workspace summaries refresh immediately after creation.

This PR was written using [Vibe Kanban](https://vibekanban.com)
