### PR TITLE
Use executor_config in workspace create flow and fix defaults fallback

### DIFF
--- a/crates/server/src/mcp/task_server/tools/task_attempts.rs
+++ b/crates/server/src/mcp/task_server/tools/task_attempts.rs
@@ -1,6 +1,6 @@
 use std::str::FromStr;
 
-use executors::{executors::BaseCodingAgent, profile::ExecutorProfileId};
+use executors::{executors::BaseCodingAgent, profile::ExecutorConfig};
 use rmcp::{
     ErrorData, handler::server::tool::Parameters, model::CallToolResult, schemars, tool,
     tool_router,
@@ -184,9 +184,13 @@ impl TaskServer {
             name: Some(title.clone()),
             repos: workspace_repos,
             linked_issue,
-            executor_profile_id: ExecutorProfileId {
+            executor_config: ExecutorConfig {
                 executor: base_executor,
                 variant,
+                model_id: None,
+                agent_id: None,
+                reasoning_id: None,
+                permission_policy: None,
             },
             prompt: workspace_prompt,
         };

--- a/crates/server/src/routes/task_attempts.rs
+++ b/crates/server/src/routes/task_attempts.rs
@@ -40,7 +40,7 @@ use executors::{
         script::{ScriptContext, ScriptRequest, ScriptRequestLanguage},
     },
     executors::{CodingAgent, ExecutorError},
-    profile::{ExecutorConfigs, ExecutorProfileId},
+    profile::{ExecutorConfig, ExecutorConfigs, ExecutorProfileId},
 };
 use git::{ConflictOp, GitCliError, GitService, GitServiceError};
 use git2::BranchType;
@@ -1841,7 +1841,7 @@ pub struct CreateAndStartWorkspaceRequest {
     pub name: Option<String>,
     pub repos: Vec<WorkspaceRepoInput>,
     pub linked_issue: Option<LinkedIssueInfo>,
-    pub executor_profile_id: ExecutorProfileId,
+    pub executor_config: ExecutorConfig,
     pub prompt: String,
 }
 
@@ -1936,7 +1936,7 @@ pub async fn create_and_start_workspace(
         name,
         repos,
         linked_issue,
-        executor_profile_id,
+        executor_config,
         prompt,
     } = payload;
 
@@ -2038,15 +2038,15 @@ pub async fn create_and_start_workspace(
 
     let execution_process = deployment
         .container()
-        .start_workspace(&workspace, executor_profile_id.clone(), workspace_prompt)
+        .start_workspace(&workspace, executor_config.clone(), workspace_prompt)
         .await?;
 
     deployment
         .track_if_analytics_allowed(
             "workspace_created_and_started",
             serde_json::json!({
-                "executor": &executor_profile_id.executor,
-                "variant": &executor_profile_id.variant,
+                "executor": &executor_config.executor,
+                "variant": &executor_config.variant,
                 "workspace_id": workspace.id.to_string(),
             }),
         )

--- a/crates/services/src/services/container.rs
+++ b/crates/services/src/services/container.rs
@@ -1086,7 +1086,7 @@ pub trait ContainerService {
     async fn start_workspace(
         &self,
         workspace: &Workspace,
-        executor_profile_id: ExecutorProfileId,
+        executor_config: ExecutorConfig,
         prompt: String,
     ) -> Result<ExecutionProcess, ContainerError> {
         // Create container
@@ -1102,14 +1102,12 @@ pub trait ContainerService {
         let session = Session::create(
             &self.db().pool,
             &CreateSession {
-                executor: Some(executor_profile_id.executor.to_string()),
+                executor: Some(executor_config.executor.to_string()),
             },
             Uuid::new_v4(),
             workspace.id,
         )
         .await?;
-
-        let executor_config = ExecutorConfig::from(executor_profile_id);
 
         let repos_with_setup: Vec<_> = repos.iter().filter(|r| r.setup_script.is_some()).collect();
 

--- a/frontend/src/hooks/useCreateModeState.ts
+++ b/frontend/src/hooks/useCreateModeState.ts
@@ -341,11 +341,12 @@ export function useCreateModeState({
   const hasAppliedRepoDefaultsRef = useRef(false);
   const sourceWorkspaceId = useMemo(() => {
     if (state.linkedIssue) {
-      return getLatestWorkspaceIdForRemoteProject({
+      const linkedIssueWorkspaceId = getLatestWorkspaceIdForRemoteProject({
         remoteWorkspaces,
         localWorkspaceIds,
         remoteProjectId: state.linkedIssue.remoteProjectId,
       });
+      return linkedIssueWorkspaceId ?? lastWorkspaceId;
     }
     return lastWorkspaceId;
   }, [state.linkedIssue, remoteWorkspaces, localWorkspaceIds, lastWorkspaceId]);

--- a/frontend/src/hooks/useCreateWorkspace.ts
+++ b/frontend/src/hooks/useCreateWorkspace.ts
@@ -32,6 +32,8 @@ export function useCreateWorkspace() {
     onSuccess: () => {
       // Invalidate workspace summaries so they refresh with the new workspace included
       queryClient.invalidateQueries({ queryKey: workspaceSummaryKeys.all });
+      // Ensure create-mode defaults refetch the latest session/model selection.
+      queryClient.invalidateQueries({ queryKey: ['workspaceCreateDefaults'] });
     },
     onError: (err) => {
       console.error('Failed to create workspace:', err);

--- a/frontend/src/hooks/useExecutorConfig.ts
+++ b/frontend/src/hooks/useExecutorConfig.ts
@@ -299,13 +299,16 @@ export function useExecutorConfig({
         if ('model_id' in partial && !('reasoning_id' in partial)) {
           delete next.reasoning_id;
         }
+        const persistedConfig = executor.effective
+          ? {
+              ...next,
+              executor: executor.effective,
+              variant: variant.resolved,
+            }
+          : null;
         // Persist with current effective executor/variant
-        if (executor.effective) {
-          persist({
-            ...next,
-            executor: executor.effective,
-            variant: variant.resolved,
-          });
+        if (persistedConfig) {
+          persist(persistedConfig);
         }
         return next;
       });

--- a/frontend/src/hooks/useWorkspaceCreateDefaults.ts
+++ b/frontend/src/hooks/useWorkspaceCreateDefaults.ts
@@ -31,19 +31,22 @@ export function useWorkspaceCreateDefaults({
   const { data, status } = useQuery<WorkspaceCreateDefaultsData>({
     queryKey: ['workspaceCreateDefaults', sourceWorkspaceId],
     enabled: queryEnabled,
+    staleTime: 0,
+    refetchOnMount: 'always',
     queryFn: async () => {
       const [repos, workspaceWithSession] = await Promise.all([
         attemptsApi.getRepos(sourceWorkspaceId!),
         attemptsApi.getWithSession(sourceWorkspaceId!),
       ]);
 
-      return {
+      const result = {
         repos,
         sourceSessionId: workspaceWithSession.session?.id ?? undefined,
         sourceSessionExecutor:
           (workspaceWithSession.session
             ?.executor as ExecutorConfig['executor']) ?? null,
       };
+      return result;
     },
   });
 

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -324,7 +324,7 @@ export type GetPrCommentsError = { "type": "no_pr_attached" } | { "type": "cli_n
 
 export type GetPrCommentsQuery = { repo_id: string, };
 
-export type CreateAndStartWorkspaceRequest = { name: string | null, repos: Array<WorkspaceRepoInput>, linked_issue: LinkedIssueInfo | null, executor_profile_id: ExecutorProfileId, prompt: string, };
+export type CreateAndStartWorkspaceRequest = { name: string | null, repos: Array<WorkspaceRepoInput>, linked_issue: LinkedIssueInfo | null, executor_config: ExecutorConfig, prompt: string, };
 
 export type CreateAndStartWorkspaceResponse = { workspace: Workspace, execution_process: ExecutionProcess, };
 


### PR DESCRIPTION
## Summary
- switch workspace create-and-start to use executor_config as the API contract
- pass executor_config from create-mode frontend and through backend container start
- regenerate shared types for the breaking request-shape change
- fix linked-issue create-mode defaults to fall back to lastWorkspaceId when no project-matching workspace exists
- ensure create defaults queries refetch fresh data and are invalidated after workspace creation

## Validation
- pnpm run format
- pnpm run lint