### PR TITLE
Pin aws-lc-sys to 0.37.0 to unblock prerelease Windows builds (Vibe Kanban)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -539,9 +539,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.37.1"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b092fe214090261288111db7a2b2c2118e5a7f30dc2569f1732c4069a6840549"
+checksum = "5c34dda4df7017c8db52132f0f8a2e0f8161649d15723ed63fc00c82d0f2081a"
 dependencies = [
  "cc",
  "cmake",


### PR DESCRIPTION
## Summary
This PR pins `aws-lc-sys` from `0.37.1` back to `0.37.0` in `Cargo.lock`.

## What Changed
- Updated lock resolution for `aws-lc-sys`:
  - `0.37.1 -> 0.37.0`
  - corresponding checksum update in `Cargo.lock`
- No source code or workflow logic changes were made.

## Why
Pre-release workflows were repeatedly failing in the Windows cross-build jobs (`cargo xwin build`) during `aws-lc-sys` compilation. The failures were reproducible across multiple runs and not a one-off.

Based on the investigation of the failing run logs, the failure path was:
- `aws-lc-sys v0.37.1` picked up `TARGET_CC=clang-cl`
- applied that compiler to host Linux-target checks (`x86_64-unknown-linux-gnu`)
- produced `clang-cl` invocation/flag incompatibilities and exited with build error `101`

Pinning to `0.37.0` restores the previously working lock resolution and unblocks pre-release builds immediately.

## Implementation Details
- This is intentionally a minimal-risk unblock:
  - single-file lockfile change
  - no behavior changes to runtime code paths
  - no workflow config changes
- Follow-up work can revisit upgrading `aws-lc-sys` with a durable cross-compile env/toolchain fix.

This PR was written using [Vibe Kanban](https://vibekanban.com)
