### PR TITLE
fix: auto-install VS Code extension via CLI toggle

### DIFF
--- a/crates/server/src/routes/config.rs
+++ b/crates/server/src/routes/config.rs
@@ -475,9 +475,10 @@ async fn check_editor_availability(
     // Construct a minimal EditorConfig for checking
     let editor_config = EditorConfig::new(
         query.editor_type,
-        None, // custom_command
-        None, // remote_ssh_host
-        None, // remote_ssh_user
+        None,  // custom_command
+        None,  // remote_ssh_host
+        None,  // remote_ssh_user
+        false, // auto_install_extension
     );
 
     let available = editor_config.check_availability().await;

--- a/crates/services/src/services/config/versions/v2.rs
+++ b/crates/services/src/services/config/versions/v2.rs
@@ -18,6 +18,7 @@ impl From<v1::EditorConfig> for EditorConfig {
             old.custom_command,
             None,
             None,
+            true,
         )
     }
 }

--- a/frontend/src/components/ui-new/dialogs/settings/GeneralSettingsSection.tsx
+++ b/frontend/src/components/ui-new/dialogs/settings/GeneralSettingsSection.tsx
@@ -379,6 +379,27 @@ export function GeneralSettingsSection() {
             )}
           </>
         )}
+
+        {(draft?.editor.editor_type === EditorType.VS_CODE ||
+          draft?.editor.editor_type === EditorType.VS_CODE_INSIDERS ||
+          draft?.editor.editor_type === EditorType.CURSOR) && (
+          <SettingsCheckbox
+            id="auto-install-extension"
+            label={t('settings.general.editor.autoInstallExtension.label')}
+            description={t(
+              'settings.general.editor.autoInstallExtension.helper'
+            )}
+            checked={draft?.editor.auto_install_extension ?? true}
+            onChange={(checked) =>
+              updateDraft({
+                editor: {
+                  ...draft!.editor,
+                  auto_install_extension: checked,
+                },
+              })
+            }
+          />
+        )}
       </SettingsCard>
 
       {/* Default Coding Agent */}

--- a/frontend/src/i18n/locales/en/settings.json
+++ b/frontend/src/i18n/locales/en/settings.json
@@ -89,6 +89,10 @@
             "helper": "SSH username for the remote connection. If not set, VS Code will use your SSH config or prompt you."
           }
         },
+        "autoInstallExtension": {
+          "label": "Auto-install VS Code Extension",
+          "helper": "Automatically install the Vibe Kanban extension when opening a project in VS Code or Cursor. This runs in the background and has no effect if the extension is already installed."
+        },
         "availability": {
           "checking": "Checking availability...",
           "available": "Available",

--- a/frontend/src/i18n/locales/es/settings.json
+++ b/frontend/src/i18n/locales/es/settings.json
@@ -89,6 +89,10 @@
             "helper": "Nombre de usuario SSH para la conexión remota. Si no se establece, VS Code usará tu configuración SSH o te lo pedirá."
           }
         },
+        "autoInstallExtension": {
+          "label": "Auto-install VS Code Extension",
+          "helper": "Automatically install the Vibe Kanban extension when opening a project in VS Code or Cursor. This runs in the background and has no effect if the extension is already installed."
+        },
         "availability": {
           "checking": "Verificando disponibilidad...",
           "available": "Disponible",

--- a/frontend/src/i18n/locales/fr/settings.json
+++ b/frontend/src/i18n/locales/fr/settings.json
@@ -89,6 +89,10 @@
             "helper": "Nom d'utilisateur SSH pour la connexion distante. S'il n'est pas défini, VS Code utilisera votre config SSH ou vous demandera."
           }
         },
+        "autoInstallExtension": {
+          "label": "Auto-install VS Code Extension",
+          "helper": "Automatically install the Vibe Kanban extension when opening a project in VS Code or Cursor. This runs in the background and has no effect if the extension is already installed."
+        },
         "availability": {
           "checking": "Vérification de la disponibilité...",
           "available": "Disponible",

--- a/frontend/src/i18n/locales/ja/settings.json
+++ b/frontend/src/i18n/locales/ja/settings.json
@@ -89,6 +89,10 @@
             "helper": "リモート接続のSSHユーザー名。設定されていない場合、VS CodeはSSH設定を使用するか、入力を求めます。"
           }
         },
+        "autoInstallExtension": {
+          "label": "Auto-install VS Code Extension",
+          "helper": "Automatically install the Vibe Kanban extension when opening a project in VS Code or Cursor. This runs in the background and has no effect if the extension is already installed."
+        },
         "availability": {
           "checking": "利用可能性を確認中...",
           "available": "利用可能",

--- a/frontend/src/i18n/locales/ko/settings.json
+++ b/frontend/src/i18n/locales/ko/settings.json
@@ -89,6 +89,10 @@
             "helper": "원격 연결을 위한 SSH 사용자 이름입니다. 설정하지 않으면 VS Code가 SSH 설정을 사용하거나 입력을 요청합니다."
           }
         },
+        "autoInstallExtension": {
+          "label": "Auto-install VS Code Extension",
+          "helper": "Automatically install the Vibe Kanban extension when opening a project in VS Code or Cursor. This runs in the background and has no effect if the extension is already installed."
+        },
         "availability": {
           "checking": "사용 가능 여부 확인 중...",
           "available": "사용 가능",

--- a/frontend/src/i18n/locales/zh-Hans/settings.json
+++ b/frontend/src/i18n/locales/zh-Hans/settings.json
@@ -89,6 +89,10 @@
             "helper": "远程连接的 SSH 用户名。如果未设置，VS Code 将使用您的 SSH 配置或提示您输入。"
           }
         },
+        "autoInstallExtension": {
+          "label": "Auto-install VS Code Extension",
+          "helper": "Automatically install the Vibe Kanban extension when opening a project in VS Code or Cursor. This runs in the background and has no effect if the extension is already installed."
+        },
         "availability": {
           "checking": "检查可用性...",
           "available": "可用",

--- a/frontend/src/i18n/locales/zh-Hant/settings.json
+++ b/frontend/src/i18n/locales/zh-Hant/settings.json
@@ -89,6 +89,10 @@
             "helper": "遠端連線的 SSH 使用者名稱。若未設定，VS Code 將使用您的 SSH 設定或提示輸入。"
           }
         },
+        "autoInstallExtension": {
+          "label": "Auto-install VS Code Extension",
+          "helper": "Automatically install the Vibe Kanban extension when opening a project in VS Code or Cursor. This runs in the background and has no effect if the extension is already installed."
+        },
         "availability": {
           "checking": "檢查可用性...",
           "available": "可用",

--- a/frontend/src/pages/ui-new/LandingPage.tsx
+++ b/frontend/src/pages/ui-new/LandingPage.tsx
@@ -251,6 +251,7 @@ export function LandingPage() {
         editorType === EditorType.CUSTOM ? customCommand.trim() : null,
       remote_ssh_host: null,
       remote_ssh_user: null,
+      auto_install_extension: true,
     };
 
     trackRemoteOnboardingEvent(REMOTE_ONBOARDING_EVENTS.STAGE_SUBMITTED, {

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -452,7 +452,7 @@ export type NotificationConfig = { sound_enabled: boolean, push_enabled: boolean
 
 export enum ThemeMode { LIGHT = "LIGHT", DARK = "DARK", SYSTEM = "SYSTEM" }
 
-export type EditorConfig = { editor_type: EditorType, custom_command: string | null, remote_ssh_host: string | null, remote_ssh_user: string | null, };
+export type EditorConfig = { editor_type: EditorType, custom_command: string | null, remote_ssh_host: string | null, remote_ssh_user: string | null, auto_install_extension: boolean, };
 
 export enum EditorType { VS_CODE = "VS_CODE", VS_CODE_INSIDERS = "VS_CODE_INSIDERS", CURSOR = "CURSOR", WINDSURF = "WINDSURF", INTELLI_J = "INTELLI_J", ZED = "ZED", XCODE = "XCODE", GOOGLE_ANTIGRAVITY = "GOOGLE_ANTIGRAVITY", CUSTOM = "CUSTOM" }
 


### PR DESCRIPTION
## Summary
- replace file-based `.vscode/extensions.json` recommendations with fire-and-forget CLI install (`--install-extension bloop.vibe-kanban`) to avoid dirty git worktrees
- add `editor.auto_install_extension` config (default `true`) and wire it through Rust config, migration call sites, generated shared types, and onboarding defaults
- add a Settings toggle (VS Code / VS Code Insiders / Cursor only) plus i18n strings in all supported locales

## Verification
- `pnpm run backend:check`
- `pnpm run check`
- `pnpm run lint`
- `pnpm run generate-types:check`
- `pnpm run format`

Closes #2676