### PR TITLE
Fix signature_delta mismatch warning in Claude streaming (Vibe Kanban)

### DIFF
--- a/crates/executors/src/executors/claude.rs
+++ b/crates/executors/src/executors/claude.rs
@@ -1990,6 +1990,9 @@ impl StreamingContentState {
             ) => {
                 self.buffer.push_str(thinking);
             }
+            // Signature deltas are sent at the end of thinking blocks for verification;
+            // they don't contain display content so we ignore them.
+            (StreamingContentKind::Thinking, ClaudeContentBlockDelta::SignatureDelta { .. }) => {}
             _ => {
                 tracing::warn!(
                     "Mismatched content types: delta {:?}, kind {:?}",
@@ -2215,6 +2218,11 @@ pub enum ClaudeContentBlockDelta {
     TextDelta { text: String },
     #[serde(rename = "thinking_delta")]
     ThinkingDelta { thinking: String },
+    #[serde(rename = "signature_delta")]
+    SignatureDelta {
+        #[serde(default)]
+        signature: String,
+    },
     #[serde(other)]
     Unknown,
 }


### PR DESCRIPTION
## Summary

- Added `SignatureDelta` variant to `ClaudeContentBlockDelta` enum to properly deserialize `signature_delta` events from the Claude API
- Handle `SignatureDelta` as a no-op during thinking blocks in `apply_content_delta`

## Why

The Claude API sends `signature_delta` events at the end of extended thinking content blocks (for verification purposes). Since the `ClaudeContentBlockDelta` enum only handled `text_delta` and `thinking_delta`, these signature deltas were falling through to the `#[serde(other)] Unknown` catch-all variant, which triggered a spurious warning on every thinking response:

```
WARN executors::executors::claude: Mismatched content types: delta Unknown, kind Thinking
```

## Implementation details

- `SignatureDelta` is added to the `ClaudeContentBlockDelta` enum with `#[serde(rename = "signature_delta")]` so it deserializes correctly instead of becoming `Unknown`
- In `StreamingContentState::apply_content_delta`, the `(Thinking, SignatureDelta)` match arm is a no-op — signatures are metadata for verification, not display content that needs to be buffered

## File changed

- `crates/executors/src/executors/claude.rs`

- [x] tested

This PR was written using [Vibe Kanban](https://vibekanban.com)