### PR TITLE
Rename Kanban create label key from task to issue (Vibe Kanban)

### DIFF
--- a/frontend/src/components/ui-new/views/KanbanIssuePanel.tsx
+++ b/frontend/src/components/ui-new/views/KanbanIssuePanel.tsx
@@ -387,7 +387,7 @@ export function KanbanIssuePanel({
         {isCreateMode && (
           <div className="px-base pb-base flex items-center gap-half">
             <PrimaryButton
-              value={t('kanban.createTask')}
+              value={t('kanban.createIssue')}
               onClick={onSubmit}
               disabled={isSubmitting || !formData.title.trim()}
               actionIcon={isSubmitting ? 'spinner' : undefined}

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -477,7 +477,7 @@
     "issueDescriptionPlaceholder": "Enter task description here...",
     "createDraftWorkspaceImmediately": "Create draft workspace immediately",
     "createDraftWorkspaceDescription": "Tick to automatically create a workspace",
-    "createTask": "Create Issue",
+    "createIssue": "Create Issue",
     "newIssue": "New Issue",
     "previewCodeBlock": "[Code block]",
     "previewImage": "[Image]",

--- a/frontend/src/i18n/locales/es/common.json
+++ b/frontend/src/i18n/locales/es/common.json
@@ -463,7 +463,7 @@
     "issueDescriptionPlaceholder": "Ingresa la descripción de la tarea...",
     "createDraftWorkspaceImmediately": "Crear workspace borrador inmediatamente",
     "createDraftWorkspaceDescription": "Marca para crear automáticamente un workspace",
-    "createTask": "Crear tarea",
+    "createIssue": "Crear tarea",
     "newIssue": "Nuevo issue",
     "previewCodeBlock": "[Bloque de código]",
     "previewImage": "[Imagen]",

--- a/frontend/src/i18n/locales/fr/common.json
+++ b/frontend/src/i18n/locales/fr/common.json
@@ -463,7 +463,7 @@
     "issueDescriptionPlaceholder": "Entrez la description de la tâche...",
     "createDraftWorkspaceImmediately": "Créer immédiatement un espace de travail brouillon",
     "createDraftWorkspaceDescription": "Cochez pour créer automatiquement un espace de travail",
-    "createTask": "Créer la tâche",
+    "createIssue": "Créer la tâche",
     "newIssue": "Nouveau ticket",
     "previewCodeBlock": "[Bloc de code]",
     "previewImage": "[Image]",

--- a/frontend/src/i18n/locales/ja/common.json
+++ b/frontend/src/i18n/locales/ja/common.json
@@ -463,7 +463,7 @@
     "issueDescriptionPlaceholder": "タスクの説明を入力してください...",
     "createDraftWorkspaceImmediately": "下書きワークスペースをすぐに作成",
     "createDraftWorkspaceDescription": "チェックするとワークスペースを自動作成します",
-    "createTask": "タスクを作成",
+    "createIssue": "タスクを作成",
     "newIssue": "新しい課題",
     "previewCodeBlock": "[コードブロック]",
     "previewImage": "[画像]",

--- a/frontend/src/i18n/locales/ko/common.json
+++ b/frontend/src/i18n/locales/ko/common.json
@@ -463,7 +463,7 @@
     "issueDescriptionPlaceholder": "작업 설명을 입력하세요...",
     "createDraftWorkspaceImmediately": "초안 워크스페이스를 즉시 생성",
     "createDraftWorkspaceDescription": "체크하면 워크스페이스를 자동으로 생성합니다",
-    "createTask": "작업 생성",
+    "createIssue": "작업 생성",
     "newIssue": "새 이슈",
     "previewCodeBlock": "[코드 블록]",
     "previewImage": "[이미지]",

--- a/frontend/src/i18n/locales/zh-Hans/common.json
+++ b/frontend/src/i18n/locales/zh-Hans/common.json
@@ -463,7 +463,7 @@
     "issueDescriptionPlaceholder": "输入任务描述...",
     "createDraftWorkspaceImmediately": "立即创建草稿工作区",
     "createDraftWorkspaceDescription": "勾选后自动创建工作区",
-    "createTask": "创建任务",
+    "createIssue": "创建任务",
     "newIssue": "新问题",
     "previewCodeBlock": "[代码块]",
     "previewImage": "[图片]",

--- a/frontend/src/i18n/locales/zh-Hant/common.json
+++ b/frontend/src/i18n/locales/zh-Hant/common.json
@@ -463,7 +463,7 @@
     "issueDescriptionPlaceholder": "輸入任務描述...",
     "createDraftWorkspaceImmediately": "立即建立草稿工作區",
     "createDraftWorkspaceDescription": "勾選後自動建立工作區",
-    "createTask": "建立任務",
+    "createIssue": "建立任務",
     "newIssue": "新問題",
     "previewCodeBlock": "[程式碼區塊]",
     "previewImage": "[圖片]",


### PR DESCRIPTION
### Summary
- Updated the Kanban issue creation action from `kanban.createTask` to `kanban.createIssue` in all relevant locale files.
- Updated the Kanban issue panel to use `t('kanban.createIssue')` for the create action label.
- Renamed all string keys from `createTask` to `createIssue` in `frontend/src/i18n/locales/{en,es,fr,ja,ko,zh-Hans,zh-Hant}/common.json` and kept existing translations for each language.

### Why
- The change was requested to align the UI wording with “issue” terminology in the Kanban issue flow.
- Renaming the i18n key ensures future references stay consistent with the updated copy and avoids mixed task/issue semantics.

### Implementation details
- File-level changes are limited to one UI component and seven locale files.
- Only the translation key and associated usage were changed; no new business logic was added.
- The commit sequence included first a value rename (`Create Task` to `Create Issue`) and then a key migration (`createTask` → `createIssue`) to avoid partial state during rollout.

This PR was written using [Vibe Kanban](https://vibekanban.com)
