### PR TITLE
Remount execution process provider on workspace/session switch (Vibe Kanban)

### DIFF
--- a/frontend/src/components/ui-new/containers/ProjectRightSidebarContainer.tsx
+++ b/frontend/src/components/ui-new/containers/ProjectRightSidebarContainer.tsx
@@ -169,6 +169,7 @@ function WorkspaceSessionPanel({
 
   return (
     <ExecutionProcessesProvider
+      key={`${workspaceId}-${selectedSessionId ?? 'new'}`}
       attemptId={workspaceId}
       sessionId={selectedSessionId}
     >


### PR DESCRIPTION
## What changed
- In `frontend/src/components/ui-new/containers/ProjectRightSidebarContainer.tsx`, `WorkspaceSessionPanel` now renders `ExecutionProcessesProvider` with a `key` derived from the active workspace and selected session (`${workspaceId}-${selectedSessionId ?? 'new'}`), ensuring the provider remounts when these values change.
- This replaces stale provider state persistence with a deterministic remount on workspace/session transitions.

## Why this change
- Users were seeing logs from the previously viewed workspace when switching workspaces in `WorkspaceSessionPanel`.
- The provider kept old in-memory state because it was reused across different workspace/session contexts.
- Tying a `key` to context identifiers ensures each workspace/session pair has isolated provider state.

## Implementation details
- Added a `key` prop directly on `ExecutionProcessesProvider` in `ProjectRightSidebarContainer.tsx`, with fallback `'new'` when `selectedSessionId` is absent.
- Kept the fix narrowly scoped to the component where the stale state was observed.
- No API, backend, or migration changes required.

This PR was written using [Vibe Kanban](https://vibekanban.com)
