### PR TITLE
Fix logs auto-follow only when scrolled to bottom (Vibe Kanban)

### DIFF
--- a/frontend/src/components/ui-new/containers/VirtualizedProcessLogs.tsx
+++ b/frontend/src/components/ui-new/containers/VirtualizedProcessLogs.tsx
@@ -174,8 +174,8 @@ export function VirtualizedProcessLogs({
           data={channelData}
           context={context}
           initialLocation={INITIAL_TOP_ITEM}
-          atBottomStateChange={(isAtBottom) => {
-            isAtBottomRef.current = isAtBottom;
+          onScroll={(location) => {
+            isAtBottomRef.current = location.isAtBottom;
           }}
           computeItemKey={computeItemKey}
           ItemContent={ItemContent}


### PR DESCRIPTION
## Summary
- Stop auto-scrolling log output when the user has scrolled up, and resume only when back at the bottom.

## What changed
- Track whether the log list is at the bottom via the Virtuoso onScroll callback.
- Apply the ScrollToLastItem modifier only when the user is at the bottom; keep the initial load behavior unchanged.

## Why
- Scrolling up in the right sidebar logs should pause auto-follow so users can read older entries without being yanked back to the bottom on updates.

## Implementation details
- Uses the ListScrollLocation.isAtBottom flag from Virtuoso to gate auto-follow.
- Leaves initial positioning intact with the existing initial scroll modifier.

This PR was written using [Vibe Kanban](https://vibekanban.com)
