### PR TITLE
Carry over assignees when creating sub-issues (Vibe Kanban)

### DIFF
--- a/frontend/src/components/ui-new/containers/IssueSubIssuesSectionContainer.tsx
+++ b/frontend/src/components/ui-new/containers/IssueSubIssuesSectionContainer.tsx
@@ -5,6 +5,7 @@ import { useProjectContext } from '@/contexts/remote/ProjectContext';
 import { useOrgContext } from '@/contexts/remote/OrgContext';
 import { useKanbanNavigation } from '@/hooks/useKanbanNavigation';
 import { useActions } from '@/contexts/ActionsContext';
+import { Actions } from '@/components/ui-new/actions';
 import { bulkUpdateIssues } from '@/lib/remoteApi';
 import { ConfirmDialog } from '@/components/ui-new/dialogs/ConfirmDialog';
 import {
@@ -25,12 +26,12 @@ interface IssueSubIssuesSectionContainerProps {
 export function IssueSubIssuesSectionContainer({
   issueId,
 }: IssueSubIssuesSectionContainerProps) {
-  const { projectId, openIssue, startCreate } = useKanbanNavigation();
+  const { projectId, openIssue } = useKanbanNavigation();
   const {
+    executeAction,
     openSubIssueSelection,
     openPrioritySelection,
     openAssigneeSelection,
-    executorContext,
   } = useActions();
 
   const {
@@ -138,20 +139,12 @@ export function IssueSubIssuesSectionContainer({
 
   // Handle clicking '+' to create new sub-issue immediately
   const handleCreateNewSubIssue = useCallback(() => {
-    const parentAssigneeIds = getAssigneesForIssue(issueId).map(
-      (a) => a.user_id
-    );
-    startCreate({
-      statusId: executorContext.defaultCreateStatusId,
-      parentIssueId: issueId,
-      assigneeIds: parentAssigneeIds.length > 0 ? parentAssigneeIds : undefined,
-    });
-  }, [
-    startCreate,
-    issueId,
-    executorContext.defaultCreateStatusId,
-    getAssigneesForIssue,
-  ]);
+    if (projectId) {
+      void executeAction(Actions.CreateSubIssue, undefined, projectId, [
+        issueId,
+      ]);
+    }
+  }, [executeAction, projectId, issueId]);
 
   // Handle clicking link icon to select an existing issue as sub-issue
   const handleLinkSubIssue = useCallback(() => {

--- a/frontend/src/components/ui-new/dialogs/selections/ProjectSelectionDialog.tsx
+++ b/frontend/src/components/ui-new/dialogs/selections/ProjectSelectionDialog.tsx
@@ -1,5 +1,4 @@
 import { useState, useCallback, useMemo, useRef, useEffect } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
 import NiceModal, { useModal } from '@ebay/nice-modal-react';
 import { defineModal } from '@/lib/modals';
 import {
@@ -13,7 +12,6 @@ import type {
   ResolvedGroupItem,
 } from '@/components/ui-new/actions/pages';
 import type { Issue } from 'shared/remote-types';
-import { useUiPreferencesStore } from '@/stores/useUiPreferencesStore';
 import { buildStatusSelectionPages } from './statusSelection';
 import { buildPrioritySelectionPages } from './prioritySelection';
 import { buildSubIssueSelectionPages } from './subIssueSelection';
@@ -63,20 +61,13 @@ function getInitialPageId(selectionType: SelectionMode['type']): string {
 function ProjectSelectionContent({ selection }: { selection: SelectionMode }) {
   const modal = useModal();
   const previousFocusRef = useRef<HTMLElement | null>(null);
-  const navigate = useNavigate();
-  const { projectId } = useParams<{ projectId: string }>();
   const {
     statuses,
     issues,
-    issueAssignees,
     issueRelationships,
     updateIssue,
     insertIssueRelationship,
   } = useProjectContext();
-  const kanbanViewMode = useUiPreferencesStore((s) => s.kanbanViewMode);
-  const listViewStatusFilter = useUiPreferencesStore(
-    (s) => s.listViewStatusFilter
-  );
   const initialPageId = useMemo(
     () => getInitialPageId(selection.type),
     [selection.type]
@@ -102,14 +93,6 @@ function ProjectSelectionContent({ selection }: { selection: SelectionMode }) {
       [...statuses]
         .sort((a, b) => a.sort_order - b.sort_order)
         .map((s) => ({ id: s.id, name: s.name, color: s.color })),
-    [statuses]
-  );
-
-  const visibleStatuses = useMemo(
-    () =>
-      [...statuses]
-        .filter((s) => !s.hidden)
-        .sort((a, b) => a.sort_order - b.sort_order),
     [statuses]
   );
 
@@ -243,30 +226,8 @@ function ProjectSelectionContent({ selection }: { selection: SelectionMode }) {
               parent_issue_id: result.issueId,
             });
           }
-        } else if (result.type === 'createNew') {
-          if (!projectId) return;
-          let defaultStatusId: string | null = null;
-          if (kanbanViewMode === 'kanban') {
-            defaultStatusId = visibleStatuses[0]?.id ?? null;
-          } else if (listViewStatusFilter) {
-            defaultStatusId = listViewStatusFilter;
-          } else {
-            defaultStatusId =
-              [...statuses].sort((a, b) => a.sort_order - b.sort_order)[0]
-                ?.id ?? null;
-          }
-          const params = new URLSearchParams({ mode: 'create' });
-          if (defaultStatusId) params.set('statusId', defaultStatusId);
-          params.set('parentIssueId', selection.parentIssueId);
-          // Carry over assignees from parent issue
-          const parentAssigneeIds = issueAssignees
-            .filter((a) => a.issue_id === selection.parentIssueId)
-            .map((a) => a.user_id);
-          if (parentAssigneeIds.length > 0) {
-            params.set('assignees', parentAssigneeIds.join(','));
-          }
-          navigate(`/projects/${projectId}?${params.toString()}`);
         }
+        // 'createNew' is handled by the caller (AddSubIssue action)
       } else if (selection.type === 'relationship') {
         const result = data as RelationshipSelectionResult;
         if (selection.direction === 'forward') {
@@ -284,18 +245,7 @@ function ProjectSelectionContent({ selection }: { selection: SelectionMode }) {
         }
       }
     },
-    [
-      selection,
-      updateIssue,
-      insertIssueRelationship,
-      navigate,
-      projectId,
-      kanbanViewMode,
-      listViewStatusFilter,
-      visibleStatuses,
-      statuses,
-      issueAssignees,
-    ]
+    [selection, updateIssue, insertIssueRelationship]
   );
 
   const fallbackPage = pages[initialPageId] ?? Object.values(pages)[0];

--- a/frontend/src/contexts/ActionsContext.tsx
+++ b/frontend/src/contexts/ActionsContext.tsx
@@ -66,7 +66,7 @@ interface ActionsContextValue {
     projectId: string,
     parentIssueId: string,
     mode?: 'addChild' | 'setParent'
-  ) => Promise<void>;
+  ) => Promise<{ type: string } | undefined>;
 
   // Open workspace selection dialog to link a workspace to an issue
   openWorkspaceSelection: (projectId: string, issueId: string) => Promise<void>;
@@ -131,7 +131,7 @@ export function ActionsProvider({ children }: ActionsProviderProps) {
 
   // Navigate to create issue mode (URL-based navigation)
   const navigateToCreateIssue = useCallback(
-    (options?: { statusId?: string }) => {
+    (options?: Parameters<typeof buildIssueCreatePath>[1]) => {
       if (!projectId) return;
       navigate(buildIssueCreatePath(projectId, options));
     },
@@ -206,10 +206,10 @@ export function ActionsProvider({ children }: ActionsProviderProps) {
       const { ProjectSelectionDialog } = await import(
         '@/components/ui-new/dialogs/selections/ProjectSelectionDialog'
       );
-      await ProjectSelectionDialog.show({
+      return (await ProjectSelectionDialog.show({
         projectId,
         selection: { type: 'subIssue', parentIssueId, mode },
-      });
+      })) as { type: string } | undefined;
     },
     []
   );

--- a/frontend/src/pages/ui-new/ProjectKanban.tsx
+++ b/frontend/src/pages/ui-new/ProjectKanban.tsx
@@ -29,7 +29,8 @@ import {
  */
 function ProjectMutationsRegistration({ children }: { children: ReactNode }) {
   const { registerProjectMutations } = useActions();
-  const { removeIssue, insertIssue, getIssue, issues } = useProjectContext();
+  const { removeIssue, insertIssue, getIssue, getAssigneesForIssue, issues } =
+    useProjectContext();
 
   // Use ref to always access latest issues (avoid stale closure)
   const issuesRef = useRef(issues);
@@ -72,12 +73,19 @@ function ProjectMutationsRegistration({ children }: { children: ReactNode }) {
         });
       },
       getIssue,
+      getAssigneesForIssue,
     });
 
     return () => {
       registerProjectMutations(null);
     };
-  }, [registerProjectMutations, removeIssue, insertIssue, getIssue]);
+  }, [
+    registerProjectMutations,
+    removeIssue,
+    insertIssue,
+    getIssue,
+    getAssigneesForIssue,
+  ]);
 
   return <>{children}</>;
 }


### PR DESCRIPTION
## Summary

When creating a sub-issue, the new issue now automatically inherits assignees from the parent issue. This applies to all sub-issue creation paths:

- **"+" button** in the sub-issues section header (direct create)
- **Command bar** "Add Sub-issue" → "Create new" (via selection dialog)
- **Link icon** in sub-issues section → "Create new" (same dialog)

Additionally, new issues created from the kanban board now auto-assign based on active assignee filters (e.g. if filtering by "Me", new issues are pre-assigned to the current user).

## Implementation

The core change is **centralizing** the sub-issue assignee carry-over into a single `navigateToCreateSubIssue` helper in `actions/index.ts`, rather than duplicating the logic across multiple callsites:

- **New `CreateSubIssue` action** — navigates directly to the create form with parent's assignees. Used by the "+" button in the sub-issues section.
- **Updated `AddSubIssue` action** — opens the selection dialog, then if the user picks "Create new", calls the same shared helper for navigation with assignee carry-over.
- **`ProjectSelectionDialog`** — no longer handles "createNew" navigation/assignee logic internally. It simply returns the result to the caller, following the same pattern used by status/priority selections.

### Supporting changes

- `ProjectMutations` interface extended with `getAssigneesForIssue` so actions can look up parent assignees
- `navigateToCreateIssue` widened to accept full `IssueCreateRouteOptions` (was previously limited to `{ statusId }`)
- `openSubIssueSelection` now returns the dialog result so `AddSubIssue` can act on it
- `KanbanContainer` resolves active assignee filters into concrete user IDs for auto-assignment on new issues

## Files changed

| File | Change |
|------|--------|
| `actions/index.ts` | Added `navigateToCreateSubIssue` helper, `CreateSubIssue` action, updated `AddSubIssue`, widened types |
| `ActionsContext.tsx` | Widened `navigateToCreateIssue`, `openSubIssueSelection` returns result |
| `ProjectKanban.tsx` | Registered `getAssigneesForIssue` in project mutations |
| `IssueSubIssuesSectionContainer.tsx` | "+" button now uses `CreateSubIssue` action |
| `ProjectSelectionDialog.tsx` | Removed inline createNew handling, cleaned up unused deps |
| `KanbanContainer.tsx` | Auto-assign from active kanban assignee filters |

This PR was written using [Vibe Kanban](https://vibekanban.com)