### PR TITLE
Refactor switch defaults to improve draft workspace toggle contrast (Vibe Kanban)

### DIFF
--- a/frontend/src/components/dialogs/tasks/StartReviewDialog.tsx
+++ b/frontend/src/components/dialogs/tasks/StartReviewDialog.tsx
@@ -264,7 +264,6 @@ const StartReviewDialogImpl = NiceModal.create<StartReviewDialogProps>(
                   checked={createNewSession}
                   onCheckedChange={handleNewSessionChange}
                   disabled={!resolvedSessionId}
-                  className="!bg-border data-[state=checked]:!bg-foreground disabled:opacity-50"
                   aria-label={t('startReviewDialog.newSession')}
                 />
                 <Label

--- a/frontend/src/components/ui-new/dialogs/ResolveConflictsDialog.tsx
+++ b/frontend/src/components/ui-new/dialogs/ResolveConflictsDialog.tsx
@@ -311,7 +311,6 @@ const ResolveConflictsDialogImpl =
                       id="new-session-switch"
                       checked={createNewSession}
                       onCheckedChange={handleNewSessionChange}
-                      className="!bg-border data-[state=checked]:!bg-foreground disabled:opacity-50"
                       aria-label={t(
                         'resolveConflicts.dialog.newSession',
                         'New Session'

--- a/frontend/src/components/ui-new/primitives/Toggle.tsx
+++ b/frontend/src/components/ui-new/primitives/Toggle.tsx
@@ -24,10 +24,7 @@ export function Toggle({
         checked={checked}
         onCheckedChange={onCheckedChange}
         disabled={disabled}
-        className={cn(
-          'mt-px shrink-0',
-          !checked && '!bg-foreground/35 !border-foreground/15'
-        )}
+        className="mt-px shrink-0"
       />
       <div className="flex flex-col gap-half min-w-0">
         <span className="text-base text-normal">{label}</span>

--- a/frontend/src/components/ui/switch.tsx
+++ b/frontend/src/components/ui/switch.tsx
@@ -2,25 +2,32 @@ import * as React from 'react';
 import * as SwitchPrimitives from '@radix-ui/react-switch';
 import { cn } from '@/lib/utils';
 
+const switchRootClassName =
+  'peer inline-flex h-[18px] w-8 shrink-0 cursor-pointer items-center ' +
+  'rounded-full border-2 border-transparent transition-colors ' +
+  'data-[state=checked]:bg-foreground ' +
+  'data-[state=unchecked]:bg-foreground/35 ' +
+  'data-[state=unchecked]:border-foreground/15 ' +
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ' +
+  'focus-visible:ring-offset-2 focus-visible:ring-offset-background ' +
+  'disabled:cursor-not-allowed disabled:opacity-50';
+
+const switchThumbClassName =
+  'pointer-events-none block h-3.5 w-3.5 rounded-full shadow-sm ring-0 ' +
+  'transition-transform data-[state=checked]:translate-x-3.5 ' +
+  'data-[state=unchecked]:translate-x-0 data-[state=checked]:bg-secondary ' +
+  'data-[state=unchecked]:bg-low';
+
 const Switch = React.forwardRef<
   React.ElementRef<typeof SwitchPrimitives.Root>,
   React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root>
 >(({ className, ...props }, ref) => (
   <SwitchPrimitives.Root
     ref={ref}
-    className={cn(
-      'peer inline-flex h-[18px] w-8 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50',
-      props.checked ? 'bg-foreground' : 'bg-secondary',
-      className
-    )}
+    className={cn(switchRootClassName, className)}
     {...props}
   >
-    <SwitchPrimitives.Thumb
-      className={cn(
-        'pointer-events-none block h-3.5 w-3.5 rounded-full shadow-sm ring-0 transition-transform data-[state=checked]:translate-x-3.5 data-[state=unchecked]:translate-x-0',
-        props.checked ? 'bg-secondary' : 'bg-low'
-      )}
-    />
+    <SwitchPrimitives.Thumb className={switchThumbClassName} />
   </SwitchPrimitives.Root>
 ));
 Switch.displayName = SwitchPrimitives.Root.displayName;


### PR DESCRIPTION
## What changed
- Unified `Switch` default styling in `frontend/src/components/ui/switch.tsx` so both checked and unchecked states are now handled directly by state attributes (`data-[state=checked]`, `data-[state=unchecked]`) rather than callsite class overrides.
- Updated unchecked and checked visuals in the root switch style to keep contrast readable in all contexts (`bg-foreground/35` with `border-foreground/15` when unchecked; `bg-foreground` when checked).
- Kept thumb color changes in the same component (`bg-secondary` for checked, `bg-low` for unchecked) and moved shared classes into constants for readability.
- Removed contextual `!` overrides from `frontend/src/components/ui-new/primitives/Toggle.tsx`.
- Removed bespoke `Switch` styling from dialog callsites in `frontend/src/components/dialogs/tasks/StartReviewDialog.tsx` and `frontend/src/components/ui-new/dialogs/ResolveConflictsDialog.tsx`.

## Why
- The initial issue was that the "Create draft workspace immediately" toggle was difficult to distinguish from its panel background.
- The toggle fix was expanded into a single-source styling approach to avoid scattered exceptions and make future switch behavior predictable and easier to maintain.
- The refactor aligns with the requested readability-first goal: one consistent default switch style and no per-toggle variants or `!` override hacks.

## Implementation details
- Removed conditional class concatenation in `Switch` based on `props.checked` and switched to Tailwind `data-*` state selectors.
- Introduced explicit default `className` constants (`switchRootClassName`, `switchThumbClassName`) to make component styling clearer.
- Simplified callsites so they only pass semantic props (`checked`, `onCheckedChange`, etc.) and rely on shared component defaults.

This PR was written using [Vibe Kanban](https://vibekanban.com)
