### PR TITLE
Align preview inspect control label with context-selection behavior (Vibe Kanban)

### DIFF
--- a/frontend/src/components/ui-new/views/PreviewBrowser.tsx
+++ b/frontend/src/components/ui-new/views/PreviewBrowser.tsx
@@ -175,8 +175,8 @@ export function PreviewBrowser({
               onClick={onToggleInspectMode}
               active={isInspectMode}
               disabled={!isServerRunning}
-              aria-label="Inspect component"
-              title="Inspect component"
+              aria-label="Select element as context"
+              title="Select element as context"
             />
             <IconButtonGroupItem
               icon={TerminalIcon}


### PR DESCRIPTION
## Changes made
- Updated the inspect-mode toolbar button tooltip and accessibility label text in `frontend/src/components/ui-new/views/PreviewBrowser.tsx`.
- Replaced `Inspect component` with `Select element as context` for both `title` and `aria-label` values.

## Why
- The previous wording did not match the feature’s intent in the UI.
- This change clarifies the action as selecting an element to be used as context, which is what the interaction exposes to users.

## Implementation details
- No logic or behavior was changed; only user-facing strings were updated.
- The change is scoped to the existing inspect/devtools control group in the preview browser toolbar.
- This preserves existing state handling for inspect mode while improving discoverability and accessibility text.

This PR was written using [Vibe Kanban](https://vibekanban.com)
