### PR TITLE
Prioritize null updated-at timestamps in workspace sort (Vibe Kanban)

### DIFF
--- a/frontend/src/components/ui-new/containers/WorkspacesSidebarContainer.tsx
+++ b/frontend/src/components/ui-new/containers/WorkspacesSidebarContainer.tsx
@@ -474,15 +474,15 @@ export function WorkspacesSidebarContainer({
         const aTimestamp = getWorkspaceSortTimestamp(a, workspaceSort.sortBy);
         const bTimestamp = getWorkspaceSortTimestamp(b, workspaceSort.sortBy);
 
-        // Workspaces without the selected timestamp are always sorted last.
+        // Workspaces without the selected timestamp are always sorted first.
         if (aTimestamp === null && bTimestamp === null) {
           return a.name.localeCompare(b.name);
         }
         if (aTimestamp === null) {
-          return 1;
+          return -1;
         }
         if (bTimestamp === null) {
-          return -1;
+          return 1;
         }
 
         if (aTimestamp === bTimestamp) {


### PR DESCRIPTION
## What changed
- Updated the workspace sidebar sort comparator in `frontend/src/components/ui-new/containers/WorkspacesSidebarContainer.tsx` so entries without a sort timestamp are treated as highest priority instead of lowest.
- Kept pinned workspaces pinned-first and preserved existing timestamp-based ordering (`updated_at` uses latest process completion time; `created_at` still uses workspace creation time).
- Kept existing alphabetical tie-breakers for equal timestamps.

## Why
- Running workspaces can have `latestProcessCompletedAt = null`, which caused them to sink to the bottom when sorting by `updated_at` in ascending order.
- The requested behavior is that these running entries should not be pushed down by a missing completion time, so they now stay near the top of the list while remaining in the correct sort direction.

## Implementation details
- Changed comparator logic in `sortWorkspaces` in `frontend/src/components/ui-new/containers/WorkspacesSidebarContainer.tsx`.
- Null timestamp handling was flipped:
  - both-null timestamps: compare by `name`
  - `a` null / `b` non-null: `a` sorts first
  - `b` null / `a` non-null: `b` sorts first
- All other sorting behavior (pinned-first + asc/desc comparison using numeric timestamp values) is unchanged.

This PR was written using [Vibe Kanban](https://vibekanban.com)
