### PR TITLE
Fix review annotation width in horizontally scrolling diffs (Vibe Kanban)

### DIFF
--- a/frontend/src/components/ui-new/containers/PierreDiffCard.tsx
+++ b/frontend/src/components/ui-new/containers/PierreDiffCard.tsx
@@ -103,10 +103,12 @@ const PIERRE_DIFFS_THEME_CSS = `
     width: 22px !important;
   }
 
-  /* Make annotation content span full width including under line numbers */
+  /* Keep annotations full-row without inheriting long-line scroll width */
   [data-annotation-content] {
     grid-column: 1 / -1 !important;
-    width: 100% !important;
+    left: 0 !important;
+    width: var(--diffs-column-width, 100%) !important;
+    max-width: 100% !important;
   }
   
   [data-line-annotation] {


### PR DESCRIPTION
## Summary
Constrain review comment annotation width in horizontally scrollable diffs so comment inputs stay within the diff container.

## Changes
- Updated `PIERRE_DIFFS_THEME_CSS` in `frontend/src/components/ui-new/containers/PierreDiffCard.tsx`.
- In the `[data-annotation-content]` style override, replaced `width: 100%` with:
  - `left: 0 !important`
  - `width: var(--diffs-column-width, 100%) !important`
  - `max-width: 100% !important`
- Kept full-row annotation placement via `grid-column: 1 / -1`.

## Why
The review comment box (`CommentCard`) was stretching to the width of the horizontally scrollable code track when long lines were present. This made the comment area overly wide and scrollable, which is inconsistent with the surrounding diff card layout.

## Implementation details
- This change is intentionally limited to the `@pierre/diffs` theme override CSS used inside `PierreDiffCard`.
- `--diffs-column-width` aligns the annotation container with the visible diff column, and `max-width: 100%` prevents it from exceeding its container.
- Existing code horizontal scrolling behavior is unchanged and remains controlled by the existing wrap/scroll handling in `PierreDiffCard`.

This PR was written using [Vibe Kanban](https://vibekanban.com)
