### PR TITLE
feat: mobile single-panel layout mode for phone screens

### DIFF
--- a/packages/web-core/src/pages/workspaces/RightSidebar.tsx
+++ b/packages/web-core/src/pages/workspaces/RightSidebar.tsx
@@ -9,6 +9,8 @@ import { useChangesView } from '@/shared/hooks/useChangesView';
 import { useWorkspaceContext } from '@/shared/hooks/useWorkspaceContext';
 import { ArrowsOutSimpleIcon } from '@phosphor-icons/react';
 import { useLogsPanel } from '@/shared/hooks/useLogsPanel';
+import { useIsMobile } from '@/shared/hooks/useIsMobile';
+import { cn } from '@/shared/lib/utils';
 import type { RepoWithTargetBranch, Workspace } from 'shared/types';
 import {
   PERSIST_KEYS,
@@ -48,6 +50,7 @@ export function RightSidebar({
   const { selectFile } = useChangesView();
   const { diffs } = useWorkspaceContext();
   const { setExpanded } = useExpandedAll();
+  const isMobile = useIsMobile();
   const isTerminalVisible = useUiPreferencesStore((s) => s.isTerminalVisible);
   const { expandTerminal, isTerminalExpanded } = useLogsPanel();
 
@@ -187,7 +190,12 @@ export function RightSidebar({
   }
 
   return (
-    <div className="h-full border-l bg-secondary overflow-y-auto">
+    <div
+      className={cn(
+        'h-full bg-secondary overflow-y-auto',
+        !isMobile && 'border-l'
+      )}
+    >
       <div className="divide-y border-b">
         {sections
           .filter((section) => section.visible)

--- a/packages/web-core/src/pages/workspaces/WorkspacesSidebarContainer.tsx
+++ b/packages/web-core/src/pages/workspaces/WorkspacesSidebarContainer.tsx
@@ -18,6 +18,8 @@ import {
   type WorkspaceSortOrder,
 } from '@/shared/stores/useUiPreferencesStore';
 import type { Workspace } from '@/shared/hooks/useWorkspaces';
+import { useMobileLayoutStore } from '@/shared/stores/useMobileLayoutStore';
+import { useIsMobile } from '@/shared/hooks/useIsMobile';
 import { CommandBarDialog } from '@/shared/dialogs/command-bar/CommandBarDialog';
 import {
   WorkspacesSidebar,
@@ -258,6 +260,11 @@ export function WorkspacesSidebarContainer({
     selectWorkspace,
     navigateToCreate,
   } = useWorkspaceContext();
+
+  const isMobile = useIsMobile();
+  const setMobileActivePanel = useMobileLayoutStore(
+    (s) => s.setMobileActivePanel
+  );
 
   const [searchQuery, setSearchQuery] = useState('');
   const [showArchive, setShowArchive] = usePersistedExpanded(
@@ -567,8 +574,17 @@ export function WorkspacesSidebarContainer({
       } else {
         selectWorkspace(id);
       }
+      if (isMobile) {
+        setMobileActivePanel('chat');
+      }
     },
-    [selectedWorkspaceId, selectWorkspace, onScrollToBottom]
+    [
+      selectedWorkspaceId,
+      selectWorkspace,
+      onScrollToBottom,
+      isMobile,
+      setMobileActivePanel,
+    ]
   );
 
   const handleOpenWorkspaceActions = useCallback((workspaceId: string) => {

--- a/packages/web-core/src/shared/actions/index.ts
+++ b/packages/web-core/src/shared/actions/index.ts
@@ -50,6 +50,8 @@ import {
   useUiPreferencesStore,
   RIGHT_MAIN_PANEL_MODES,
 } from '@/shared/stores/useUiPreferencesStore';
+import { useMobileLayoutStore } from '@/shared/stores/useMobileLayoutStore';
+import { isMobileQuery } from '@/shared/hooks/useIsMobile';
 
 import { attemptsApi, repoApi } from '@/shared/lib/api';
 import { bulkUpdateIssues } from '@/shared/lib/remoteApi';
@@ -570,9 +572,16 @@ export const Actions = {
     shortcut: 'V S',
     requiresTarget: ActionTargetType.NONE,
     isVisible: (ctx) => ctx.layoutMode === 'workspaces',
-    isActive: (ctx) => ctx.isLeftSidebarVisible,
+    isActive: (ctx) =>
+      ctx.isMobile
+        ? ctx.mobileActivePanel === 'sidebar'
+        : ctx.isLeftSidebarVisible,
     execute: () => {
-      useUiPreferencesStore.getState().toggleLeftSidebar();
+      if (isMobileQuery()) {
+        useMobileLayoutStore.getState().setMobileActivePanel('sidebar');
+      } else {
+        useUiPreferencesStore.getState().toggleLeftSidebar();
+      }
     },
   },
 
@@ -583,15 +592,24 @@ export const Actions = {
     shortcut: 'V H',
     requiresTarget: ActionTargetType.NONE,
     isVisible: (ctx) => ctx.layoutMode === 'workspaces',
-    isActive: (ctx) => ctx.isLeftMainPanelVisible,
+    isActive: (ctx) =>
+      ctx.isMobile
+        ? ctx.mobileActivePanel === 'chat'
+        : ctx.isLeftMainPanelVisible,
     isEnabled: (ctx) =>
-      !(ctx.isLeftMainPanelVisible && ctx.rightMainPanelMode === null),
+      ctx.isMobile
+        ? true
+        : !(ctx.isLeftMainPanelVisible && ctx.rightMainPanelMode === null),
     getLabel: (ctx) =>
       ctx.isLeftMainPanelVisible ? 'Hide Chat Panel' : 'Show Chat Panel',
     execute: (ctx) => {
-      useUiPreferencesStore
-        .getState()
-        .toggleLeftMainPanel(ctx.currentWorkspaceId ?? undefined);
+      if (isMobileQuery()) {
+        useMobileLayoutStore.getState().setMobileActivePanel('chat');
+      } else {
+        useUiPreferencesStore
+          .getState()
+          .toggleLeftMainPanel(ctx.currentWorkspaceId ?? undefined);
+      }
     },
   },
 
@@ -604,9 +622,16 @@ export const Actions = {
     icon: RightSidebarIcon,
     requiresTarget: ActionTargetType.NONE,
     isVisible: (ctx) => ctx.layoutMode === 'workspaces',
-    isActive: (ctx) => ctx.isRightSidebarVisible,
+    isActive: (ctx) =>
+      ctx.isMobile
+        ? ctx.mobileActivePanel === 'right-sidebar'
+        : ctx.isRightSidebarVisible,
     execute: () => {
-      useUiPreferencesStore.getState().toggleRightSidebar();
+      if (isMobileQuery()) {
+        useMobileLayoutStore.getState().setMobileActivePanel('right-sidebar');
+      } else {
+        useUiPreferencesStore.getState().toggleRightSidebar();
+      }
     },
   },
 
@@ -618,19 +643,25 @@ export const Actions = {
     requiresTarget: ActionTargetType.NONE,
     isVisible: (ctx) => !ctx.isCreateMode && ctx.layoutMode === 'workspaces',
     isActive: (ctx) =>
-      ctx.rightMainPanelMode === RIGHT_MAIN_PANEL_MODES.CHANGES,
+      ctx.isMobile
+        ? ctx.mobileActivePanel === 'changes'
+        : ctx.rightMainPanelMode === RIGHT_MAIN_PANEL_MODES.CHANGES,
     isEnabled: (ctx) => !ctx.isCreateMode,
     getLabel: (ctx) =>
       ctx.rightMainPanelMode === RIGHT_MAIN_PANEL_MODES.CHANGES
         ? 'Hide Changes Panel'
         : 'Show Changes Panel',
     execute: (ctx) => {
-      useUiPreferencesStore
-        .getState()
-        .toggleRightMainPanelMode(
-          RIGHT_MAIN_PANEL_MODES.CHANGES,
-          ctx.currentWorkspaceId ?? undefined
-        );
+      if (isMobileQuery()) {
+        useMobileLayoutStore.getState().setMobileActivePanel('changes');
+      } else {
+        useUiPreferencesStore
+          .getState()
+          .toggleRightMainPanelMode(
+            RIGHT_MAIN_PANEL_MODES.CHANGES,
+            ctx.currentWorkspaceId ?? undefined
+          );
+      }
     },
   },
 
@@ -641,19 +672,26 @@ export const Actions = {
     shortcut: 'V L',
     requiresTarget: ActionTargetType.NONE,
     isVisible: (ctx) => !ctx.isCreateMode && ctx.layoutMode === 'workspaces',
-    isActive: (ctx) => ctx.rightMainPanelMode === RIGHT_MAIN_PANEL_MODES.LOGS,
+    isActive: (ctx) =>
+      ctx.isMobile
+        ? ctx.mobileActivePanel === 'logs'
+        : ctx.rightMainPanelMode === RIGHT_MAIN_PANEL_MODES.LOGS,
     isEnabled: (ctx) => !ctx.isCreateMode,
     getLabel: (ctx) =>
       ctx.rightMainPanelMode === RIGHT_MAIN_PANEL_MODES.LOGS
         ? 'Hide Logs Panel'
         : 'Show Logs Panel',
     execute: (ctx) => {
-      useUiPreferencesStore
-        .getState()
-        .toggleRightMainPanelMode(
-          RIGHT_MAIN_PANEL_MODES.LOGS,
-          ctx.currentWorkspaceId ?? undefined
-        );
+      if (isMobileQuery()) {
+        useMobileLayoutStore.getState().setMobileActivePanel('logs');
+      } else {
+        useUiPreferencesStore
+          .getState()
+          .toggleRightMainPanelMode(
+            RIGHT_MAIN_PANEL_MODES.LOGS,
+            ctx.currentWorkspaceId ?? undefined
+          );
+      }
     },
   },
 
@@ -665,19 +703,25 @@ export const Actions = {
     requiresTarget: ActionTargetType.NONE,
     isVisible: (ctx) => !ctx.isCreateMode && ctx.layoutMode === 'workspaces',
     isActive: (ctx) =>
-      ctx.rightMainPanelMode === RIGHT_MAIN_PANEL_MODES.PREVIEW,
+      ctx.isMobile
+        ? ctx.mobileActivePanel === 'preview'
+        : ctx.rightMainPanelMode === RIGHT_MAIN_PANEL_MODES.PREVIEW,
     isEnabled: (ctx) => !ctx.isCreateMode,
     getLabel: (ctx) =>
       ctx.rightMainPanelMode === RIGHT_MAIN_PANEL_MODES.PREVIEW
         ? 'Hide Preview Panel'
         : 'Show Preview Panel',
     execute: (ctx) => {
-      useUiPreferencesStore
-        .getState()
-        .toggleRightMainPanelMode(
-          RIGHT_MAIN_PANEL_MODES.PREVIEW,
-          ctx.currentWorkspaceId ?? undefined
-        );
+      if (isMobileQuery()) {
+        useMobileLayoutStore.getState().setMobileActivePanel('preview');
+      } else {
+        useUiPreferencesStore
+          .getState()
+          .toggleRightMainPanelMode(
+            RIGHT_MAIN_PANEL_MODES.PREVIEW,
+            ctx.currentWorkspaceId ?? undefined
+          );
+      }
     },
   },
 
@@ -808,12 +852,16 @@ export const Actions = {
       } else {
         ctx.startDevServer();
         // Auto-open preview mode when starting dev server
-        useUiPreferencesStore
-          .getState()
-          .setRightMainPanelMode(
-            RIGHT_MAIN_PANEL_MODES.PREVIEW,
-            ctx.currentWorkspaceId ?? undefined
-          );
+        if (isMobileQuery()) {
+          useMobileLayoutStore.getState().setMobileActivePanel('preview');
+        } else {
+          useUiPreferencesStore
+            .getState()
+            .setRightMainPanelMode(
+              RIGHT_MAIN_PANEL_MODES.PREVIEW,
+              ctx.currentWorkspaceId ?? undefined
+            );
+        }
       }
     },
   },

--- a/packages/web-core/src/shared/components/ui-new/containers/NavbarContainer.tsx
+++ b/packages/web-core/src/shared/components/ui-new/containers/NavbarContainer.tsx
@@ -160,13 +160,15 @@ export function NavbarContainer() {
     [actionCtx, handleExecuteAction, isMigratePage]
   );
 
-  const navbarTitle = isCreateMode
-    ? 'Create Workspace'
-    : isMigratePage
-      ? 'Migrate'
-      : isOnProjectPage
-        ? orgName
-        : selectedWorkspace?.branch;
+  const navbarTitle = actionCtx.isMobile
+    ? ''
+    : isCreateMode
+      ? 'Create Workspace'
+      : isMigratePage
+        ? 'Migrate'
+        : isOnProjectPage
+          ? orgName
+          : selectedWorkspace?.branch;
 
   return (
     <Navbar

--- a/packages/web-core/src/shared/components/ui-new/containers/SharedAppLayout.tsx
+++ b/packages/web-core/src/shared/components/ui-new/containers/SharedAppLayout.tsx
@@ -3,8 +3,10 @@ import type { DropResult } from '@hello-pangea/dnd';
 import { Outlet, useLocation, useNavigate } from '@tanstack/react-router';
 import { siDiscord, siGithub } from 'simple-icons';
 import { SyncErrorProvider } from '@/shared/providers/SyncErrorProvider';
+import { cn } from '@/shared/lib/utils';
 
 import { NavbarContainer } from './NavbarContainer';
+import { useIsMobile } from '@/shared/hooks/useIsMobile';
 import { AppBar } from '@vibe/ui/components/AppBar';
 import { AppBarUserPopoverContainer } from './AppBarUserPopoverContainer';
 import { useUserOrganizations } from '@/shared/hooks/useUserOrganizations';
@@ -46,6 +48,7 @@ export function SharedAppLayout() {
   const location = useLocation();
   const isMigrateRoute = location.pathname.startsWith('/migrate');
   const { isSignedIn } = useAuth();
+  const isMobile = useIsMobile();
   const { data: onlineCount } = useDiscordOnlineCount();
   const { data: starCount } = useGitHubStars();
 
@@ -259,7 +262,12 @@ export function SharedAppLayout() {
 
   return (
     <SyncErrorProvider>
-      <div className="flex h-screen bg-primary">
+      <div
+        className={cn(
+          'flex bg-primary',
+          isMobile ? 'h-dvh overflow-hidden' : 'h-screen'
+        )}
+      >
         {!isMigrateRoute && (
           <AppBar
             projects={orderedProjects}

--- a/packages/web-core/src/shared/hooks/useActionVisibilityContext.ts
+++ b/packages/web-core/src/shared/hooks/useActionVisibilityContext.ts
@@ -17,6 +17,8 @@ import { useShape } from '@/shared/integrations/electric/hooks';
 import { useExecutionProcessesContext } from '@/shared/hooks/useExecutionProcessesContext';
 import { useLogsPanel } from '@/shared/hooks/useLogsPanel';
 import { useAuth } from '@/shared/hooks/auth/useAuth';
+import { useIsMobile } from '@/shared/hooks/useIsMobile';
+import { useMobileLayoutStore } from '@/shared/stores/useMobileLayoutStore';
 import { PROJECT_ISSUES_SHAPE } from 'shared/remote-types';
 import type { Merge } from 'shared/types';
 import type {
@@ -45,6 +47,8 @@ export function useActionVisibilityContext(
   const diffPaths = useDiffViewStore((s) => s.diffPaths);
   const diffViewMode = useDiffViewMode();
   const expanded = useUiPreferencesStore((s) => s.expanded);
+  const isMobile = useIsMobile();
+  const mobileActivePanel = useMobileLayoutStore((s) => s.mobileActivePanel);
 
   // Derive kanban state from URL (URL is single source of truth)
   const { projectId: routeProjectId, issueId: routeIssueId } = useParams({
@@ -148,6 +152,8 @@ export function useActionVisibilityContext(
       hasSelectedKanbanIssueParent,
       isCreatingIssue: kanbanCreateMode,
       isSignedIn,
+      isMobile,
+      mobileActivePanel,
     };
   }, [
     layoutMode,
@@ -172,5 +178,7 @@ export function useActionVisibilityContext(
     hasSelectedKanbanIssueParent,
     kanbanCreateMode,
     isSignedIn,
+    isMobile,
+    mobileActivePanel,
   ]);
 }

--- a/packages/web-core/src/shared/hooks/useIsMobile.ts
+++ b/packages/web-core/src/shared/hooks/useIsMobile.ts
@@ -1,0 +1,32 @@
+import { useSyncExternalStore } from 'react';
+
+export const MOBILE_MAX_WIDTH = 767;
+const MEDIA_QUERY = `(max-width: ${MOBILE_MAX_WIDTH}px)`;
+
+/**
+ * Non-hook check for mobile breakpoint. Safe to call outside React components
+ * and in non-DOM environments (returns false when window is unavailable).
+ */
+export function isMobileQuery(): boolean {
+  return (
+    typeof window !== 'undefined' && window.matchMedia(MEDIA_QUERY).matches
+  );
+}
+
+function subscribe(callback: () => void): () => void {
+  const mql = window.matchMedia(MEDIA_QUERY);
+  mql.addEventListener('change', callback);
+  return () => mql.removeEventListener('change', callback);
+}
+
+function getSnapshot(): boolean {
+  return window.matchMedia(MEDIA_QUERY).matches;
+}
+
+function getServerSnapshot(): boolean {
+  return false;
+}
+
+export function useIsMobile(): boolean {
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}

--- a/packages/web-core/src/shared/stores/useMobileLayoutStore.ts
+++ b/packages/web-core/src/shared/stores/useMobileLayoutStore.ts
@@ -1,0 +1,19 @@
+import { create } from 'zustand';
+
+export type MobileActivePanel =
+  | 'sidebar'
+  | 'chat'
+  | 'changes'
+  | 'logs'
+  | 'preview'
+  | 'right-sidebar';
+
+interface MobileLayoutState {
+  mobileActivePanel: MobileActivePanel;
+  setMobileActivePanel: (panel: MobileActivePanel) => void;
+}
+
+export const useMobileLayoutStore = create<MobileLayoutState>((set) => ({
+  mobileActivePanel: 'chat',
+  setMobileActivePanel: (panel) => set({ mobileActivePanel: panel }),
+}));

--- a/packages/web-core/src/shared/types/actions.ts
+++ b/packages/web-core/src/shared/types/actions.ts
@@ -11,6 +11,7 @@ import type { Workspace as RemoteWorkspace } from 'shared/remote-types';
 import type { DiffViewMode } from '@/shared/stores/useDiffViewStore';
 import type { LayoutMode } from '@/shared/stores/useUiPreferencesStore';
 import { RIGHT_MAIN_PANEL_MODES } from '@/shared/stores/useUiPreferencesStore';
+import type { MobileActivePanel } from '@/shared/stores/useMobileLayoutStore';
 import type { IssueCreateRouteOptions } from '@/shared/lib/routes/projectSidebarRoutes';
 
 // Portable type aliases (avoid importing from component containers)
@@ -145,6 +146,10 @@ export interface ActionVisibilityContext {
 
   // Auth state
   isSignedIn: boolean;
+
+  // Mobile state
+  isMobile: boolean;
+  mobileActivePanel: MobileActivePanel;
 }
 
 // Enum discriminant for action target types


### PR DESCRIPTION
## Problem

The Vibe Kanban workspace layout assumes a desktop viewport. On phones (~390px wide), fixed-width sidebars (300px each) cause horizontal overflow, `h-screen` (100vh) doesn't account for iOS Safari's dynamic browser chrome, and users must manually toggle panels on/off to see any single piece of content. The navbar toggle buttons work as independent on/off switches, but on mobile you really only want one panel visible at a time.

## Design Decisions

**One panel at a time, radio-style switching**: On screens ≤767px, the 6 existing navbar toggle buttons become mutually exclusive — tapping one shows that panel and hides the others. The six mobile "screens" are: Workspaces list (sidebar), Chat, Changes/Diff, Logs, Preview, and Right sidebar (Git/Terminal/Notes).

**Separate Zustand store**: Mobile panel state lives in its own `useMobileLayoutStore`, completely isolated from `useUiPreferencesStore`. This avoids two problems:
1. The main store's `.subscribe()` fires on _any_ state change with no diffing, which would trigger wasted scratch persistence API calls on every panel switch
2. Desktop panel state stays untouched — no contamination of persisted preferences

**Keep all panels mounted, hide with CSS**: Instead of conditionally rendering (unmount/remount) panels, inactive panels get `display: none` via the `hidden` Tailwind class. This preserves: half-typed messages (session drafts are server-persisted via scratch with 500ms debounce, but cursor/undo history are local), scroll positions, preview iframes (avoids full page reload), and terminal sessions. Components using `ResizeObserver` (xterm `FitAddon`, Virtuoso virtual scroll) automatically re-measure when their container transitions from `display: none` to visible.

**Breakpoint at 767px**: Sits cleanly below Tailwind's `md` breakpoint (768px), avoiding off-by-one ambiguity.

**AppBar kept as-is**: Hiding the vertical AppBar on mobile was considered but would remove project switching, user menu, and sign-in entry points. It stays visible for now.

**Branch name hidden on mobile**: The navbar center section (branch name) is cleared on mobile to save horizontal space. Users can identify their workspace via the sidebar list where the active workspace is highlighted.

**RightSidebar with `rightMainPanelMode={null}`**: On mobile, the right sidebar gets its own dedicated panel, so passing `null` prevents it from showing a redundant upper section (file tree/process list/preview controls) that duplicates the dedicated Changes/Logs/Preview panels.

**`ctx.isMobile` in actions instead of `window.innerWidth`**: Action `isActive`/`isEnabled` callbacks use the reactive context value for consistency and testability. The `execute` callbacks use a `isMobileQuery()` helper (inline `window.matchMedia` check) since `ActionExecutorContext` doesn't carry visibility state.

## Implementation

### New files (2)
- **`frontend/src/hooks/useIsMobile.ts`** — Reactive hook using `useSyncExternalStore` + `matchMedia('(max-width: 767px)')`. Updates on resize/rotation.
- **`frontend/src/stores/useMobileLayoutStore.ts`** — Lightweight Zustand store: `mobileActivePanel` enum (`'sidebar' | 'chat' | 'changes' | 'logs' | 'preview' | 'right-sidebar'`), defaults to `'chat'`, not persisted.

### Modified files (7)
- **`actions/index.ts`** — Added `isMobile` and `mobileActivePanel` to `ActionVisibilityContext`. Six toggle actions (`ToggleLeftSidebar`, `ToggleLeftMainPanel`, `ToggleChangesMode`, `ToggleLogsMode`, `TogglePreviewMode`, `ToggleRightSidebar`) + `ToggleDevServer` now check mobile state: `execute` calls `setMobileActivePanel(...)` on mobile instead of the desktop toggle logic; `isActive` checks `mobileActivePanel` on mobile; `isEnabled` on `ToggleLeftMainPanel` returns `true` on mobile (radio behavior, always enabled).
- **`actions/useActionVisibility.ts`** — Wires `useIsMobile()` and `useMobileLayoutStore` into the `ActionVisibilityContext` returned by `useActionVisibilityContext()`.
- **`containers/SharedAppLayout.tsx`** — Switches root container from `h-screen` to `h-dvh overflow-hidden` on mobile, fixing the iOS Safari 100vh overflow issue.
- **`containers/NavbarContainer.tsx`** — Passes empty string for `workspaceTitle` on mobile.
- **`containers/WorkspacesLayout.tsx`** — Core layout change. On mobile, renders all 6 panels wrapped in `hidden`/`h-full` divs based on `mobileActivePanel`. Guards the desktop-only `rightMainPanelMode === null` reset effect. Adds effect to default to `'sidebar'` when no workspace is selected. Providers (`CreateModeProvider`/`ExecutionProcessesProvider`, `ReviewProvider`, `ChangesViewProvider`) wrap all panels identically to the desktop path.
- **`containers/RightSidebar.tsx`** — Conditionally removes `border-l` on mobile (full-width rendering).
- **`containers/WorkspacesSidebarContainer.tsx`** — Auto-navigates to chat (`setMobileActivePanel('chat')`) when a workspace is selected on mobile.

## Verification

Have been using personally, looks good!

Please also consider #2889 