### PR TITLE
Electric redundancy

### DIFF
--- a/crates/remote/.sqlx/query-5a652dd2a3d8bcbc8824584f8a1d9ccbb1fa56f54575b6c9dcd855a26de1edc5.json
+++ b/crates/remote/.sqlx/query-5a652dd2a3d8bcbc8824584f8a1d9ccbb1fa56f54575b6c9dcd855a26de1edc5.json
@@ -1,0 +1,34 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT p.pubname AS pubname, n.nspname AS schema_name, c.relname AS table_name\n           FROM pg_publication_rel pr\n           JOIN pg_publication p ON pr.prpubid = p.oid\n           JOIN pg_class c ON pr.prrelid = c.oid\n           JOIN pg_namespace n ON c.relnamespace = n.oid\n           WHERE p.pubname = ANY($1)",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "pubname",
+        "type_info": "Name"
+      },
+      {
+        "ordinal": 1,
+        "name": "schema_name",
+        "type_info": "Name"
+      },
+      {
+        "ordinal": 2,
+        "name": "table_name",
+        "type_info": "Name"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "NameArray"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "5a652dd2a3d8bcbc8824584f8a1d9ccbb1fa56f54575b6c9dcd855a26de1edc5"
+}

--- a/crates/remote/.sqlx/query-c30d54026d89b9cf9c938f5aff5cf09ca12af2ab456094aac9a417473645b7e4.json
+++ b/crates/remote/.sqlx/query-c30d54026d89b9cf9c938f5aff5cf09ca12af2ab456094aac9a417473645b7e4.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT pubname FROM pg_publication WHERE pubname = ANY($1)",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "pubname",
+        "type_info": "Name"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "NameArray"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "c30d54026d89b9cf9c938f5aff5cf09ca12af2ab456094aac9a417473645b7e4"
+}

--- a/crates/remote/.sqlx/query-ce7908cdeecd4b4b94c92256bd800c165567ebe5644cfd702a9e4c0bb24091d4.json
+++ b/crates/remote/.sqlx/query-ce7908cdeecd4b4b94c92256bd800c165567ebe5644cfd702a9e4c0bb24091d4.json
@@ -1,0 +1,26 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT n.nspname AS schema_name, c.relname AS table_name\n           FROM pg_publication_rel pr\n           JOIN pg_publication p ON pr.prpubid = p.oid\n           JOIN pg_class c ON pr.prrelid = c.oid\n           JOIN pg_namespace n ON c.relnamespace = n.oid\n           WHERE p.pubname = 'electric_publication_default'",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "schema_name",
+        "type_info": "Name"
+      },
+      {
+        "ordinal": 1,
+        "name": "table_name",
+        "type_info": "Name"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false,
+      false
+    ]
+  },
+  "hash": "ce7908cdeecd4b4b94c92256bd800c165567ebe5644cfd702a9e4c0bb24091d4"
+}

--- a/crates/remote/src/app.rs
+++ b/crates/remote/src/app.rs
@@ -45,6 +45,15 @@ impl Server {
                 .context("failed to set electric role password")?;
         }
 
+        if !config.electric_publication_names.is_empty() {
+            db::electric_publications::ensure_electric_publications(
+                &pool,
+                &config.electric_publication_names,
+            )
+            .await
+            .context("failed to sync Electric publications")?;
+        }
+
         let auth_config = config.auth.clone();
         let jwt = Arc::new(JwtService::new(auth_config.jwt_secret().clone()));
 

--- a/crates/remote/src/db/electric_publications.rs
+++ b/crates/remote/src/db/electric_publications.rs
@@ -1,0 +1,144 @@
+use std::collections::HashSet;
+
+use sqlx::PgPool;
+
+#[derive(Debug)]
+struct PublicationTable {
+    schema_name: String,
+    table_name: String,
+}
+
+#[derive(Debug, Hash, PartialEq, Eq)]
+struct PublicationTableRef {
+    pubname: String,
+    schema_name: String,
+    table_name: String,
+}
+
+pub(crate) async fn ensure_electric_publications(
+    pool: &PgPool,
+    publication_names: &[String],
+) -> Result<(), sqlx::Error> {
+    if publication_names.is_empty() {
+        return Ok(());
+    }
+
+    tracing::info!(
+        publication_count = publication_names.len(),
+        publications = ?publication_names,
+        "Electric publication sync starting"
+    );
+
+    let mut tx = pool.begin().await?;
+
+    sqlx::query(r#"SELECT pg_advisory_xact_lock(hashtext('electric_publication_sync'))"#)
+        .execute(&mut *tx)
+        .await?;
+
+    let existing_publications = sqlx::query_scalar!(
+        r#"SELECT pubname FROM pg_publication WHERE pubname = ANY($1)"#,
+        publication_names
+    )
+    .fetch_all(&mut *tx)
+    .await?;
+    let existing_publications: HashSet<String> = existing_publications.into_iter().collect();
+
+    let mut created_publications = Vec::new();
+    let mut skipped_publications = Vec::new();
+
+    for publication in publication_names {
+        if !existing_publications.contains(publication) {
+            let sql = format!("CREATE PUBLICATION {}", quote_ident(publication));
+            sqlx::query(&sql).execute(&mut *tx).await?;
+            created_publications.push(publication.clone());
+        } else {
+            skipped_publications.push(publication.clone());
+        }
+    }
+
+    if !created_publications.is_empty() {
+        tracing::info!(publications = ?created_publications, "Created missing Electric publications");
+    }
+    if !skipped_publications.is_empty() {
+        tracing::info!(publications = ?skipped_publications, "Electric publications already exist (skipped)");
+    }
+
+    let tables = sqlx::query_as!(
+        PublicationTable,
+        r#"SELECT n.nspname AS schema_name, c.relname AS table_name
+           FROM pg_publication_rel pr
+           JOIN pg_publication p ON pr.prpubid = p.oid
+           JOIN pg_class c ON pr.prrelid = c.oid
+           JOIN pg_namespace n ON c.relnamespace = n.oid
+           WHERE p.pubname = 'electric_publication_default'"#
+    )
+    .fetch_all(&mut *tx)
+    .await?;
+
+    tracing::info!(
+        default_table_count = tables.len(),
+        "Loaded tables from electric_publication_default"
+    );
+
+    let existing_pairs = sqlx::query_as!(
+        PublicationTableRef,
+        r#"SELECT p.pubname AS pubname, n.nspname AS schema_name, c.relname AS table_name
+           FROM pg_publication_rel pr
+           JOIN pg_publication p ON pr.prpubid = p.oid
+           JOIN pg_class c ON pr.prrelid = c.oid
+           JOIN pg_namespace n ON c.relnamespace = n.oid
+           WHERE p.pubname = ANY($1)"#,
+        publication_names
+    )
+    .fetch_all(&mut *tx)
+    .await?;
+    let existing_pairs: HashSet<PublicationTableRef> = existing_pairs.into_iter().collect();
+
+    let mut missing_pairs = Vec::new();
+    for table in &tables {
+        for publication in publication_names {
+            let key = PublicationTableRef {
+                pubname: publication.clone(),
+                schema_name: table.schema_name.clone(),
+                table_name: table.table_name.clone(),
+            };
+            if !existing_pairs.contains(&key) {
+                missing_pairs.push(key);
+            }
+        }
+    }
+
+    tracing::info!(
+        missing_pair_count = missing_pairs.len(),
+        "Computed missing publication/table mappings"
+    );
+
+    for entry in &missing_pairs {
+        let sql = format!(
+            "ALTER PUBLICATION {} ADD TABLE {}.{}",
+            quote_ident(&entry.pubname),
+            quote_ident(&entry.schema_name),
+            quote_ident(&entry.table_name)
+        );
+        sqlx::query(&sql).execute(&mut *tx).await?;
+    }
+
+    if !missing_pairs.is_empty() {
+        tracing::info!(
+            added_pair_count = missing_pairs.len(),
+            "Added missing tables to Electric publications"
+        );
+    } else {
+        tracing::info!("No missing tables to add to Electric publications");
+    }
+
+    tx.commit().await?;
+
+    tracing::info!("Electric publication sync completed");
+
+    Ok(())
+}
+
+fn quote_ident(ident: &str) -> String {
+    format!("\"{}\"", ident.replace('\"', "\"\""))
+}

--- a/crates/remote/src/db/mod.rs
+++ b/crates/remote/src/db/mod.rs
@@ -1,6 +1,7 @@
 pub mod attachments;
 pub mod auth;
 pub mod blobs;
+pub mod electric_publications;
 pub mod github_app;
 pub mod identity_errors;
 pub mod invitations;

--- a/crates/remote/src/routes/electric_proxy.rs
+++ b/crates/remote/src/routes/electric_proxy.rs
@@ -28,6 +28,7 @@ pub(crate) struct ShapeQuery {
 }
 
 const ELECTRIC_PARAMS: &[&str] = &["offset", "handle", "live", "cursor", "columns"];
+const ELECTRIC_STICKY_HEADER: &str = "x-vk-electric-sticky";
 
 pub fn router() -> Router<AppState> {
     let mut router = Router::new();
@@ -46,6 +47,7 @@ pub(crate) async fn proxy_table(
     shape: &dyn ShapeExport,
     client_params: &HashMap<String, String>,
     electric_params: &[String],
+    session_id: Uuid,
 ) -> Result<Response, ProxyError> {
     // Build the Electric URL
     let mut origin_url = url::Url::parse(&state.config.electric_url)
@@ -86,6 +88,7 @@ pub(crate) async fn proxy_table(
     let response = state
         .http_client
         .get(origin_url.as_str())
+        .header(ELECTRIC_STICKY_HEADER, session_id.to_string())
         .send()
         .await
         .map_err(ProxyError::Connection)?;

--- a/crates/remote/src/shape_route.rs
+++ b/crates/remote/src/shape_route.rs
@@ -187,6 +187,7 @@ fn build_proxy_handler(
                     shape,
                     &query.params,
                     &[query.organization_id.to_string()],
+                    ctx.session_id,
                 )
                 .await
             },
@@ -209,6 +210,7 @@ fn build_proxy_handler(
                     shape,
                     &query.params,
                     &[query.organization_id.to_string(), ctx.user.id.to_string()],
+                    ctx.session_id,
                 )
                 .await
             },
@@ -223,7 +225,14 @@ fn build_proxy_handler(
                     .await
                     .map_err(|e| ProxyError::Authorization(e.to_string()))?;
 
-                proxy_table(&state, shape, &query.params, &[project_id.to_string()]).await
+                proxy_table(
+                    &state,
+                    shape,
+                    &query.params,
+                    &[project_id.to_string()],
+                    ctx.session_id,
+                )
+                .await
             },
         ),
 
@@ -236,7 +245,14 @@ fn build_proxy_handler(
                     .await
                     .map_err(|e| ProxyError::Authorization(e.to_string()))?;
 
-                proxy_table(&state, shape, &query.params, &[issue_id.to_string()]).await
+                proxy_table(
+                    &state,
+                    shape,
+                    &query.params,
+                    &[issue_id.to_string()],
+                    ctx.session_id,
+                )
+                .await
             },
         ),
 
@@ -244,7 +260,14 @@ fn build_proxy_handler(
             move |State(state): State<AppState>,
                   Extension(ctx): Extension<RequestContext>,
                   Query(query): Query<ShapeQuery>| async move {
-                proxy_table(&state, shape, &query.params, &[ctx.user.id.to_string()]).await
+                proxy_table(
+                    &state,
+                    shape,
+                    &query.params,
+                    &[ctx.user.id.to_string()],
+                    ctx.session_id,
+                )
+                .await
             },
         ),
     }


### PR DESCRIPTION
Enable support for multiple electric replicas in the remote backend.

Currently, each electric replica needs a separate Postgres publication as both replication slots and publications are controlled by a single environment variable in Electric SQL. A bootstrap job was added to create publications for the expected number of replicas and and grant access to the Electric Shape PostgreSQL tables.

The remote backend supplements electric requests with the user session id as a sticky header for the electric load L7 load balancer, which will directs the same session to the same electric instance to reduce the chance of Electric cache misses.
