### PR TITLE
Enforce login when VK_ENFORCE_LOGIN is enabled

### DIFF
--- a/crates/server/src/middleware/enforce_login.rs
+++ b/crates/server/src/middleware/enforce_login.rs
@@ -1,0 +1,45 @@
+use axum::{
+    body::Body,
+    extract::State,
+    http::{Request, StatusCode},
+    middleware::Next,
+    response::{IntoResponse, Response},
+};
+use api_types::LoginStatus;
+
+use crate::DeploymentImpl;
+
+/// Middleware to enforce login when VK_ENFORCE_LOGIN environment variable is set to true.
+/// 
+/// This middleware checks if VK_ENFORCE_LOGIN is enabled and if the user is logged in.
+/// If enforcement is enabled and the user is not logged in, it returns 401 Unauthorized.
+pub async fn enforce_login_middleware(
+    State(deployment): State<DeploymentImpl>,
+    request: Request<Body>,
+    next: Next,
+) -> Response {
+    // Check if enforce_login is enabled via environment variable
+    let enforce_login = std::env::var("VK_ENFORCE_LOGIN")
+        .ok()
+        .and_then(|v| v.parse::<bool>().ok())
+        .unwrap_or(false);
+
+    // If not enforcing, proceed with the request
+    if !enforce_login {
+        return next.run(request).await;
+    }
+
+    // Check login status
+    let login_status = deployment.get_login_status().await;
+
+    match login_status {
+        LoginStatus::LoggedIn { .. } => {
+            // User is logged in, proceed with the request
+            next.run(request).await
+        }
+        LoginStatus::LoggedOut => {
+            // User is not logged in and enforce_login is enabled
+            StatusCode::UNAUTHORIZED.into_response()
+        }
+    }
+}

--- a/crates/server/src/middleware/mod.rs
+++ b/crates/server/src/middleware/mod.rs
@@ -1,5 +1,7 @@
+pub mod enforce_login;
 pub mod model_loaders;
 pub mod origin;
 
+pub use enforce_login::*;
 pub use model_loaders::*;
 pub use origin::*;

--- a/crates/server/src/routes/config.rs
+++ b/crates/server/src/routes/config.rs
@@ -94,6 +94,8 @@ pub struct UserSystemInfo {
     pub capabilities: HashMap<String, Vec<BaseAgentCapability>>,
     pub shared_api_base: Option<String>,
     pub preview_proxy_port: Option<u16>,
+    /// Whether login is enforced (based on VK_ENFORCE_LOGIN env var)
+    pub enforce_login: bool,
 }
 
 // TODO: update frontend, BE schema has changed, this replaces GET /config and /config/constants
@@ -127,6 +129,10 @@ async fn get_user_system_info(
         },
         shared_api_base: deployment.shared_api_base(),
         preview_proxy_port: crate::preview_proxy::get_proxy_port(),
+        enforce_login: std::env::var("VK_ENFORCE_LOGIN")
+            .ok()
+            .and_then(|v| v.parse::<bool>().ok())
+            .unwrap_or(false),
     };
 
     ResponseJson(ApiResponse::success(user_system_info))

--- a/crates/server/src/routes/mod.rs
+++ b/crates/server/src/routes/mod.rs
@@ -30,14 +30,19 @@ pub mod terminal;
 
 pub fn router(deployment: DeploymentImpl) -> IntoMakeService<Router> {
     // Create routers with different middleware layers
-    let base_routes = Router::new()
+    // Routes that should NOT require authentication even when VK_ENFORCE_LOGIN is enabled
+    let public_routes = Router::new()
         .route("/health", get(health::health_check))
-        .merge(config::router())
+        .merge(config::router())  // /config/info and other config endpoints
+        .merge(oauth::router())   // /auth/* endpoints for login/logout
+        .with_state(deployment.clone());
+
+    // Routes that require authentication when VK_ENFORCE_LOGIN is enabled
+    let protected_routes = Router::new()
         .merge(containers::router(&deployment))
         .merge(task_attempts::router(&deployment))
         .merge(execution_processes::router(&deployment))
         .merge(tags::router(&deployment))
-        .merge(oauth::router())
         .merge(organizations::router())
         .merge(filesystem::router())
         .merge(repo::router())
@@ -50,6 +55,16 @@ pub fn router(deployment: DeploymentImpl) -> IntoMakeService<Router> {
         .merge(terminal::router())
         .nest("/remote", remote::router())
         .nest("/images", images::routes())
+        .layer(axum::middleware::from_fn_with_state(
+            deployment.clone(),
+            middleware::enforce_login_middleware,
+        ))
+        .with_state(deployment.clone());
+
+    // Combine public and protected routes
+    let base_routes = Router::new()
+        .merge(public_routes)
+        .merge(protected_routes)
         .layer(ValidateRequestHeaderLayer::custom(
             middleware::validate_origin,
         ))

--- a/frontend/src/components/ConfigProvider.tsx
+++ b/frontend/src/components/ConfigProvider.tsx
@@ -38,6 +38,7 @@ interface UserSystemContextType {
   capabilities: Record<string, BaseAgentCapability[]> | null;
   analyticsUserId: string | null;
   loginStatus: LoginStatus | null;
+  enforceLogin: boolean;
   setEnvironment: (env: Environment | null) => void;
   setProfiles: (profiles: Record<string, ExecutorProfile> | null) => void;
   setCapabilities: (caps: Record<string, BaseAgentCapability[]> | null) => void;
@@ -71,6 +72,7 @@ export function UserSystemProvider({ children }: UserSystemProviderProps) {
   const environment = userSystemInfo?.environment || null;
   const analyticsUserId = userSystemInfo?.analytics_user_id || null;
   const loginStatus = userSystemInfo?.login_status || null;
+  const enforceLogin = userSystemInfo?.enforce_login ?? false;
   const profiles =
     (userSystemInfo?.executors as Record<string, ExecutorProfile> | null) ||
     null;
@@ -195,6 +197,7 @@ export function UserSystemProvider({ children }: UserSystemProviderProps) {
       capabilities,
       analyticsUserId,
       loginStatus,
+      enforceLogin,
       updateConfig,
       saveConfig,
       updateAndSaveConfig,
@@ -211,6 +214,7 @@ export function UserSystemProvider({ children }: UserSystemProviderProps) {
       capabilities,
       analyticsUserId,
       loginStatus,
+      enforceLogin,
       updateConfig,
       saveConfig,
       updateAndSaveConfig,

--- a/frontend/src/components/ui-new/containers/SharedAppLayout.tsx
+++ b/frontend/src/components/ui-new/containers/SharedAppLayout.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { DropResult } from '@hello-pangea/dnd';
-import { Outlet, useLocation, useNavigate } from '@tanstack/react-router';
+import { Navigate, Outlet, useLocation, useNavigate } from '@tanstack/react-router';
 import { SyncErrorProvider } from '@/contexts/SyncErrorContext';
 
 import { NavbarContainer } from './NavbarContainer';
@@ -8,6 +8,7 @@ import { AppBar } from '../primitives/AppBar';
 import { useUserOrganizations } from '@/hooks/useUserOrganizations';
 import { useOrganizationStore } from '@/stores/useOrganizationStore';
 import { useAuth } from '@/hooks/auth/useAuth';
+import { useUserSystem } from '@/components/ConfigProvider';
 import {
   buildProjectRootPath,
   parseProjectSidebarRoute,
@@ -36,6 +37,12 @@ export function SharedAppLayout() {
   const location = useLocation();
   const isMigrateRoute = location.pathname.startsWith('/migrate');
   const { isSignedIn } = useAuth();
+  const { enforceLogin, loading } = useUserSystem();
+
+  // If enforce_login is enabled and user is not signed in, redirect to onboarding
+  if (enforceLogin && !isSignedIn && !loading) {
+    return <Navigate to="/onboarding" />;
+  }
 
   // Register CMD+K shortcut globally for all routes under SharedAppLayout
   useCommandBarShortcut(() => CommandBarDialog.show());

--- a/frontend/src/pages/ui-new/OnboardingSignInPage.tsx
+++ b/frontend/src/pages/ui-new/OnboardingSignInPage.tsx
@@ -69,7 +69,7 @@ export function OnboardingSignInPage() {
   const { t } = useTranslation('common');
   const { theme } = useTheme();
   const posthog = usePostHog();
-  const { config, loginStatus, loading, updateAndSaveConfig } = useUserSystem();
+  const { config, loginStatus, loading, updateAndSaveConfig, enforceLogin } = useUserSystem();
   const setSelectedOrgId = useOrganizationStore((s) => s.setSelectedOrgId);
 
   const [showComparison, setShowComparison] = useState(false);
@@ -260,30 +260,32 @@ export function OnboardingSignInPage() {
                 />
               </section>
 
-              <div className="flex justify-center">
-                <button
-                  type="button"
-                  className="text-sm text-low hover:text-normal underline underline-offset-2"
-                  onClick={() => {
-                    if (!showComparison) {
-                      trackRemoteOnboardingEvent(
-                        REMOTE_ONBOARDING_EVENTS.MORE_OPTIONS_OPENED,
-                        {
-                          stage: 'sign_in',
-                        }
-                      );
-                    }
-                    setShowComparison(true);
-                  }}
-                  disabled={saving || pendingProvider !== null}
-                >
-                  {t('onboardingSignIn.moreOptions')}
-                </button>
-              </div>
+              {!enforceLogin && (
+                <div className="flex justify-center">
+                  <button
+                    type="button"
+                    className="text-sm text-low hover:text-normal underline underline-offset-2"
+                    onClick={() => {
+                      if (!showComparison) {
+                        trackRemoteOnboardingEvent(
+                          REMOTE_ONBOARDING_EVENTS.MORE_OPTIONS_OPENED,
+                          {
+                            stage: 'sign_in',
+                          }
+                        );
+                      }
+                      setShowComparison(true);
+                    }}
+                    disabled={saving || pendingProvider !== null}
+                  >
+                    {t('onboardingSignIn.moreOptions')}
+                  </button>
+                </div>
+              )}
             </>
           )}
 
-          {showComparison && !isLoggedIn && (
+          {!enforceLogin && showComparison && !isLoggedIn && (
             <section className="space-y-base rounded-sm border border-border bg-panel p-base">
               <div className="overflow-x-auto rounded-sm border border-border">
                 <table className="w-full border-collapse">

--- a/frontend/src/pages/ui-new/RootRedirectPage.tsx
+++ b/frontend/src/pages/ui-new/RootRedirectPage.tsx
@@ -9,7 +9,7 @@ import { toOnboarding, toWorkspacesCreate } from '@/lib/routes/navigation';
 const DEFAULT_DESTINATION = '/workspaces/create';
 
 export function RootRedirectPage() {
-  const { config, loading, loginStatus } = useUserSystem();
+  const { config, loading, loginStatus, enforceLogin } = useUserSystem();
   const setSelectedOrgId = useOrganizationStore((s) => s.setSelectedOrgId);
   const [destination, setDestination] = useState<string | null>(null);
 
@@ -22,6 +22,12 @@ export function RootRedirectPage() {
       }
 
       if (!config.remote_onboarding_acknowledged) {
+        setDestination('/onboarding');
+        return;
+      }
+
+      // If enforce_login is enabled and user is not logged in, redirect to onboarding
+      if (enforceLogin && loginStatus?.status !== 'loggedin') {
         setDestination('/onboarding');
         return;
       }
@@ -45,7 +51,7 @@ export function RootRedirectPage() {
     return () => {
       cancelled = true;
     };
-  }, [config, loading, loginStatus?.status, setSelectedOrgId]);
+  }, [config, loading, loginStatus?.status, setSelectedOrgId, enforceLogin]);
 
   if (loading || !config || !destination) {
     return (

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -260,7 +260,11 @@ export type UserSystemInfo = { config: Config, analytics_user_id: string, login_
 /**
  * Capabilities supported per executor (e.g., { "CLAUDE_CODE": ["SESSION_FORK"] })
  */
-capabilities: { [key in string]?: Array<BaseAgentCapability> }, shared_api_base: string | null, preview_proxy_port: number | null, executors: { [key in BaseCodingAgent]?: ExecutorProfile }, };
+capabilities: { [key in string]?: Array<BaseAgentCapability> }, shared_api_base: string | null, preview_proxy_port: number | null, 
+/**
+ * Whether login is enforced (based on VK_ENFORCE_LOGIN env var)
+ */
+enforce_login: boolean, executors: { [key in BaseCodingAgent]?: ExecutorProfile }, };
 
 export type Environment = { os_type: string, os_version: string, os_architecture: string, bitness: string, };
 


### PR DESCRIPTION

## What changed

Added an optional `VK_ENFORCE_LOGIN` environment variable to enforce user authentication across the entire Vibe Kanban application:

- Added `enforce_login` field to `UserSystemInfo` struct in backend
- Implemented `enforce_login_middleware` for API protection
- Split API routes into public and protected categories
- Added frontend route guards in `SharedAppLayout` and `RootRedirectPage`
- Hide skip login options in `OnboardingSignInPage` when enforcement is enabled
- Updated TypeScript types to include `enforce_login: boolean`

## Why

This PR enables deployment scenarios where anonymous usage must be prevented, providing administrators with fine-grained control over access requirements:

- **Multi-tenant deployments**: Ensure all users are authenticated and identifiable
- **Enterprise environments**: Comply with security policies requiring authentication
- **Shared infrastructure**: Prevent resource abuse from anonymous users
- **Backward compatibility**: Maintains existing behavior by default (enforcement disabled)

Without this feature, Vibe Kanban allows users to skip sign-in and create workspaces anonymously, which may not be acceptable in certain deployment contexts.

## Important implementation details

### Three-layer protection architecture:

1. **Backend API middleware** (primary security layer)
   - `enforce_login_middleware` checks `VK_ENFORCE_LOGIN` env var and login status
   - Returns 401 Unauthorized for unauthenticated requests to protected routes
   - Public routes exempt: `/api/health`, `/api/config/*`, `/api/auth/*`
   - Prevents bypass via direct API calls (most critical security measure)

2. **Frontend layout guards** (UX layer)
   - `SharedAppLayout`: Protects all `/workspaces` and `/projects` routes
   - Redirects unauthenticated users to `/onboarding` when enforcement enabled

3. **Frontend route logic** (entry point)
   - `RootRedirectPage`: Redirects to `/onboarding` if enforce_login && not logged in
   - `OnboardingSignInPage`: Hides "More options" and skip button when enforcement enabled

### Configuration:

- Environment variable: `VK_ENFORCE_LOGIN=true` (default: `false`)
- Read once at runtime via `std::env::var()` in `/api/info` endpoint
- Exposed to frontend through `UserSystemInfo` response
- Single source of truth: backend controls the enforcement flag

### Route classification:

**Public routes** (always accessible):
- Frontend: `/`, `/onboarding`, `/onboarding/sign-in`
- Backend: Health checks, config, OAuth authentication endpoints

**Protected routes** (require login when VK_ENFORCE_LOGIN=true):
- Frontend: All `_app` routes (workspaces, projects, settings, etc.)
- Backend: All business logic APIs (workspace CRUD, agent interactions, etc.)

## Testing

```bash
# Format and lint
pnpm run format
cargo fmt

# Type checking
pnpm tsc --noEmit
cargo check --bin server

# Manual testing - enforcement disabled (default behavior)
export VK_ENFORCE_LOGIN=false
export BACKEND_PORT=3002
pnpm backend:dev:watch
pnpm frontend:dev
# Verify: Can skip login, create workspaces anonymously

# Manual testing - enforcement enabled
export VK_ENFORCE_LOGIN=true
export BACKEND_PORT=3002
pnpm backend:dev:watch
pnpm frontend:dev
# Verify: 
# 1. Cannot skip login (no "More options" button)
# 2. Unauthenticated access to /workspaces redirects to /onboarding
# 3. Direct API calls return 401 when not authenticated
# 4. After OAuth login, all features work normally
```

## Notes

- Changes are minimal and surgical - only affects authentication flow
- No modifications to existing business logic or database schema
- Default behavior unchanged - enforcement is opt-in
- Compatible with both GitHub and Google OAuth providers
