### PR TITLE
Hide Workspaces button in remote app bar (Vibe Kanban)

### DIFF
--- a/packages/remote-web/src/app/layout/RemoteAppShell.tsx
+++ b/packages/remote-web/src/app/layout/RemoteAppShell.tsx
@@ -131,6 +131,7 @@ export function RemoteAppShell({ children }: RemoteAppShellProps) {
         projects={projects}
         onCreateProject={handleCreateProject}
         onWorkspacesClick={handleWorkspacesClick}
+        showWorkspacesButton={false}
         onProjectClick={handleProjectClick}
         onProjectsDragEnd={() => {}}
         isSavingProjectOrder={true}

--- a/packages/ui/src/components/AppBar.tsx
+++ b/packages/ui/src/components/AppBar.tsx
@@ -45,6 +45,7 @@ interface AppBarProps {
   projects: AppBarProject[];
   onCreateProject: () => void;
   onWorkspacesClick: () => void;
+  showWorkspacesButton?: boolean;
   onProjectClick: (projectId: string) => void;
   onProjectsDragEnd: (result: DropResult) => void;
   isSavingProjectOrder?: boolean;
@@ -71,6 +72,7 @@ export function AppBar({
   projects,
   onCreateProject,
   onWorkspacesClick,
+  showWorkspacesButton = true,
   onProjectClick,
   onProjectsDragEnd,
   isSavingProjectOrder,
@@ -95,15 +97,16 @@ export function AppBar({
         'bg-secondary border-r border-border'
       )}
     >
-      {/* Top section: Workspaces button */}
-      <div className="flex flex-col items-center gap-1">
-        <AppBarButton
-          icon={LayoutIcon}
-          label="Workspaces"
-          isActive={isWorkspacesActive}
-          onClick={onWorkspacesClick}
-        />
-      </div>
+      {showWorkspacesButton && (
+        <div className="flex flex-col items-center gap-1">
+          <AppBarButton
+            icon={LayoutIcon}
+            label="Workspaces"
+            isActive={isWorkspacesActive}
+            onClick={onWorkspacesClick}
+          />
+        </div>
+      )}
 
       {/* Project management popover for unsigned users */}
       {!isSignedIn && (


### PR DESCRIPTION
## What changed
- Added an optional `showWorkspacesButton` prop to the shared `AppBar` component, defaulting to `true`.
- Wrapped the Workspaces button render in `AppBar` behind `showWorkspacesButton`.
- Set `showWorkspacesButton={false}` in `RemoteAppShell` so the remote web app bar no longer shows the Workspaces button.

## Why
This branch’s task was to hide the Workspaces button specifically in the remote web app bar. The implementation keeps the change minimal and readable while scoping behavior to remote web only.

## Implementation details
- `packages/ui/src/components/AppBar.tsx`
  - `AppBarProps` now supports `showWorkspacesButton?: boolean`.
  - The prop defaults to `true` to preserve existing behavior for other `AppBar` consumers.
  - The Workspaces button block is conditionally rendered only when the flag is enabled.
- `packages/remote-web/src/app/layout/RemoteAppShell.tsx`
  - Passes `showWorkspacesButton={false}` to `AppBar`.

This avoids route-level or migration-related changes and keeps local/shared layouts unchanged.

Validation performed:
- `pnpm run format`
- `pnpm --filter @vibe/ui run check`
- `pnpm --filter @vibe/remote-web run check`

This PR was written using [Vibe Kanban](https://vibekanban.com)
