### PR TITLE
Persist last selected org and project in scratch store (Vibe Kanban)

### DIFF
--- a/crates/db/src/models/scratch.rs
+++ b/crates/db/src/models/scratch.rs
@@ -135,6 +135,12 @@ pub struct UiPreferencesData {
     /// Workspace sidebar sort preferences
     #[serde(default)]
     pub workspace_sort: WorkspaceSortStateData,
+    /// Last selected organization ID
+    #[serde(default)]
+    pub selected_org_id: Option<String>,
+    /// Last selected project ID
+    #[serde(default)]
+    pub selected_project_id: Option<String>,
 }
 
 /// Linked issue data for draft workspace scratch

--- a/packages/web-core/src/pages/root/RootRedirectPage.tsx
+++ b/packages/web-core/src/pages/root/RootRedirectPage.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import { useUserSystem } from '@/shared/hooks/useUserSystem';
 import { getFirstProjectDestination } from '@/shared/lib/firstProjectDestination';
 import { useOrganizationStore } from '@/shared/stores/useOrganizationStore';
+import { useUiPreferencesStore } from '@/shared/stores/useUiPreferencesStore';
 import { useAppNavigation } from '@/shared/hooks/useAppNavigation';
 
 export function RootRedirectPage() {
@@ -26,7 +27,16 @@ export function RootRedirectPage() {
         return;
       }
 
-      const destination = await getFirstProjectDestination(setSelectedOrgId);
+      // Read saved selections imperatively to avoid re-triggering this effect
+      // when the scratch store initializes from the server
+      const { selectedOrgId, selectedProjectId } =
+        useUiPreferencesStore.getState();
+
+      const destination = await getFirstProjectDestination(
+        setSelectedOrgId,
+        selectedOrgId,
+        selectedProjectId
+      );
       if (!isActive) {
         return;
       }

--- a/packages/web-core/src/shared/components/ui-new/containers/SharedAppLayout.tsx
+++ b/packages/web-core/src/shared/components/ui-new/containers/SharedAppLayout.tsx
@@ -157,6 +157,16 @@ export function SharedAppLayout() {
   const isWorkspacesActive = isWorkspacesDestination(currentDestination);
   const activeProjectId = projectDestination?.projectId ?? null;
 
+  // Persist last selected project to scratch store
+  const setSelectedProjectId = useUiPreferencesStore(
+    (s) => s.setSelectedProjectId
+  );
+  useEffect(() => {
+    if (activeProjectId) {
+      setSelectedProjectId(activeProjectId);
+    }
+  }, [activeProjectId, setSelectedProjectId]);
+
   const handleWorkspacesClick = useCallback(() => {
     appNavigation.goToWorkspaces();
   }, [appNavigation]);

--- a/packages/web-core/src/shared/hooks/useUiPreferencesScratch.ts
+++ b/packages/web-core/src/shared/hooks/useUiPreferencesScratch.ts
@@ -42,6 +42,8 @@ function storeToScratchData(state: {
   workspacePanelStates: Record<string, WorkspacePanelState>;
   workspaceFilters: WorkspaceFilterState;
   workspaceSort: WorkspaceSortState;
+  selectedOrgId: string | null;
+  selectedProjectId: string | null;
 }): UiPreferencesData {
   const workspacePanelStates: { [key: string]: WorkspacePanelStateData } = {};
   for (const [key, value] of Object.entries(state.workspacePanelStates)) {
@@ -70,6 +72,8 @@ function storeToScratchData(state: {
       sort_by: state.workspaceSort.sortBy,
       sort_order: state.workspaceSort.sortOrder,
     },
+    selected_org_id: state.selectedOrgId,
+    selected_project_id: state.selectedProjectId,
   };
 }
 
@@ -89,6 +93,8 @@ function scratchDataToStore(data: UiPreferencesData): {
   workspacePanelStates: Record<string, WorkspacePanelState>;
   workspaceFilters: WorkspaceFilterState;
   workspaceSort: WorkspaceSortState;
+  selectedOrgId: string | null;
+  selectedProjectId: string | null;
 } {
   const workspacePanelStates: Record<string, WorkspacePanelState> = {};
   if (data.workspace_panel_states) {
@@ -138,6 +144,8 @@ function scratchDataToStore(data: UiPreferencesData): {
       sortOrder:
         (data.workspace_sort?.sort_order as WorkspaceSortOrder) ?? 'desc',
     },
+    selectedOrgId: data.selected_org_id ?? null,
+    selectedProjectId: data.selected_project_id ?? null,
   };
 }
 
@@ -170,6 +178,8 @@ export function useUiPreferencesScratch() {
     workspacePanelStates: state.workspacePanelStates,
     workspaceFilters: state.workspaceFilters,
     workspaceSort: state.workspaceSort,
+    selectedOrgId: state.selectedOrgId,
+    selectedProjectId: state.selectedProjectId,
   }));
 
   // Extract scratch data
@@ -197,6 +207,8 @@ export function useUiPreferencesScratch() {
       workspacePanelStates: currentState.workspacePanelStates,
       workspaceFilters: currentState.workspaceFilters,
       workspaceSort: currentState.workspaceSort,
+      selectedOrgId: currentState.selectedOrgId,
+      selectedProjectId: currentState.selectedProjectId,
     });
 
     try {
@@ -240,6 +252,8 @@ export function useUiPreferencesScratch() {
         workspacePanelStates: serverState.workspacePanelStates,
         workspaceFilters: serverState.workspaceFilters,
         workspaceSort: serverState.workspaceSort,
+        selectedOrgId: serverState.selectedOrgId,
+        selectedProjectId: serverState.selectedProjectId,
       });
 
       // Allow a brief delay for state to settle

--- a/packages/web-core/src/shared/lib/firstProjectDestination.ts
+++ b/packages/web-core/src/shared/lib/firstProjectDestination.ts
@@ -17,9 +17,9 @@ function getFirstOrganization(
   return organizations[0];
 }
 
-async function getFirstProjectInOrganization(
+async function getProjectsInOrganization(
   organizationId: string
-): Promise<Project | null> {
+): Promise<Project[] | null> {
   const collection = createShapeCollection(PROJECTS_SHAPE, {
     organization_id: organizationId,
   });
@@ -28,16 +28,15 @@ async function getFirstProjectInOrganization(
     collection.toArray as unknown as Project[];
 
   if (collection.isReady()) {
-    const projects = getCollectionProjects();
-    return getFirstProjectByOrder(projects);
+    return getCollectionProjects();
   }
 
-  return new Promise<Project | null>((resolve) => {
+  return new Promise<Project[] | null>((resolve) => {
     let settled = false;
     let timeoutId: number | undefined;
     let subscription: { unsubscribe: () => void } | undefined;
 
-    const settle = (project: Project | null) => {
+    const settle = (projects: Project[] | null) => {
       if (settled) return;
       settled = true;
 
@@ -50,7 +49,7 @@ async function getFirstProjectInOrganization(
         subscription = undefined;
       }
 
-      resolve(project);
+      resolve(projects);
     };
 
     const tryResolve = () => {
@@ -58,8 +57,7 @@ async function getFirstProjectInOrganization(
         return;
       }
 
-      const projects = getCollectionProjects();
-      settle(getFirstProjectByOrder(projects));
+      settle(getCollectionProjects());
     };
 
     subscription = collection.subscribeChanges(tryResolve, {
@@ -75,23 +73,37 @@ async function getFirstProjectInOrganization(
 }
 
 export async function getFirstProjectDestination(
-  setSelectedOrgId: (orgId: string | null) => void
+  setSelectedOrgId: (orgId: string | null) => void,
+  savedOrgId?: string | null,
+  savedProjectId?: string | null
 ): Promise<AppDestination | null> {
   try {
     const organizationsResponse = await organizationsApi.getUserOrganizations();
-    const firstOrganization = getFirstOrganization(
-      organizationsResponse.organizations ?? []
-    );
+    const organizations = organizationsResponse.organizations ?? [];
 
-    if (!firstOrganization) {
+    // Prefer saved org if it still exists, otherwise fall back to first org
+    const savedOrg = savedOrgId
+      ? organizations.find((org) => org.id === savedOrgId)
+      : null;
+    const resolvedOrg = savedOrg ?? getFirstOrganization(organizations);
+
+    if (!resolvedOrg) {
       return null;
     }
 
-    setSelectedOrgId(firstOrganization.id);
+    setSelectedOrgId(resolvedOrg.id);
 
-    const firstProject = await getFirstProjectInOrganization(
-      firstOrganization.id
-    );
+    const projects = await getProjectsInOrganization(resolvedOrg.id);
+
+    // If we have a saved project in the same saved org, use it if still valid
+    if (savedProjectId && savedOrg && projects) {
+      if (projects.some((p) => p.id === savedProjectId)) {
+        return { kind: 'project', projectId: savedProjectId };
+      }
+    }
+
+    // Fall back to first project by sort order
+    const firstProject = projects ? getFirstProjectByOrder(projects) : null;
     if (!firstProject) {
       return null;
     }

--- a/packages/web-core/src/shared/stores/useOrganizationStore.ts
+++ b/packages/web-core/src/shared/stores/useOrganizationStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
+import { useUiPreferencesStore } from './useUiPreferencesStore';
 
 type State = {
   selectedOrgId: string | null;
@@ -20,6 +21,11 @@ export const useOrganizationStore = create<State>()(
     }
   )
 );
+
+// Sync org store changes into the UI preferences store for server persistence
+useOrganizationStore.subscribe((state) => {
+  useUiPreferencesStore.getState().setSelectedOrgId(state.selectedOrgId);
+});
 
 export const useSelectedOrgId = () =>
   useOrganizationStore((s) => s.selectedOrgId);

--- a/packages/web-core/src/shared/stores/useUiPreferencesStore.ts
+++ b/packages/web-core/src/shared/stores/useUiPreferencesStore.ts
@@ -341,6 +341,10 @@ type State = {
   // Mobile font scale
   mobileFontScale: MobileFontScale;
 
+  // Last selected organization and project (persisted via scratch store)
+  selectedOrgId: string | null;
+  selectedProjectId: string | null;
+
   // UI preferences actions
   setRepoAction: (repoId: string, action: RepoAction) => void;
   setExpanded: (key: string, value: boolean) => void;
@@ -418,6 +422,11 @@ type State = {
 
   // Mobile font scale actions
   setMobileFontScale: (scale: MobileFontScale) => void;
+
+  // Last selected organization and project actions
+  setSelectedOrgId: (orgId: string | null) => void;
+  clearSelectedOrgId: () => void;
+  setSelectedProjectId: (projectId: string | null) => void;
 };
 
 export const useUiPreferencesStore = create<State>()((set, get) => ({
@@ -456,6 +465,10 @@ export const useUiPreferencesStore = create<State>()((set, get) => ({
 
   // Mobile font scale
   mobileFontScale: loadMobileFontScale(),
+
+  // Last selected organization and project
+  selectedOrgId: null,
+  selectedProjectId: null,
 
   // UI preferences actions
   setRepoAction: (repoId, action) =>
@@ -779,6 +792,11 @@ export const useUiPreferencesStore = create<State>()((set, get) => ({
     }
     set({ mobileFontScale: scale });
   },
+
+  // Last selected organization and project actions
+  setSelectedOrgId: (orgId) => set({ selectedOrgId: orgId }),
+  clearSelectedOrgId: () => set({ selectedOrgId: null }),
+  setSelectedProjectId: (projectId) => set({ selectedProjectId: projectId }),
 }));
 
 // Hook for repo action preference

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -118,7 +118,15 @@ workspace_filters: WorkspaceFilterStateData,
 /**
  * Workspace sidebar sort preferences
  */
-workspace_sort: WorkspaceSortStateData, };
+workspace_sort: WorkspaceSortStateData, 
+/**
+ * Last selected organization ID
+ */
+selected_org_id: string | null, 
+/**
+ * Last selected project ID
+ */
+selected_project_id: string | null, };
 
 export type ScratchPayload = { "type": "DRAFT_TASK", "data": string } | { "type": "DRAFT_FOLLOW_UP", "data": DraftFollowUpData } | { "type": "DRAFT_WORKSPACE", "data": DraftWorkspaceData } | { "type": "DRAFT_ISSUE", "data": DraftIssueData } | { "type": "PREVIEW_SETTINGS", "data": PreviewSettingsData } | { "type": "WORKSPACE_NOTES", "data": WorkspaceNotesData } | { "type": "UI_PREFERENCES", "data": UiPreferencesData };
 


### PR DESCRIPTION
## Summary

When starting the app, users lose their last selected organization and project, having to re-select them each time. This PR persists both selections in the server-synced scratch store (`UiPreferencesData`) so they survive across devices and browser clears.

## Changes

- **`crates/db/src/models/scratch.rs`** — Added `selected_org_id` and `selected_project_id` fields to the `UiPreferencesData` struct, with `#[serde(default)]` for backwards compatibility
- **`shared/types.ts`** — Regenerated TypeScript types from Rust
- **`useUiPreferencesStore.ts`** — Added `selectedOrgId` and `selectedProjectId` state with setter actions to the central UI preferences store
- **`useUiPreferencesScratch.ts`** — Extended the store↔server sync layer to include both new fields in all conversion and synchronization paths
- **`useOrganizationStore.ts`** — Added a `subscribe()` call to sync org selection changes into the preferences store for server persistence, while keeping the existing Zustand + localStorage store intact
- **`SharedAppLayout.tsx`** — Added a `useEffect` to persist the active project ID (derived from the URL) into the preferences store whenever the user navigates to a project
- **`firstProjectDestination.ts`** — Refactored to accept saved org/project IDs and prefer them over the default first-in-list fallback, with validation that the saved selections still exist
- **`RootRedirectPage.tsx`** — Reads saved org/project IDs imperatively from the preferences store on startup and passes them to the redirect logic

## Implementation Details

- The organization store (`useOrganizationStore`) is kept as a real Zustand store with localStorage persist for backwards compatibility. A `subscribe()` bridges changes into the server-synced preferences store.
- Saved selections are read imperatively via `getState()` in `RootRedirectPage` to avoid re-triggering the redirect effect when the scratch store initializes from the server.
- `getFirstProjectInOrganization` was refactored to `getProjectsInOrganization` (returns the full list) to avoid double-fetching when validating a saved project ID.
- Both saved org and project are validated against the current data — if a saved org/project no longer exists, the app falls back to the first available one.

---

This PR was written using [Vibe Kanban](https://vibekanban.com)