### PR TITLE
Simplify typeahead placement with live geometry and diagnostics (Vibe Kanban)

### DIFF
--- a/packages/ui/src/components/TypeaheadMenu.tsx
+++ b/packages/ui/src/components/TypeaheadMenu.tsx
@@ -33,7 +33,10 @@ function parseLength(value: string): number {
   return Number.isFinite(parsed) ? parsed : 0;
 }
 
-function resolveLineHeight(style: CSSStyleDeclaration, fallbackHeight: number): number {
+function resolveLineHeight(
+  style: CSSStyleDeclaration,
+  fallbackHeight: number
+): number {
   const explicit = parseLength(style.lineHeight);
   if (explicit > 0) return explicit;
 
@@ -51,7 +54,10 @@ function clamp(value: number, min: number, max: number) {
   return Math.min(max, Math.max(min, value));
 }
 
-function placementsEqual(a: TypeaheadPlacement, b: TypeaheadPlacement): boolean {
+function placementsEqual(
+  a: TypeaheadPlacement,
+  b: TypeaheadPlacement
+): boolean {
   return (
     a.side === b.side &&
     a.left === b.left &&
@@ -79,7 +85,9 @@ function computePlacement(
   const configuredMinHeight = parseLength(menuStyles.minHeight);
   const configuredMaxHeight = parseLength(menuStyles.maxHeight);
   const measuredHeight = round(
-    menuRect.height || parseLength(menuStyles.height) || parseLength(menuStyles.minHeight)
+    menuRect.height ||
+      parseLength(menuStyles.height) ||
+      parseLength(menuStyles.minHeight)
   );
 
   const lineHeight = resolveLineHeight(anchorStyles, anchorRect.height);
@@ -91,13 +99,19 @@ function computePlacement(
   const belowSpace = viewportHeight - anchorRect.bottom - marginTop;
   const side: VerticalSide =
     belowSpace >= measuredHeight || belowSpace >= aboveSpace ? 'bottom' : 'top';
-  const availableSpace = Math.max(side === 'bottom' ? belowSpace : aboveSpace, 0);
+  const availableSpace = Math.max(
+    side === 'bottom' ? belowSpace : aboveSpace,
+    0
+  );
 
   let maxHeight = configuredMaxHeight
     ? Math.min(configuredMaxHeight, availableSpace)
     : availableSpace;
   if (configuredMinHeight) {
-    maxHeight = Math.max(maxHeight, Math.min(configuredMinHeight, availableSpace));
+    maxHeight = Math.max(
+      maxHeight,
+      Math.min(configuredMinHeight, availableSpace)
+    );
   }
 
   const measuredWidth =
@@ -105,7 +119,10 @@ function computePlacement(
     round(parseLength(menuStyles.width)) ||
     round(parseLength(menuStyles.minWidth));
   const minLeft = marginLeft;
-  const maxLeft = Math.max(minLeft, viewportWidth - measuredWidth - marginRight);
+  const maxLeft = Math.max(
+    minLeft,
+    viewportWidth - measuredWidth - marginRight
+  );
   const left = clamp(round(anchorRect.left), round(minLeft), round(maxLeft));
   const top =
     side === 'bottom'


### PR DESCRIPTION
## What changed
- Rewrote `TypeaheadMenu` placement to use a single live geometry calculation (`computePlacement`) based on anchor, menu, editor, viewport, and computed CSS values.
- Removed hardcoded placement constants and switched to measured width/height/margins/min-max constraints from the rendered menu styles.
- Added deterministic placement syncing via `useLayoutEffect` + a follow-up animation-frame pass, viewport listeners, and `ResizeObserver` on anchor/menu/editor.
- Updated top placement behavior to anchor near the active cursor line (instead of editor top), preventing overlap with the current input line and keeping the menu near the caret in tall textareas.
- Added `[FileTagTypeahead][position]` debug instrumentation in `FileTagTypeaheadPlugin.tsx` for trigger/query/search/open/close/anchor lifecycle events, including geometry and viewport snapshots.
- Scoped layout-effect placement work to stable dependencies to avoid re-running synchronous geometry logic on every render.

## Why
- The menu was intermittently rendering at the far left and only correcting after a resize.
- When placed above input, it could obscure the caret/current line.
- In larger textareas, top placement could appear far away from the cursor.
- Debug visibility was needed to correlate trigger/search/anchor state while investigating positioning regressions.

## Important implementation details
- Placement now computes `side`, `left`, `top`, and `maxHeight` from live DOM measurements (`getBoundingClientRect`) and computed styles.
- Horizontal placement clamps to the visible viewport using live menu width, avoiding left/right overflow without fixed pixel offsets.
- Top-side boundary uses `max(editorTop, anchorTop - lineHeight)` so the menu stays close to the caret while avoiding coverage of the active line.
- Initial menu render is hidden until placement is measured, preventing visual jumps.
- Placement state updates are guarded by structural equality to reduce unnecessary rerenders.

This PR was written using [Vibe Kanban](https://vibekanban.com)
