### PR TITLE
feat: fetch remote base branch before creating workspace worktree

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12726,6 +12726,7 @@ version = "0.1.44"
 dependencies = [
  "dunce",
  "git",
+ "git2",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",

--- a/crates/git/src/lib.rs
+++ b/crates/git/src/lib.rs
@@ -1367,7 +1367,7 @@ impl GitService {
         Ok(())
     }
 
-    pub(crate) fn find_branch<'a>(
+    pub fn find_branch<'a>(
         repo: &'a Repository,
         branch_name: &str,
     ) -> Result<git2::Branch<'a>, GitServiceError> {
@@ -1532,7 +1532,7 @@ impl GitService {
     }
 
     /// Fetch from remote repository using native git authentication
-    fn fetch_branch_from_remote(
+    pub fn fetch_branch_from_remote(
         &self,
         repo: &Repository,
         branch: &Reference,

--- a/crates/worktree-manager/Cargo.toml
+++ b/crates/worktree-manager/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 
 [dependencies]
 git = { path = "../git" }
+git2 = { workspace = true }
 utils = { path = "../utils" }
 tokio = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/worktree-manager/src/worktree_manager.rs
+++ b/crates/worktree-manager/src/worktree_manager.rs
@@ -8,6 +8,7 @@ use std::{
 static WORKSPACE_DIR_OVERRIDE: OnceLock<PathBuf> = OnceLock::new();
 
 use git::{GitService, GitServiceError};
+use git2::Repository;
 use thiserror::Error;
 use tracing::{debug, info, trace};
 use utils::{path::normalize_macos_private_alias, shell::resolve_executable_path};
@@ -70,11 +71,23 @@ impl WorktreeManager {
             let base_branch_owned = base_branch.to_string();
 
             tokio::task::spawn_blocking(move || {
-                GitService::new().create_branch(
-                    &repo_path_owned,
+                let repo = Repository::open(&repo_path_owned)?;
+                let mut base_branch_ref =
+                    GitService::find_branch(&repo, &base_branch_owned)?.into_reference();
+                // If the base branch is remote, fetch latest before branching
+                if base_branch_ref.is_remote() {
+                    let git = GitService::new();
+                    git.fetch_branch_from_remote(&repo, &base_branch_ref)?;
+                    // Re-lookup to get fresh OID from disk after fetch
+                    base_branch_ref =
+                        GitService::find_branch(&repo, &base_branch_owned)?.into_reference();
+                }
+                repo.branch(
                     &branch_name_owned,
-                    &base_branch_owned,
-                )
+                    &base_branch_ref.peel_to_commit()?,
+                    false,
+                )?;
+                Ok::<(), GitServiceError>(())
             })
             .await
             .map_err(|e| WorktreeError::TaskJoin(format!("Task join error: {e}")))??;


### PR DESCRIPTION
When creating a worktree from a remote base branch (e.g. origin/main), fetch the latest ref from the remote first. This ensures new workspaces always start from the most recent remote state rather than relying on stale remote-tracking refs that were only updated as a side effect of branch status polling.

Mirrors the existing fetch-before-use pattern in rebase_branch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes worktree/branch creation flow and adds network fetches when the base is remote, which could affect workspace creation behavior and error cases if remotes/auth are misconfigured.
> 
> **Overview**
> Worktree creation now **refreshes remote-tracking base branches** before branching: `WorktreeManager::create_worktree` opens the repo via `git2`, detects when `base_branch` is remote (e.g. `origin/main`), runs a targeted fetch, then re-resolves the ref and creates the new local branch from the updated commit.
> 
> To support this, `worktree-manager` adds a direct `git2` dependency and `git::GitService` exposes `find_branch` and `fetch_branch_from_remote` publicly so worktree creation can reuse the shared branch/ref resolution and fetch logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea76b9131b9889a0601c18db988796cb69ae2fb8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->