### PR TITLE
Fix remote App Bar create-project no-op (Vibe Kanban)

### DIFF
--- a/packages/remote-web/src/app/layout/RemoteAppShell.tsx
+++ b/packages/remote-web/src/app/layout/RemoteAppShell.tsx
@@ -16,6 +16,10 @@ import {
   CreateOrganizationDialog,
   type CreateOrganizationResult,
 } from "@/shared/dialogs/org/CreateOrganizationDialog";
+import {
+  CreateRemoteProjectDialog,
+  type CreateRemoteProjectResult,
+} from "@/shared/dialogs/org/CreateRemoteProjectDialog";
 
 interface RemoteAppShellProps {
   children: ReactNode;
@@ -108,9 +112,28 @@ export function RemoteAppShell({ children }: RemoteAppShellProps) {
     [navigate],
   );
 
-  const handleCreateProject = useCallback(() => {
-    navigate({ to: "/" });
-  }, [navigate]);
+  const handleCreateProject = useCallback(async () => {
+    if (!activeOrganizationId) {
+      return;
+    }
+
+    try {
+      const result: CreateRemoteProjectResult =
+        await CreateRemoteProjectDialog.show({
+          organizationId: activeOrganizationId,
+        });
+
+      if (result.action === "created" && result.project) {
+        void projectsQuery.refetch();
+        navigate({
+          to: "/projects/$projectId",
+          params: { projectId: result.project.id },
+        });
+      }
+    } catch {
+      // Dialog cancelled
+    }
+  }, [activeOrganizationId, navigate, projectsQuery]);
 
   const handleCreateOrg = useCallback(async () => {
     try {


### PR DESCRIPTION
## Summary
This PR fixes the non-functional project creation button in the remote web App Bar.

## What Changed
- Updated `packages/remote-web/src/app/layout/RemoteAppShell.tsx`.
- Replaced the placeholder `handleCreateProject` behavior (`navigate({ to: '/' })`) with the actual project-creation flow.
- Wired the App Bar create action to `CreateRemoteProjectDialog.show({ organizationId })`.
- On successful creation:
  - Refetches the projects query used by `RemoteAppShell` so the App Bar project list updates immediately.
  - Navigates to the newly created project route (`/projects/$projectId`).
- Preserved cancel behavior by swallowing dialog cancellation in the existing `try/catch` pattern.

## Why
The task context reported that on remote web, clicking the App Bar "create project" button did nothing useful. The handler was a no-op placeholder that only redirected to home. This change makes the button perform the expected create-project action in place.

## Implementation Details
- Uses `activeOrganizationId` as the source organization for creation, which is the same resolved organization ID used by the projects query in this shell.
- Uses the existing shared modal (`CreateRemoteProjectDialog`) instead of introducing a new API path or duplicate dialog logic.
- Calls `projectsQuery.refetch()` after successful creation to keep the remote App Bar data source in sync without waiting for stale-time expiration.
- Keeps the change scoped to one file for readability and minimal surface area.

This PR was written using [Vibe Kanban](https://vibekanban.com)
