### PR TITLE
Add remote web relay SPAKE2 pairing flow and host management (Vibe Kanban)

### DIFF
--- a/crates/api-types/src/relay.rs
+++ b/crates/api-types/src/relay.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use ts_rs::TS;
 use uuid::Uuid;
 
-#[derive(Debug, Clone, Serialize, Deserialize, TS)]
+#[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow, TS)]
 pub struct RelayHost {
     pub id: Uuid,
     pub owner_user_id: Uuid,
@@ -14,6 +14,11 @@ pub struct RelayHost {
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
     pub access_role: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, TS)]
+pub struct ListRelayHostsResponse {
+    pub hosts: Vec<RelayHost>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]

--- a/crates/remote/src/bin/generate_types.rs
+++ b/crates/remote/src/bin/generate_types.rs
@@ -11,7 +11,7 @@ use api_types::{
     PullRequestStatus, RelayHost, RelaySession, RelaySessionAuthCodeResponse, Tag,
     UpdateIssueCommentReactionRequest, UpdateIssueCommentRequest, UpdateIssueRequest,
     UpdateNotificationRequest, UpdateProjectRequest, UpdateProjectStatusRequest,
-    UpdateTagRequest, User, UserData, Workspace,
+    UpdateTagRequest, User, UserData, Workspace, ListRelayHostsResponse,
 };
 use remote::{
     routes::{
@@ -95,6 +95,7 @@ fn export_shapes() -> String {
         UserData::decl(),
         User::decl(),
         RelayHost::decl(),
+        ListRelayHostsResponse::decl(),
         RelaySession::decl(),
         CreateRelaySessionResponse::decl(),
         RelaySessionAuthCodeResponse::decl(),

--- a/crates/remote/src/db/hosts.rs
+++ b/crates/remote/src/db/hosts.rs
@@ -1,4 +1,4 @@
-use api_types::RelaySession;
+use api_types::{RelayHost, RelaySession};
 use chrono::{DateTime, Utc};
 use sqlx::PgPool;
 use uuid::Uuid;
@@ -70,6 +70,38 @@ impl<'a> HostRepository<'a> {
             expires_at
         )
         .fetch_one(self.pool)
+        .await
+    }
+
+    pub async fn list_accessible_hosts(
+        &self,
+        user_id: Uuid,
+    ) -> Result<Vec<RelayHost>, sqlx::Error> {
+        sqlx::query_as::<_, RelayHost>(
+            r#"
+            SELECT
+                h.id,
+                h.owner_user_id,
+                h.name,
+                h.status,
+                h.last_seen_at,
+                h.agent_version,
+                h.created_at,
+                h.updated_at,
+                CASE
+                    WHEN h.owner_user_id = $1 THEN 'owner'
+                    ELSE 'member'
+                END AS access_role
+            FROM hosts h
+            LEFT JOIN organization_member_metadata om
+                ON om.organization_id = h.shared_with_organization_id
+                AND om.user_id = $1
+            WHERE h.owner_user_id = $1 OR om.user_id IS NOT NULL
+            ORDER BY h.updated_at DESC
+            "#,
+        )
+        .bind(user_id)
+        .fetch_all(self.pool)
         .await
     }
 }

--- a/packages/remote-web/src/app/entry/Bootstrap.tsx
+++ b/packages/remote-web/src/app/entry/Bootstrap.tsx
@@ -10,7 +10,7 @@ import { getToken, triggerRefresh } from "@remote/shared/lib/auth/tokenManager";
 import "@remote/app/styles/index.css";
 import "@/i18n";
 import { configureAuthRuntime } from "@/shared/lib/auth/runtime";
-import { setRemoteApiBase } from "@/shared/lib/remoteApi";
+import { setRelayApiBase, setRemoteApiBase } from "@/shared/lib/remoteApi";
 import "@/shared/types/modals";
 import { queryClient } from "@/shared/lib/queryClient";
 
@@ -21,6 +21,11 @@ if (import.meta.env.VITE_PUBLIC_POSTHOG_KEY) {
 }
 
 setRemoteApiBase(import.meta.env.VITE_API_BASE_URL || window.location.origin);
+setRelayApiBase(
+  import.meta.env.VITE_RELAY_API_BASE_URL ||
+    import.meta.env.VITE_API_BASE_URL ||
+    window.location.origin,
+);
 
 configureAuthRuntime({
   getToken,

--- a/packages/remote-web/src/shared/constants/settings.ts
+++ b/packages/remote-web/src/shared/constants/settings.ts
@@ -3,4 +3,5 @@ import type { SettingsSectionType } from "@/shared/dialogs/settings/settings/Set
 export const REMOTE_SETTINGS_SECTIONS: SettingsSectionType[] = [
   "organizations",
   "remote-projects",
+  "relay",
 ];

--- a/packages/remote-web/src/vite-env.d.ts
+++ b/packages/remote-web/src/vite-env.d.ts
@@ -2,6 +2,7 @@
 
 interface ImportMetaEnv {
   readonly VITE_API_BASE_URL: string;
+  readonly VITE_RELAY_API_BASE_URL: string;
   readonly VITE_APP_BASE_URL: string;
   readonly VITE_PUBLIC_POSTHOG_KEY: string;
   readonly VITE_PUBLIC_POSTHOG_HOST: string;

--- a/packages/web-core/package.json
+++ b/packages/web-core/package.json
@@ -27,6 +27,7 @@
     "@lexical/react": "^0.36.2",
     "@lexical/rich-text": "^0.36.2",
     "@lexical/table": "^0.36.2",
+    "@noble/curves": "^1.9.7",
     "@phosphor-icons/react": "^2.1.10",
     "@pierre/diffs": "^1.0.8",
     "@radix-ui/react-accordion": "^1.2.1",

--- a/packages/web-core/src/shared/lib/relayPairingStorage.ts
+++ b/packages/web-core/src/shared/lib/relayPairingStorage.ts
@@ -1,0 +1,68 @@
+const DB_NAME = 'vk-relay-pairing';
+const DB_VERSION = 1;
+const PAIRED_HOSTS_STORE = 'paired_hosts';
+
+export interface PairedRelayHost {
+  host_id: string;
+  host_name: string;
+  public_key_b64: string;
+  private_key_jwk: JsonWebKey;
+  server_public_key_b64: string;
+  paired_at: string;
+}
+
+function openDb(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, DB_VERSION);
+
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains(PAIRED_HOSTS_STORE)) {
+        db.createObjectStore(PAIRED_HOSTS_STORE, { keyPath: 'host_id' });
+      }
+    };
+
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+export async function listPairedRelayHosts(): Promise<PairedRelayHost[]> {
+  const db = await openDb();
+  return new Promise<PairedRelayHost[]>((resolve, reject) => {
+    const tx = db.transaction(PAIRED_HOSTS_STORE, 'readonly');
+    const store = tx.objectStore(PAIRED_HOSTS_STORE);
+    const request = store.getAll();
+
+    request.onsuccess = () => {
+      const pairedHosts = (request.result as PairedRelayHost[]) ?? [];
+      pairedHosts.sort((a, b) => b.paired_at.localeCompare(a.paired_at));
+      resolve(pairedHosts);
+    };
+    request.onerror = () => reject(request.error);
+    tx.onerror = () => reject(tx.error);
+    tx.onabort = () => reject(tx.error);
+    tx.oncomplete = () => {
+      db.close();
+    };
+  });
+}
+
+export async function savePairedRelayHost(
+  host: PairedRelayHost
+): Promise<void> {
+  const db = await openDb();
+  await new Promise<void>((resolve, reject) => {
+    const tx = db.transaction(PAIRED_HOSTS_STORE, 'readwrite');
+    const store = tx.objectStore(PAIRED_HOSTS_STORE);
+    const request = store.put(host);
+
+    request.onerror = () => reject(request.error);
+    tx.onerror = () => reject(tx.error);
+    tx.onabort = () => reject(tx.error);
+    tx.oncomplete = () => {
+      db.close();
+      resolve();
+    };
+  });
+}

--- a/packages/web-core/src/shared/lib/relayPake.ts
+++ b/packages/web-core/src/shared/lib/relayPake.ts
@@ -1,0 +1,324 @@
+import { ed25519 } from '@noble/curves/ed25519';
+
+const ENCODER = new TextEncoder();
+
+const SPAKE2_CLIENT_ID = ENCODER.encode('vibe-kanban-browser');
+const SPAKE2_SERVER_ID = ENCODER.encode('vibe-kanban-server');
+
+const KEY_CONFIRMATION_INFO = ENCODER.encode('key-confirmation');
+const CLIENT_PROOF_CONTEXT = ENCODER.encode('vk-spake2-client-proof-v2');
+const SERVER_PROOF_CONTEXT = ENCODER.encode('vk-spake2-server-proof-v2');
+
+const SPAKE2_PASSWORD_INFO = ENCODER.encode('SPAKE2 pw');
+const ENROLLMENT_CODE_LENGTH = 6;
+
+// Ed25519 subgroup order (same value used in curve25519-dalek).
+const CURVE_ORDER =
+  7237005577332262213973186563042994240857116359379907606001950938285454250989n;
+
+const SPAKE2_M = ed25519.ExtendedPoint.fromHex(
+  '15cfd18e385952982b6a8f8c7854963b58e34388c8e6dae891db756481a02312'
+);
+const SPAKE2_N = ed25519.ExtendedPoint.fromHex(
+  'f04f2e7eb734b2a8f8b472eaf9c3c632576ac64aea650b496a8a20ff00e583c3'
+);
+
+export interface Spake2EnrollmentClientState {
+  passwordBytes: Uint8Array;
+  passwordScalar: bigint;
+  xScalar: bigint;
+  clientMessageBytes: Uint8Array;
+}
+
+export function normalizeEnrollmentCode(rawCode: string): string {
+  return rawCode
+    .trim()
+    .toUpperCase()
+    .replace(/[^A-Z0-9]/g, '');
+}
+
+export async function startSpake2Enrollment(
+  rawEnrollmentCode: string
+): Promise<{ state: Spake2EnrollmentClientState; clientMessageB64: string }> {
+  const enrollmentCode = normalizeEnrollmentCode(rawEnrollmentCode);
+  if (enrollmentCode.length !== ENROLLMENT_CODE_LENGTH) {
+    throw new Error('Enrollment code must be 6 characters.');
+  }
+
+  const passwordBytes = ENCODER.encode(enrollmentCode);
+  const passwordScalar = await hashToSpake2Scalar(passwordBytes);
+  const xScalar = randomScalar();
+
+  const clientPoint = ed25519.ExtendedPoint.BASE.multiply(xScalar).add(
+    SPAKE2_M.multiply(passwordScalar)
+  );
+  const clientPointBytes = clientPoint.toRawBytes();
+
+  const clientMessage = new Uint8Array(1 + clientPointBytes.length);
+  clientMessage[0] = 0x41; // 'A'
+  clientMessage.set(clientPointBytes, 1);
+
+  return {
+    state: {
+      passwordBytes,
+      passwordScalar,
+      xScalar,
+      clientMessageBytes: clientPointBytes,
+    },
+    clientMessageB64: bytesToBase64(clientMessage),
+  };
+}
+
+export async function finishSpake2Enrollment(
+  state: Spake2EnrollmentClientState,
+  serverMessageB64: string
+): Promise<Uint8Array> {
+  const serverMessage = base64ToBytes(serverMessageB64);
+  if (serverMessage.length !== 33) {
+    throw new Error('Server message has invalid length.');
+  }
+  if (serverMessage[0] !== 0x42) {
+    throw new Error('Server message has invalid side identifier.');
+  }
+
+  const serverPointBytes = serverMessage.slice(1);
+  const serverPoint = ed25519.ExtendedPoint.fromHex(serverPointBytes);
+  const negativePasswordScalar =
+    (CURVE_ORDER - state.passwordScalar) % CURVE_ORDER;
+
+  const keyPoint = serverPoint
+    .add(SPAKE2_N.multiply(negativePasswordScalar))
+    .multiply(state.xScalar);
+  const keyPointBytes = keyPoint.toRawBytes();
+
+  return hashAb(
+    state.passwordBytes,
+    SPAKE2_CLIENT_ID,
+    SPAKE2_SERVER_ID,
+    state.clientMessageBytes,
+    serverPointBytes,
+    keyPointBytes
+  );
+}
+
+export async function generateRelaySigningKeyPair(): Promise<{
+  privateKeyJwk: JsonWebKey;
+  publicKeyBytes: Uint8Array;
+  publicKeyB64: string;
+}> {
+  const keyPair = (await crypto.subtle.generateKey({ name: 'Ed25519' }, true, [
+    'sign',
+    'verify',
+  ])) as CryptoKeyPair;
+
+  const [privateKeyJwk, publicKeyRaw] = await Promise.all([
+    crypto.subtle.exportKey('jwk', keyPair.privateKey),
+    crypto.subtle.exportKey('raw', keyPair.publicKey),
+  ]);
+
+  const publicKeyBytes = new Uint8Array(publicKeyRaw);
+  return {
+    privateKeyJwk,
+    publicKeyBytes,
+    publicKeyB64: bytesToBase64(publicKeyBytes),
+  };
+}
+
+export async function buildClientProofB64(
+  sharedKey: Uint8Array,
+  enrollmentId: string,
+  browserPublicKeyBytes: Uint8Array
+): Promise<string> {
+  const confirmationKey = await deriveConfirmationKey(sharedKey);
+  const enrollmentIdBytes = uuidToBytes(enrollmentId);
+  const payload = concatBytes(
+    CLIENT_PROOF_CONTEXT,
+    enrollmentIdBytes,
+    browserPublicKeyBytes
+  );
+  const proof = await hmacSha256(confirmationKey, payload);
+  return bytesToBase64(proof);
+}
+
+export async function verifyServerProof(
+  sharedKey: Uint8Array,
+  enrollmentId: string,
+  browserPublicKeyBytes: Uint8Array,
+  serverPublicKeyB64: string,
+  serverProofB64: string
+): Promise<boolean> {
+  const confirmationKey = await deriveConfirmationKey(sharedKey);
+  const enrollmentIdBytes = uuidToBytes(enrollmentId);
+  const serverPublicKeyBytes = base64ToBytes(serverPublicKeyB64);
+
+  const payload = concatBytes(
+    SERVER_PROOF_CONTEXT,
+    enrollmentIdBytes,
+    browserPublicKeyBytes,
+    serverPublicKeyBytes
+  );
+  const expectedProof = await hmacSha256(confirmationKey, payload);
+  const actualProof = base64ToBytes(serverProofB64);
+
+  return constantTimeEqual(expectedProof, actualProof);
+}
+
+async function hashAb(
+  passwordBytes: Uint8Array,
+  idA: Uint8Array,
+  idB: Uint8Array,
+  firstMessage: Uint8Array,
+  secondMessage: Uint8Array,
+  keyBytes: Uint8Array
+): Promise<Uint8Array> {
+  const transcript = new Uint8Array(6 * 32);
+
+  transcript.set(await sha256(passwordBytes), 0);
+  transcript.set(await sha256(idA), 32);
+  transcript.set(await sha256(idB), 64);
+  transcript.set(firstMessage, 96);
+  transcript.set(secondMessage, 128);
+  transcript.set(keyBytes, 160);
+
+  return sha256(transcript);
+}
+
+async function hashToSpake2Scalar(passwordBytes: Uint8Array): Promise<bigint> {
+  const okm = await hkdfSha256(
+    passwordBytes,
+    new Uint8Array(0),
+    SPAKE2_PASSWORD_INFO,
+    48
+  );
+
+  const reducible = new Uint8Array(64);
+  for (let i = 0; i < okm.length; i += 1) {
+    reducible[okm.length - 1 - i] = okm[i];
+  }
+
+  return bytesToBigIntLE(reducible) % CURVE_ORDER;
+}
+
+function randomScalar(): bigint {
+  const randomBytes = new Uint8Array(64);
+  crypto.getRandomValues(randomBytes);
+  return bytesToBigIntLE(randomBytes) % CURVE_ORDER;
+}
+
+async function deriveConfirmationKey(
+  sharedKey: Uint8Array
+): Promise<Uint8Array> {
+  return hkdfSha256(sharedKey, new Uint8Array(0), KEY_CONFIRMATION_INFO, 32);
+}
+
+async function hkdfSha256(
+  ikm: Uint8Array,
+  salt: Uint8Array,
+  info: Uint8Array,
+  length: number
+): Promise<Uint8Array> {
+  const key = await crypto.subtle.importKey(
+    'raw',
+    toArrayBuffer(ikm),
+    'HKDF',
+    false,
+    ['deriveBits']
+  );
+  const derivedBits = await crypto.subtle.deriveBits(
+    {
+      name: 'HKDF',
+      hash: 'SHA-256',
+      salt: toArrayBuffer(salt),
+      info: toArrayBuffer(info),
+    },
+    key,
+    length * 8
+  );
+  return new Uint8Array(derivedBits);
+}
+
+async function hmacSha256(
+  keyBytes: Uint8Array,
+  data: Uint8Array
+): Promise<Uint8Array> {
+  const key = await crypto.subtle.importKey(
+    'raw',
+    toArrayBuffer(keyBytes),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign']
+  );
+  const signature = await crypto.subtle.sign('HMAC', key, toArrayBuffer(data));
+  return new Uint8Array(signature);
+}
+
+async function sha256(data: Uint8Array): Promise<Uint8Array> {
+  const digest = await crypto.subtle.digest('SHA-256', toArrayBuffer(data));
+  return new Uint8Array(digest);
+}
+
+function toArrayBuffer(data: Uint8Array): ArrayBuffer {
+  return new Uint8Array(data).buffer;
+}
+
+function uuidToBytes(rawUuid: string): Uint8Array {
+  const hex = rawUuid.replace(/-/g, '');
+  if (hex.length !== 32) {
+    throw new Error('Invalid enrollment ID.');
+  }
+
+  const bytes = new Uint8Array(16);
+  for (let i = 0; i < 16; i += 1) {
+    const value = Number.parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+    if (Number.isNaN(value)) {
+      throw new Error('Invalid enrollment ID.');
+    }
+    bytes[i] = value;
+  }
+
+  return bytes;
+}
+
+function bytesToBigIntLE(bytes: Uint8Array): bigint {
+  let value = 0n;
+  for (let i = bytes.length - 1; i >= 0; i -= 1) {
+    value = (value << 8n) + BigInt(bytes[i]);
+  }
+  return value;
+}
+
+function concatBytes(...chunks: Uint8Array[]): Uint8Array {
+  const totalLength = chunks.reduce((sum, chunk) => sum + chunk.length, 0);
+  const output = new Uint8Array(totalLength);
+  let offset = 0;
+  for (const chunk of chunks) {
+    output.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return output;
+}
+
+function constantTimeEqual(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+  let mismatch = 0;
+  for (let i = 0; i < a.length; i += 1) {
+    mismatch |= a[i] ^ b[i];
+  }
+  return mismatch === 0;
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  const binary = String.fromCharCode(...bytes);
+  return btoa(binary);
+}
+
+function base64ToBytes(value: string): Uint8Array {
+  const binary = atob(value);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}

--- a/packages/web-core/src/vite-env.d.ts
+++ b/packages/web-core/src/vite-env.d.ts
@@ -1,3 +1,8 @@
 /// <reference types="vite/client" />
 
+interface ImportMetaEnv {
+  readonly VITE_VK_SHARED_API_BASE?: string;
+  readonly VITE_RELAY_API_BASE_URL?: string;
+}
+
 declare const __APP_VERSION__: string;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -623,6 +623,9 @@ importers:
       '@lexical/table':
         specifier: ^0.36.2
         version: 0.36.2
+      '@noble/curves':
+        specifier: ^1.9.7
+        version: 1.9.7
       '@phosphor-icons/react':
         specifier: ^2.1.10
         version: 2.1.10(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1482,6 +1485,14 @@ packages:
 
   '@microsoft/fetch-event-source@2.0.1':
     resolution: {integrity: sha512-W6CLUJ2eBMw3Rec70qrsEW0jOm/3twwJv21mrmj2yORiaVmVYGS4sSS5yUwvQc1ZlDLYGPnClVWmUUMagKNsfA==}
+
+  '@noble/curves@1.9.7':
+    resolution: {integrity: sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@noble/hashes@1.8.0':
+    resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
+    engines: {node: ^14.21.3 || >=16}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -5130,6 +5141,12 @@ snapshots:
   '@marijn/find-cluster-break@1.0.2': {}
 
   '@microsoft/fetch-event-source@2.0.1': {}
+
+  '@noble/curves@1.9.7':
+    dependencies:
+      '@noble/hashes': 1.8.0
+
+  '@noble/hashes@1.8.0': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:

--- a/shared/remote-types.ts
+++ b/shared/remote-types.ts
@@ -48,8 +48,6 @@ export type UserData = { user_id: string, first_name: string | null, last_name: 
 
 export type User = { id: string, email: string, first_name: string | null, last_name: string | null, username: string | null, created_at: string, updated_at: string, };
 
-export type Host = { id: string, owner_user_id: string, name: string, status: string, last_seen_at: string | null, agent_version: string | null, created_at: string, updated_at: string, };
-
 export type RelayHost = { id: string, owner_user_id: string, name: string, status: string, last_seen_at: string | null, agent_version: string | null, created_at: string, updated_at: string, access_role: string, };
 
 export type ListRelayHostsResponse = { hosts: Array<RelayHost>, };


### PR DESCRIPTION
## Summary
This PR adds browser-based relay pairing for remote web using SPAKE2/PAKE, with a complete settings UX for pairing hosts via one-time code and persisting trusted keys in IndexedDB.

## What Changed
- Added a new protected remote endpoint to list relay hosts accessible to the signed-in user:
  - `GET /v1/hosts`
  - Includes ownership/member access role resolution in the query layer.
- Added relay host list response type to shared API types and remote type generation.
- Extended remote web API client support for relay flows:
  - list hosts
  - create relay session
  - request relay session auth code
  - relay API base URL configuration (`VITE_RELAY_API_BASE_URL`) with runtime fallback.
- Enabled the relay section in remote settings navigation.
- Reworked `RelaySettingsSection` to support remote-web pairing journey while preserving existing local behavior:
  - list previously paired hosts
  - start “Pair new host” flow
  - select host to pair
  - OTP-style 6-character code input (auto-uppercase, paste support, keyboard navigation)
  - show pairing progress loader and success/error states
- Implemented browser PAKE helpers (`relayPake.ts`) to match the server relay auth protocol in `crates/server/src/routes/relay_auth.rs`:
  - enrollment code normalization
  - SPAKE2 start/finish message handling
  - client/server proof generation/verification
  - extractable Ed25519 keypair generation via WebCrypto
- Implemented IndexedDB storage for paired host key material (`relayPairingStorage.ts`).
- Added `@noble/curves` dependency for curve math used by browser SPAKE2.

## Why
The task requires relay pairing to work directly from remote web with a simple, readable implementation and a smooth user journey. Users should be able to open settings, see paired hosts, pair a new host with a one-time code, and complete pairing with clear progress feedback. This PR delivers that flow end-to-end and aligns the browser-side protocol with the existing server relay auth implementation.

## Important Implementation Details
- Pairing is only shown in remote context; local settings behavior remains available via context-based rendering split.
- Pairing code handling is intentionally strict and user-friendly:
  - normalized to uppercase alphanumeric
  - constrained to 6 characters
  - supports multi-character paste into segmented input.
- Relay session auth-code requests target relay API base, which can be configured independently from shared API base.
- Host listing query uses runtime `query_as` mapping for readability and avoids introducing SQLx offline metadata churn for this endpoint.
- Remote types were regenerated to include `ListRelayHostsResponse` and updated relay host typing.

This PR was written using [Vibe Kanban](https://vibekanban.com)
