### PR TITLE
Add remote relay host unpair action in settings (Vibe Kanban)

### DIFF
--- a/packages/web-core/src/shared/lib/relayPairingStorage.ts
+++ b/packages/web-core/src/shared/lib/relayPairingStorage.ts
@@ -68,3 +68,20 @@ export async function savePairedRelayHost(
     };
   });
 }
+
+export async function removePairedRelayHost(hostId: string): Promise<void> {
+  const db = await openDb();
+  await new Promise<void>((resolve, reject) => {
+    const tx = db.transaction(PAIRED_HOSTS_STORE, 'readwrite');
+    const store = tx.objectStore(PAIRED_HOSTS_STORE);
+    const request = store.delete(hostId);
+
+    request.onerror = () => reject(request.error);
+    tx.onerror = () => reject(tx.error);
+    tx.onabort = () => reject(tx.error);
+    tx.oncomplete = () => {
+      db.close();
+      resolve();
+    };
+  });
+}


### PR DESCRIPTION
## What changed
- Added host removal support in remote relay settings so users can unpair hosts from the browser UI.
- Introduced `removePairedRelayHost(hostId)` in IndexedDB pairing storage (`relayPairingStorage.ts`) to delete a paired host entry by `host_id`.
- Updated `RemoteRelaySettingsSectionContent` to:
  - track removal state (`removingHostId`) and removal errors (`removeError`),
  - add `handleRemovePairedHost` to perform deletion and refresh the paired-host list,
  - render a per-host **Remove** action in the paired hosts list,
  - show loading/spinner state on the active remove action and display remove failures inline.

## Why
The task requirement was to provide a way to remove hosts in remote web relay settings (`RelaySettingsSection.tsx`). Previously, paired hosts could be listed and new hosts could be paired, but there was no unpair/remove path. This change closes that gap and makes host pairing management complete from the remote settings UI.

## Important implementation details
- Removal is implemented as a local unpair action by deleting credentials/state from browser IndexedDB (`paired_hosts` store), matching how paired hosts are currently persisted.
- After removal, the UI reloads paired hosts from storage to keep derived state (`availableHostsToPair`, paired rows) consistent.
- The remove button is disabled while a removal is in progress, and only the active row shows a spinner.
- Existing pairing flow and host-loading behavior are unchanged.

This PR was written using [Vibe Kanban](https://vibekanban.com)
