### PR TITLE
Add HOSTS/BOARDS labels and host pairing shortcut in remote app bar (Vibe Kanban)

### DIFF
--- a/packages/remote-web/src/app/layout/RemoteAppShell.tsx
+++ b/packages/remote-web/src/app/layout/RemoteAppShell.tsx
@@ -206,6 +206,13 @@ export function RemoteAppShell({ children }: RemoteAppShellProps) {
     [navigate],
   );
 
+  const handlePairHostClick = useCallback(() => {
+    void SettingsDialog.show({
+      initialSection: "relay",
+      sections: REMOTE_SETTINGS_SECTIONS,
+    });
+  }, []);
+
   return (
     <div className="flex h-screen bg-primary">
       <AppBar
@@ -213,6 +220,7 @@ export function RemoteAppShell({ children }: RemoteAppShellProps) {
         hosts={relayHosts}
         hostsLabel="HOSTS"
         projectsLabel="BOARDS"
+        onPairHostClick={isSignedIn ? handlePairHostClick : undefined}
         activeHostId={activeHostId}
         onCreateProject={handleCreateProject}
         onWorkspacesClick={handleWorkspacesClick}

--- a/packages/ui/src/components/AppBar.tsx
+++ b/packages/ui/src/components/AppBar.tsx
@@ -7,6 +7,7 @@ import {
 import type { ReactNode } from 'react';
 import {
   LayoutIcon,
+  LinkIcon,
   PlusIcon,
   KanbanIcon,
   SpinnerIcon,
@@ -46,6 +47,7 @@ interface AppBarProps {
   hosts?: AppBarHost[];
   hostsLabel?: string;
   projectsLabel?: string;
+  onPairHostClick?: () => void;
   activeHostId?: string | null;
   onCreateProject: () => void;
   onWorkspacesClick: () => void;
@@ -98,6 +100,7 @@ export function AppBar({
   hosts = [],
   hostsLabel,
   projectsLabel,
+  onPairHostClick,
   activeHostId = null,
   onCreateProject,
   onWorkspacesClick,
@@ -119,6 +122,8 @@ export function AppBar({
   discordIconPath,
 }: AppBarProps) {
   const { t } = useTranslation('common');
+  const showHostsSection =
+    showWorkspacesButton || hosts.length > 0 || !!onPairHostClick;
 
   return (
     <div
@@ -127,7 +132,7 @@ export function AppBar({
         'bg-secondary border-r border-border'
       )}
     >
-      {(showWorkspacesButton || hosts.length > 0) && (
+      {showHostsSection && (
         <div className="flex flex-col items-center gap-1">
           {hostsLabel && (
             <p className="w-10 text-center text-[9px] font-medium uppercase leading-none tracking-wide text-low">
@@ -189,10 +194,27 @@ export function AppBar({
               </Tooltip>
             );
           })}
+          {onPairHostClick && (
+            <Tooltip content="Pair host" side="right">
+              <button
+                type="button"
+                onClick={onPairHostClick}
+                className={cn(
+                  'flex items-center justify-center w-10 h-10 rounded-lg',
+                  'text-sm font-medium transition-colors cursor-pointer',
+                  'focus:outline-none focus-visible:ring-2 focus-visible:ring-brand',
+                  'bg-primary text-muted hover:text-normal hover:bg-tertiary'
+                )}
+                aria-label="Pair host"
+              >
+                <LinkIcon size={20} />
+              </button>
+            </Tooltip>
+          )}
         </div>
       )}
 
-      {hosts.length > 0 && (
+      {(hosts.length > 0 || onPairHostClick) && (
         <div className="w-8 h-px bg-border" aria-hidden="true" />
       )}
 


### PR DESCRIPTION
## What changed
- Added compact app-bar section labels in remote web: `HOSTS` for the host list and `BOARDS` for the project/board list.
- Extended the shared `AppBar` component with optional props to support section labels (`hostsLabel`, `projectsLabel`) and an optional host action (`onPairHostClick`).
- Added a new host pairing shortcut button (link icon) in the hosts section of the app bar.
- Wired the remote app shell so the new host action opens Settings directly to the Relay section.

## Why
- The app bar is narrow, so explicit section labels improve scanability and reduce ambiguity between hosts and boards.
- Pairing a host previously required navigating through settings manually; the new shortcut provides a direct entry point similar to the existing board add affordance.

## Important implementation details
- `AppBar` remains backwards-compatible: all new props are optional.
- The hosts section now renders when any of these are true: workspaces button is shown, hosts exist, or the host pairing action is provided.
- The host pairing button is styled consistently with existing app-bar action buttons and uses tooltip/ARIA label `Pair host`.
- In remote web, `onPairHostClick` is passed only when signed in, and opens:
  - `SettingsDialog.show({ initialSection: "relay", sections: REMOTE_SETTINGS_SECTIONS })`

This PR was written using [Vibe Kanban](https://vibekanban.com)
