### PR TITLE
Track relay host session and pairing analytics events (Vibe Kanban)

### DIFF
--- a/crates/remote/src/routes/hosts.rs
+++ b/crates/remote/src/routes/hosts.rs
@@ -73,5 +73,16 @@ async fn create_relay_session(
             ErrorResponse::new(StatusCode::INTERNAL_SERVER_ERROR, "Failed to create session")
         })?;
 
+    if let Some(analytics) = state.analytics() {
+        analytics.track(
+            ctx.user.id,
+            "relay_host_session_created",
+            serde_json::json!({
+                "host_id": host_id,
+                "relay_session_id": session.id,
+            }),
+        );
+    }
+
     Ok(Json(CreateRelaySessionResponse { session }))
 }

--- a/crates/server/src/routes/relay_auth.rs
+++ b/crates/server/src/routes/relay_auth.rs
@@ -260,6 +260,18 @@ async fn finish_spake2_enrollment(
         "completed relay PAKE enrollment"
     );
 
+    deployment
+        .track_if_analytics_allowed(
+            "relay_host_paired",
+            serde_json::json!({
+                "client_id": payload.client_id,
+                "client_browser": payload.client_browser,
+                "client_os": payload.client_os,
+                "client_device": payload.client_device,
+            }),
+        )
+        .await;
+
     Ok(Json(ApiResponse::success(FinishSpake2EnrollmentResponse {
         signing_session_id,
         server_public_key_b64,


### PR DESCRIPTION
## Summary
This PR adds analytics instrumentation for relay host usage and pairing completion across the remote and local backends.

## What Changed
- Added a `relay_host_session_created` event in the remote API relay session creation path:
  - `crates/remote/src/routes/hosts.rs` (`create_relay_session`)
  - Properties: `host_id`, `relay_session_id`
- Added a `relay_host_paired` event in the local relay pairing completion path:
  - `crates/server/src/routes/relay_auth.rs` (`finish_spake2_enrollment`)
  - Properties: `client_id`, `client_browser`, `client_os`, `client_device`

## Why
The task is to track how many users are using the hosts relay feature. These two events provide visibility into:
- Active relay usage (`relay_host_session_created`)
- Successful host pairing completion (`relay_host_paired`)

## Important Implementation Details
- Both events are emitted only after successful operations.
- Remote tracking uses the authenticated remote user (`ctx.user.id`) via `state.analytics()`.
- Local tracking uses `track_if_analytics_allowed`, so analytics preferences are respected.
- No database migrations or shared type generation changes were needed.
- Scope is intentionally minimal and focused on readable route-level instrumentation.

This PR was written using [Vibe Kanban](https://vibekanban.com)
