### PR TITLE
Lower relay reconnect retry logs to debug (Vibe Kanban)

### DIFF
--- a/crates/server/src/tunnel.rs
+++ b/crates/server/src/tunnel.rs
@@ -105,7 +105,7 @@ pub async fn spawn_relay(deployment: &DeploymentImpl) {
         while !cancel_token.is_cancelled()
             && let Err(error) = start_relay(&params, cancel_token.clone()).await
         {
-            tracing::warn!(
+            tracing::debug!(
                 ?error,
                 retry_in_secs = delay.as_secs(),
                 "Relay connection failed; retrying"


### PR DESCRIPTION
## What changed
- Updated the relay reconnect retry log level in `crates/server/src/tunnel.rs` from `tracing::warn!` to `tracing::debug!`.
- The log message and structured fields are unchanged (`?error`, `retry_in_secs`, and "Relay connection failed; retrying").

## Why
- The reconnect loop intentionally retries after failures using exponential backoff (capped at 30 seconds).
- During expected/transient failures (for example relay downtime or unauthorized token refresh issues), the previous `WARN` log created noisy repeated warnings.
- This change reduces operational log noise while keeping the retry diagnostics available at debug level when needed.

## Implementation details
- This is a logging-only adjustment in the `spawn_relay` retry loop.
- No behavior changes to relay reconnect timing, retry policy, cancellation flow, or error propagation.
- The reconnect loop still retries exactly as before; only severity of the retry message is lowered.

This PR was written using [Vibe Kanban](https://vibekanban.com)
