### PR TITLE
Rename relay enrollment code UI copy to pairing code (Vibe Kanban)

### DIFF
--- a/packages/web-core/src/i18n/locales/en/settings.json
+++ b/packages/web-core/src/i18n/locales/en/settings.json
@@ -504,11 +504,11 @@
         "helper": "When enabled, this instance can be accessed remotely through a relay tunnel."
       },
       "enrollmentCode": {
-        "label": "Enrollment Code",
+        "label": "Pairing Code",
         "helper": "Enter this code in the browser to pair with this instance.",
-        "loginRequired": "Log in to generate an enrollment code.",
-        "fetchError": "Failed to fetch enrollment code.",
-        "show": "Show enrollment code"
+        "loginRequired": "Log in to generate a pairing code.",
+        "fetchError": "Failed to fetch pairing code.",
+        "show": "Show pairing code"
       }
     },
     "remoteProjects": {

--- a/packages/web-core/src/i18n/locales/es/settings.json
+++ b/packages/web-core/src/i18n/locales/es/settings.json
@@ -504,11 +504,11 @@
         "helper": "When enabled, this instance can be accessed remotely through a relay tunnel."
       },
       "enrollmentCode": {
-        "label": "Enrollment Code",
+        "label": "Pairing Code",
         "helper": "Enter this code in the browser to pair with this instance.",
-        "loginRequired": "Log in to generate an enrollment code.",
-        "fetchError": "Failed to fetch enrollment code.",
-        "show": "Show enrollment code"
+        "loginRequired": "Log in to generate a pairing code.",
+        "fetchError": "Failed to fetch pairing code.",
+        "show": "Show pairing code"
       }
     },
     "remoteProjects": {

--- a/packages/web-core/src/i18n/locales/fr/settings.json
+++ b/packages/web-core/src/i18n/locales/fr/settings.json
@@ -504,11 +504,11 @@
         "helper": "When enabled, this instance can be accessed remotely through a relay tunnel."
       },
       "enrollmentCode": {
-        "label": "Enrollment Code",
+        "label": "Pairing Code",
         "helper": "Enter this code in the browser to pair with this instance.",
-        "loginRequired": "Log in to generate an enrollment code.",
-        "fetchError": "Failed to fetch enrollment code.",
-        "show": "Show enrollment code"
+        "loginRequired": "Log in to generate a pairing code.",
+        "fetchError": "Failed to fetch pairing code.",
+        "show": "Show pairing code"
       }
     },
     "remoteProjects": {

--- a/packages/web-core/src/i18n/locales/ja/settings.json
+++ b/packages/web-core/src/i18n/locales/ja/settings.json
@@ -504,11 +504,11 @@
         "helper": "When enabled, this instance can be accessed remotely through a relay tunnel."
       },
       "enrollmentCode": {
-        "label": "Enrollment Code",
+        "label": "Pairing Code",
         "helper": "Enter this code in the browser to pair with this instance.",
-        "loginRequired": "Log in to generate an enrollment code.",
-        "fetchError": "Failed to fetch enrollment code.",
-        "show": "Show enrollment code"
+        "loginRequired": "Log in to generate a pairing code.",
+        "fetchError": "Failed to fetch pairing code.",
+        "show": "Show pairing code"
       }
     },
     "remoteProjects": {

--- a/packages/web-core/src/i18n/locales/ko/settings.json
+++ b/packages/web-core/src/i18n/locales/ko/settings.json
@@ -504,11 +504,11 @@
         "helper": "When enabled, this instance can be accessed remotely through a relay tunnel."
       },
       "enrollmentCode": {
-        "label": "Enrollment Code",
+        "label": "Pairing Code",
         "helper": "Enter this code in the browser to pair with this instance.",
-        "loginRequired": "Log in to generate an enrollment code.",
-        "fetchError": "Failed to fetch enrollment code.",
-        "show": "Show enrollment code"
+        "loginRequired": "Log in to generate a pairing code.",
+        "fetchError": "Failed to fetch pairing code.",
+        "show": "Show pairing code"
       }
     },
     "remoteProjects": {

--- a/packages/web-core/src/i18n/locales/zh-Hans/settings.json
+++ b/packages/web-core/src/i18n/locales/zh-Hans/settings.json
@@ -504,11 +504,11 @@
         "helper": "When enabled, this instance can be accessed remotely through a relay tunnel."
       },
       "enrollmentCode": {
-        "label": "Enrollment Code",
+        "label": "Pairing Code",
         "helper": "Enter this code in the browser to pair with this instance.",
-        "loginRequired": "Log in to generate an enrollment code.",
-        "fetchError": "Failed to fetch enrollment code.",
-        "show": "Show enrollment code"
+        "loginRequired": "Log in to generate a pairing code.",
+        "fetchError": "Failed to fetch pairing code.",
+        "show": "Show pairing code"
       }
     },
     "remoteProjects": {

--- a/packages/web-core/src/i18n/locales/zh-Hant/settings.json
+++ b/packages/web-core/src/i18n/locales/zh-Hant/settings.json
@@ -504,11 +504,11 @@
         "helper": "When enabled, this instance can be accessed remotely through a relay tunnel."
       },
       "enrollmentCode": {
-        "label": "Enrollment Code",
+        "label": "Pairing Code",
         "helper": "Enter this code in the browser to pair with this instance.",
-        "loginRequired": "Log in to generate an enrollment code.",
-        "fetchError": "Failed to fetch enrollment code.",
-        "show": "Show enrollment code"
+        "loginRequired": "Log in to generate a pairing code.",
+        "fetchError": "Failed to fetch pairing code.",
+        "show": "Show pairing code"
       }
     },
     "remoteProjects": {

--- a/scripts/relay-test-client/README.md
+++ b/scripts/relay-test-client/README.md
@@ -21,7 +21,7 @@ Open:
 - `Relay API Base` (example: `https://relay.localhost:3001`)
 - Use **Sign In (GitHub)** or **Sign In (Google)** to authenticate directly in
   the standalone client.
-- Enter the host enrollment code shown in the local backend logs after relay
+- Enter the host pairing code shown in the local backend logs after relay
   startup (`Relay PAKE enrollment code ready`).
 - Tokens are stored in browser localStorage:
   - `relay_test_access_token`

--- a/scripts/relay-test-client/index.html
+++ b/scripts/relay-test-client/index.html
@@ -170,7 +170,7 @@
           <input id="hostIdOverride" placeholder="UUID" autocomplete="off" />
         </div>
         <div class="grid" style="grid-column: 1 / -1">
-          <label for="enrollmentCode">Host Enrollment Code</label>
+          <label for="enrollmentCode">Host Pairing Code</label>
           <input
             id="enrollmentCode"
             placeholder="Code shown in local backend relay logs"
@@ -719,7 +719,7 @@
       async function runPakeEnrollment(sessionPrefix, enrollmentCode) {
         const normalizedCode = String(enrollmentCode || "").trim().toUpperCase();
         if (!normalizedCode) {
-          throw new Error("Missing host enrollment code.");
+          throw new Error("Missing host pairing code.");
         }
 
         const signingKey = await createSigningKey();


### PR DESCRIPTION
## What changed
- Updated relay settings copy from "Enrollment Code" to "Pairing Code" in all currently used locale files:
  - `packages/web-core/src/i18n/locales/en/settings.json`
  - `packages/web-core/src/i18n/locales/es/settings.json`
  - `packages/web-core/src/i18n/locales/fr/settings.json`
  - `packages/web-core/src/i18n/locales/ja/settings.json`
  - `packages/web-core/src/i18n/locales/ko/settings.json`
  - `packages/web-core/src/i18n/locales/zh-Hans/settings.json`
  - `packages/web-core/src/i18n/locales/zh-Hant/settings.json`
- Updated related relay test client wording:
  - `scripts/relay-test-client/index.html` ("Host Enrollment Code" label and missing-code error text)
  - `scripts/relay-test-client/README.md` (setup instruction wording)

## Why
- Task context required renaming the user-facing term from "Enrolment/Enrollment Code" to "Pairing Code".
- This makes the copy clearer and more action-oriented for the pairing flow.

## Implementation details
- This is a copy-only change; no pairing logic, API routes, request/response payload shapes, or storage keys were changed.
- Backend/internal identifiers (for example `enrollment_code`) remain unchanged intentionally to avoid protocol or compatibility impact.
- Scope is limited to user-facing strings in settings and relay test client documentation/UI.

This PR was written using [Vibe Kanban](https://vibekanban.com)
