### PR TITLE
fix(relay-tunnel): sync lockfile with api-types 0.1.20 to unblock relay CI (Vibe Kanban)

### DIFF
--- a/crates/relay-tunnel/Cargo.lock
+++ b/crates/relay-tunnel/Cargo.lock
@@ -34,7 +34,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "api-types"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "base64",
  "chrono",


### PR DESCRIPTION
## What changes were made
- Updated [`crates/relay-tunnel/Cargo.lock`](crates/relay-tunnel/Cargo.lock) to sync the local `api-types` path dependency version from `0.1.19` to `0.1.20`.
- No source code behavior changes; this is a lockfile consistency fix.

## Why these changes were made
- The relay image build in remote deployment CI failed on February 27, 2026 (run `22498655753`, job `65179704494`) during:
  - `cargo build --locked --release --manifest-path crates/relay-tunnel/Cargo.toml --features server`
- Failure reason: Cargo needed to mutate `crates/relay-tunnel/Cargo.lock`, but `--locked` forbids lockfile updates.
- Root cause: the `api-types` crate version had been bumped to `0.1.20`, while `crates/relay-tunnel/Cargo.lock` still referenced `0.1.19`.

## Important implementation details
- This fix keeps the existing strict `--locked` build behavior intact (instead of weakening build guarantees by changing build flags).
- The lockfile now reflects the current dependency graph for `crates/relay-tunnel`.
- Validation performed:
  - `cargo build --locked --manifest-path crates/relay-tunnel/Cargo.toml --features server`
  - `cargo build --locked --release --manifest-path crates/relay-tunnel/Cargo.toml --features server`

This PR was written using [Vibe Kanban](https://vibekanban.com)
