### PR TITLE
Handle mid-session relay host disconnects in remote workspaces (Vibe Kanban)

### DIFF
--- a/packages/remote-web/src/shared/hooks/useRelayWorkspaceHostHealth.ts
+++ b/packages/remote-web/src/shared/hooks/useRelayWorkspaceHostHealth.ts
@@ -37,10 +37,13 @@ export function useRelayWorkspaceHostHealth(
     },
   });
 
+  const isHostUnavailable =
+    hostHealthQuery.isError || hostHealthQuery.isRefetchError;
+
   return {
     isChecking: hostHealthQuery.isPending,
-    isError: hostHealthQuery.isError,
-    errorMessage: hostHealthQuery.isError
+    isError: isHostUnavailable,
+    errorMessage: isHostUnavailable
       ? getErrorMessage(hostHealthQuery.error)
       : null,
   };


### PR DESCRIPTION
## Summary
This PR improves remote workspace host availability detection so the UI correctly reports host disconnects that happen after the initial page load.

## What changed
- Updated [`useRelayWorkspaceHostHealth`](packages/remote-web/src/shared/hooks/useRelayWorkspaceHostHealth.ts) to treat both initial query failures and refetch failures as host-unavailable states.
- Added a local `isHostUnavailable` flag that combines:
  - `hostHealthQuery.isError`
  - `hostHealthQuery.isRefetchError`
- Reused that combined flag for both `isError` and `errorMessage` in the hook return value.

## Why this was needed
The reported issue was that when a host disconnected mid-session, the app could fall through to "No workspaces yet" instead of showing host-unavailable messaging. That happened because the health check hook only treated initial query errors as failures; background polling failures were not surfaced as unavailable.

This change ensures periodic health checks continue to guard the workspace UI and correctly reflect disconnects that occur after the first successful load.

## Implementation details
- Scope is intentionally minimal: one hook, no API/schema changes, no migration work.
- Existing polling behavior remains unchanged (`refetchInterval: 15_000`).
- Existing unavailable UI paths are reused; this change only makes sure they are triggered for refetch-time disconnects as well.

This PR was written using [Vibe Kanban](https://vibekanban.com)
