### PR TITLE
Simplify WYSIWYG editor: plain-text markdown editing with preview toggle (Vibe Kanban)

### DIFF
--- a/packages/web-core/src/pages/kanban/IssueWorkspacesSectionContainer.tsx
+++ b/packages/web-core/src/pages/kanban/IssueWorkspacesSectionContainer.tsx
@@ -180,8 +180,9 @@ export function IssueWorkspacesSectionContainer({
       return;
     }
 
-    const { WorkspaceSelectionDialog } =
-      await import('@/shared/dialogs/command-bar/WorkspaceSelectionDialog');
+    const { WorkspaceSelectionDialog } = await import(
+      '@/shared/dialogs/command-bar/WorkspaceSelectionDialog'
+    );
     await WorkspaceSelectionDialog.show({ projectId, issueId });
   }, [projectId, issueId]);
 

--- a/packages/web-core/src/pages/kanban/KanbanIssuePanelContainer.tsx
+++ b/packages/web-core/src/pages/kanban/KanbanIssuePanelContainer.tsx
@@ -616,8 +616,9 @@ export function KanbanIssuePanelContainer({
 
         // For statusId, open the status selection dialog with callback
         if (field === 'statusId') {
-          const { ProjectSelectionDialog } =
-            await import('@/shared/dialogs/command-bar/selections/ProjectSelectionDialog');
+          const { ProjectSelectionDialog } = await import(
+            '@/shared/dialogs/command-bar/selections/ProjectSelectionDialog'
+          );
           const result = await ProjectSelectionDialog.show({
             projectId,
             selection: { type: 'status', issueIds: [], isCreateMode: true },
@@ -636,8 +637,9 @@ export function KanbanIssuePanelContainer({
 
         // For priority, open the priority selection dialog with callback
         if (field === 'priority') {
-          const { ProjectSelectionDialog } =
-            await import('@/shared/dialogs/command-bar/selections/ProjectSelectionDialog');
+          const { ProjectSelectionDialog } = await import(
+            '@/shared/dialogs/command-bar/selections/ProjectSelectionDialog'
+          );
           const result = await ProjectSelectionDialog.show({
             projectId,
             selection: { type: 'priority', issueIds: [], isCreateMode: true },
@@ -659,8 +661,9 @@ export function KanbanIssuePanelContainer({
 
         // For assigneeIds, open the assignee selection dialog with callback
         if (field === 'assigneeIds') {
-          const { AssigneeSelectionDialog } =
-            await import('@/shared/dialogs/kanban/AssigneeSelectionDialog');
+          const { AssigneeSelectionDialog } = await import(
+            '@/shared/dialogs/kanban/AssigneeSelectionDialog'
+          );
           await AssigneeSelectionDialog.show({
             projectId,
             issueIds: [],

--- a/packages/web-core/src/pages/workspaces/PreviewBrowserContainer.tsx
+++ b/packages/web-core/src/pages/workspaces/PreviewBrowserContainer.tsx
@@ -637,9 +637,9 @@ export function PreviewBrowserContainer({
   const handleRefresh = useCallback(() => {
     const canUseBridgeRefresh = Boolean(
       showIframe &&
-      isReady &&
-      iframeRef.current?.contentWindow &&
-      bridgeRef.current
+        isReady &&
+        iframeRef.current?.contentWindow &&
+        bridgeRef.current
     );
 
     if (canUseBridgeRefresh) {

--- a/packages/web-core/src/shared/actions/index.ts
+++ b/packages/web-core/src/shared/actions/index.ts
@@ -425,8 +425,9 @@ export const Actions = {
     requiresTarget: ActionTargetType.NONE,
     isVisible: (ctx) => !ctx.isSignedIn,
     execute: async () => {
-      const { OAuthDialog } =
-        await import('@/shared/dialogs/global/OAuthDialog');
+      const { OAuthDialog } = await import(
+        '@/shared/dialogs/global/OAuthDialog'
+      );
       await OAuthDialog.show({});
     },
   } satisfies GlobalActionDefinition,
@@ -439,10 +440,12 @@ export const Actions = {
     isVisible: (ctx) => ctx.isSignedIn,
     execute: async (ctx) => {
       const { oauthApi } = await import('@/shared/lib/api');
-      const { useOrganizationStore } =
-        await import('@/shared/stores/useOrganizationStore');
-      const { organizationKeys } =
-        await import('@/shared/hooks/organizationKeys');
+      const { useOrganizationStore } = await import(
+        '@/shared/stores/useOrganizationStore'
+      );
+      const { organizationKeys } = await import(
+        '@/shared/hooks/organizationKeys'
+      );
 
       await oauthApi.logout();
       useOrganizationStore.getState().clearSelectedOrgId();
@@ -493,8 +496,9 @@ export const Actions = {
     requiresTarget: ActionTargetType.NONE,
     execute: async () => {
       // Dynamic import to avoid circular dependency (pages.ts imports Actions)
-      const { CommandBarDialog } =
-        await import('@/shared/dialogs/command-bar/CommandBarDialog');
+      const { CommandBarDialog } = await import(
+        '@/shared/dialogs/command-bar/CommandBarDialog'
+      );
       CommandBarDialog.show();
     },
   },
@@ -1219,8 +1223,9 @@ export const Actions = {
     isVisible: (ctx) => ctx.layoutMode === 'kanban' && ctx.isCreatingIssue,
     execute: async (ctx) => {
       if (!ctx.kanbanProjectId) return;
-      const { ProjectSelectionDialog } =
-        await import('@/shared/dialogs/command-bar/selections/ProjectSelectionDialog');
+      const { ProjectSelectionDialog } = await import(
+        '@/shared/dialogs/command-bar/selections/ProjectSelectionDialog'
+      );
       await ProjectSelectionDialog.show({
         projectId: ctx.kanbanProjectId,
         selection: { type: 'status', issueIds: [], isCreateMode: true },
@@ -1250,8 +1255,9 @@ export const Actions = {
     isVisible: (ctx) => ctx.layoutMode === 'kanban' && ctx.isCreatingIssue,
     execute: async (ctx) => {
       if (!ctx.kanbanProjectId) return;
-      const { ProjectSelectionDialog } =
-        await import('@/shared/dialogs/command-bar/selections/ProjectSelectionDialog');
+      const { ProjectSelectionDialog } = await import(
+        '@/shared/dialogs/command-bar/selections/ProjectSelectionDialog'
+      );
       await ProjectSelectionDialog.show({
         projectId: ctx.kanbanProjectId,
         selection: { type: 'priority', issueIds: [], isCreateMode: true },

--- a/packages/web-core/src/shared/dialogs/command-bar/CommandBarDialog.tsx
+++ b/packages/web-core/src/shared/dialogs/command-bar/CommandBarDialog.tsx
@@ -120,8 +120,9 @@ function CommandBarContent({
           repoId = repos[0].id;
         } else if (!repoId && repos.length > 1) {
           const { SelectionDialog } = await import('./SelectionDialog');
-          const { buildRepoSelectionPages } =
-            await import('./selections/repoSelection');
+          const { buildRepoSelectionPages } = await import(
+            './selections/repoSelection'
+          );
           const result = await SelectionDialog.show({
             initialPageId: 'selectRepo',
             pages: buildRepoSelectionPages(repos) as Record<

--- a/packages/web-core/src/shared/integrations/electric/hooks.ts
+++ b/packages/web-core/src/shared/integrations/electric/hooks.ts
@@ -29,11 +29,8 @@ export interface UseShapeResult<TRow> {
 /**
  * Extended result when mutation is provided — adds insert/update/remove.
  */
-export interface UseShapeMutationResult<
-  TRow,
-  TCreate,
-  TUpdate,
-> extends UseShapeResult<TRow> {
+export interface UseShapeMutationResult<TRow, TCreate, TUpdate>
+  extends UseShapeResult<TRow> {
   /** Insert a new row (optimistic), returns row and persistence promise */
   insert: (data: TCreate) => InsertResult<TRow>;
   /** Update a row by ID (optimistic), returns persistence promise */
@@ -50,8 +47,9 @@ export interface UseShapeMutationResult<
  * Options for the useShape hook.
  */
 export interface UseShapeOptions<
-  M extends MutationDefinition<unknown, unknown, unknown> | undefined =
-    undefined,
+  M extends
+    | MutationDefinition<unknown, unknown, unknown>
+    | undefined = undefined,
 > {
   /**
    * Whether to enable the Electric sync subscription.
@@ -87,8 +85,9 @@ export interface UseShapeOptions<
  */
 export function useShape<
   T extends Record<string, unknown>,
-  M extends MutationDefinition<unknown, unknown, unknown> | undefined =
-    undefined,
+  M extends
+    | MutationDefinition<unknown, unknown, unknown>
+    | undefined = undefined,
 >(
   shape: ShapeDefinition<T>,
   params: Record<string, string>,

--- a/packages/web-core/src/shared/lib/auth/tokenManager.ts
+++ b/packages/web-core/src/shared/lib/auth/tokenManager.ts
@@ -163,8 +163,9 @@ class TokenManager {
     // (i.e., their session expired unexpectedly). Don't prompt users who
     // intentionally logged out or were never logged in.
     if (wasLoggedIn) {
-      const { OAuthDialog } =
-        await import('@/shared/dialogs/global/OAuthDialog');
+      const { OAuthDialog } = await import(
+        '@/shared/dialogs/global/OAuthDialog'
+      );
       void OAuthDialog.show({});
     }
   }

--- a/packages/web-core/src/shared/providers/ActionsProvider.tsx
+++ b/packages/web-core/src/shared/providers/ActionsProvider.tsx
@@ -93,8 +93,9 @@ export function ActionsProvider({ children }: ActionsProviderProps) {
   // Open status selection dialog (uses dynamic import to avoid circular deps)
   const openStatusSelection = useCallback(
     async (projectId: string, issueIds: string[]) => {
-      const { ProjectSelectionDialog } =
-        await import('@/shared/dialogs/command-bar/selections/ProjectSelectionDialog');
+      const { ProjectSelectionDialog } = await import(
+        '@/shared/dialogs/command-bar/selections/ProjectSelectionDialog'
+      );
       await ProjectSelectionDialog.show({
         projectId,
         selection: { type: 'status', issueIds },
@@ -106,8 +107,9 @@ export function ActionsProvider({ children }: ActionsProviderProps) {
   // Open priority selection dialog (uses dynamic import to avoid circular deps)
   const openPrioritySelection = useCallback(
     async (projectId: string, issueIds: string[]) => {
-      const { ProjectSelectionDialog } =
-        await import('@/shared/dialogs/command-bar/selections/ProjectSelectionDialog');
+      const { ProjectSelectionDialog } = await import(
+        '@/shared/dialogs/command-bar/selections/ProjectSelectionDialog'
+      );
       await ProjectSelectionDialog.show({
         projectId,
         selection: { type: 'priority', issueIds },
@@ -119,8 +121,9 @@ export function ActionsProvider({ children }: ActionsProviderProps) {
   // Open assignee selection dialog (uses dynamic import to avoid circular deps)
   const openAssigneeSelection = useCallback(
     async (projectId: string, issueIds: string[], isCreateMode = false) => {
-      const { AssigneeSelectionDialog } =
-        await import('@/shared/dialogs/kanban/AssigneeSelectionDialog');
+      const { AssigneeSelectionDialog } = await import(
+        '@/shared/dialogs/kanban/AssigneeSelectionDialog'
+      );
       await AssigneeSelectionDialog.show({ projectId, issueIds, isCreateMode });
     },
     []
@@ -133,8 +136,9 @@ export function ActionsProvider({ children }: ActionsProviderProps) {
       parentIssueId: string,
       mode: 'addChild' | 'setParent' = 'addChild'
     ) => {
-      const { ProjectSelectionDialog } =
-        await import('@/shared/dialogs/command-bar/selections/ProjectSelectionDialog');
+      const { ProjectSelectionDialog } = await import(
+        '@/shared/dialogs/command-bar/selections/ProjectSelectionDialog'
+      );
       return (await ProjectSelectionDialog.show({
         projectId,
         selection: { type: 'subIssue', parentIssueId, mode },
@@ -146,8 +150,9 @@ export function ActionsProvider({ children }: ActionsProviderProps) {
   // Open workspace selection dialog (uses dynamic import to avoid circular deps)
   const openWorkspaceSelection = useCallback(
     async (projectId: string, issueId: string) => {
-      const { WorkspaceSelectionDialog } =
-        await import('@/shared/dialogs/command-bar/WorkspaceSelectionDialog');
+      const { WorkspaceSelectionDialog } = await import(
+        '@/shared/dialogs/command-bar/WorkspaceSelectionDialog'
+      );
       await WorkspaceSelectionDialog.show({ projectId, issueId });
     },
     []
@@ -161,8 +166,9 @@ export function ActionsProvider({ children }: ActionsProviderProps) {
       relationshipType: 'blocking' | 'related' | 'has_duplicate',
       direction: 'forward' | 'reverse'
     ) => {
-      const { ProjectSelectionDialog } =
-        await import('@/shared/dialogs/command-bar/selections/ProjectSelectionDialog');
+      const { ProjectSelectionDialog } = await import(
+        '@/shared/dialogs/command-bar/selections/ProjectSelectionDialog'
+      );
       await ProjectSelectionDialog.show({
         projectId,
         selection: {


### PR DESCRIPTION
## Summary

Replaces the buggy live markdown-rendering WYSIWYG editor with a simpler plain-text editing mode where users type raw markdown syntax, with a preview toggle to see the rendered output.

- **Remove `MarkdownShortcutPlugin`** — the live markdown-as-you-type conversion was the primary source of editor bugs. Users now type `**bold**` as literal text instead of it being auto-converted to rich text.
- **New `MarkdownInsertPlugin`** — intercepts `FORMAT_TEXT_COMMAND` to insert markdown syntax markers (e.g. `**`, `*`, `~~`, `` ` ``) as literal text instead of applying Lexical rich text formatting. Also handles a new `INSERT_MARKDOWN_LIST_COMMAND` for `- ` and `1. ` prefixes.
- **Standalone preview toggle** — every editable editor gets an Eye/PencilLine button (top-right corner) that toggles between edit mode and a read-only rendered preview. The preview renders a nested `<WYSIWYGEditor disabled>` with full display transformers.
- **Split transformer architecture** — `editTransformers` (custom elements + text format transformers only) vs `displayTransformers` (full markdown rendering). Edit mode preserves raw markdown; display mode renders everything.
- **Strip backslash escapes** — added `preserveMarkdownSyntax` option to `MarkdownSyncPlugin` that strips Lexical's automatic escaping of `*`, `_`, `~` etc. in the `onChange` export path, so the stored value contains the user's intended markdown syntax.
- **Toolbar simplification** — removed active state tracking (bold/italic/etc. indicators no longer meaningful), removed Underline button (no markdown equivalent), rewired list buttons to use `INSERT_MARKDOWN_LIST_COMMAND`.

## Why

The WYSIWYG editor's live markdown rendering via `MarkdownShortcutPlugin` was difficult to use and produced many edge-case bugs. By switching to plain-text editing with an explicit preview toggle, users get a predictable editing experience while still being able to format with toolbar buttons and see rendered output on demand. Custom elements (images, PR comments, component info) continue to render inline in both modes.

## Implementation details

- **Frozen selection fix**: Lexical freezes selection objects inside command handlers. The plugin creates fresh `RangeSelection` objects via `$createRangeSelection()` + `$setSelection()` for cursor positioning after marker insertion.
- **`useImperativeHandle` guard**: The nested preview editor doesn't receive a ref prop, which in React strict mode causes a frozen empty object to be passed. A guard checks for a valid ref before calling `useImperativeHandle`.
- **`hideActions` prop**: Prevents the read-only action buttons (Copy, Edit, Delete) from appearing on the nested preview editor.
- **Preview toggle z-index**: The toggle button is positioned outside `<LexicalComposer>` with `absolute top-0 right-0 z-20` to prevent the preview content from occluding it.

## Files changed

| File | Change |
|------|--------|
| `MarkdownInsertPlugin.tsx` | New plugin — intercepts format commands to insert markdown syntax as text |
| `MarkdownSyncPlugin.tsx` | Added `preserveMarkdownSyntax` to strip backslash escapes on export |
| `WYSIWYGEditor.tsx` | Split transformers, added preview toggle, replaced MarkdownShortcutPlugin |
| `ToolbarPlugin.tsx` | Removed active state tracking and Underline button |
| `StaticToolbarPlugin.tsx` | Removed active state, rewired lists to INSERT_MARKDOWN_LIST_COMMAND |
| `KeyboardCommandsPlugin.tsx` | Removed Cmd+E inline code handler (now handled by MarkdownInsertPlugin) |

## Test plan

- [ ] Type markdown syntax (`**bold**`, `*italic*`, `` `code` ``) — should appear as literal text
- [ ] Click toolbar Bold/Italic/Strikethrough/Code buttons — should insert markdown markers
- [ ] Click preview toggle (eye icon) — should render markdown (bold, italic, lists, headings, etc.)
- [ ] Click edit toggle (pencil icon) — should return to raw text editing
- [ ] Verify custom elements (images, PR comments) render in both edit and preview modes
- [ ] Verify keyboard shortcuts (Cmd+B, Cmd+I) insert markdown markers
- [ ] Verify no console errors when toggling preview

This PR was written using [Vibe Kanban](https://vibekanban.com)