### PR TITLE
fix: allow resetting session to initial message (Vibe Kanban)

### DIFF
--- a/packages/web-core/src/features/workspace-chat/model/hooks/useResetProcess.ts
+++ b/packages/web-core/src/features/workspace-chat/model/hooks/useResetProcess.ts
@@ -19,18 +19,17 @@ export function useResetProcess(): UseResetProcessResult {
   const resetMutation = useResetProcessMutation(selectedSessionId ?? '');
   const isResetPending = resetMutation.isPending;
 
-  const firstCodingProcessId = useMemo(
+  const hasCodingProcess = useMemo(
     () =>
-      processes.find(
+      processes.some(
         (process) => !process.dropped && isCodingAgent(process.run_reason)
-      )?.id,
+      ),
     [processes]
   );
 
   const canResetProcess = useCallback(
-    (executionProcessId: string) =>
-      !!firstCodingProcessId && executionProcessId !== firstCodingProcessId,
-    [firstCodingProcessId]
+    (executionProcessId: string) => hasCodingProcess && !!executionProcessId,
+    [hasCodingProcess]
   );
 
   const resetProcess = useCallback(

--- a/packages/web-core/src/features/workspace-chat/ui/NewDisplayConversationEntry.tsx
+++ b/packages/web-core/src/features/workspace-chat/ui/NewDisplayConversationEntry.tsx
@@ -703,7 +703,7 @@ function UserMessageEntry({
     !!executionProcessId && !isInEditMode && !isResetPending;
   // Edit/retry/reset is not supported when the executor doesn't have the fork capability
   const canEdit = canShowActions && executorCanFork;
-  // Only show reset if we have a process ID, not in edit mode, not pending, and not first process
+  // Only show reset if we have a process ID, not in edit mode, and not pending
   const canReset = canEdit && canResetProcess(executionProcessId);
 
   return (


### PR DESCRIPTION
## Summary

Fixes the session reset logic so users can reset back to the very first (initial) message in a workspace session. Previously, the first coding process was excluded from being reset to, making it impossible to roll back to the starting point of a session.

## Changes

- **`useResetProcess.ts`**: Changed the reset eligibility check from comparing against the first coding process ID to simply verifying that a coding process exists and the target process ID is valid. Renamed `firstCodingProcessId` to `hasCodingProcess` and switched from `find()` to `some()` since we no longer need the actual ID — just whether one exists.
- **`NewDisplayConversationEntry.tsx`**: Updated the comment to reflect the simplified reset condition (no longer excludes the first process).

## Why

Users expected to be able to reset/rollback a session to its initial message, but the previous logic specifically prevented resetting to the first coding process. This was an unnecessary restriction — if a session has a coding process, any message (including the first) should be a valid reset target.

---

This PR was written using [Vibe Kanban](https://vibekanban.com)