### PR TITLE
Stop Auto-Scrolling to Bottom After Successful Send (Vibe Kanban)

### DIFF
--- a/packages/web-core/src/features/workspace-chat/ui/SessionChatBoxContainer.tsx
+++ b/packages/web-core/src/features/workspace-chat/ui/SessionChatBoxContainer.tsx
@@ -486,7 +486,6 @@ export function SessionChatBoxContainer(props: SessionChatBoxContainerProps) {
       if (!isSlashCommand) {
         reviewContext?.clearComments();
       }
-      onScrollToBottom();
     }
   }, [
     send,
@@ -498,7 +497,6 @@ export function SessionChatBoxContainer(props: SessionChatBoxContainerProps) {
     isNewSessionMode,
     clearDraft,
     reviewContext,
-    onScrollToBottom,
   ]);
 
   // Track previous process count for queue refresh


### PR DESCRIPTION
## Summary
- Removes the explicit `onScrollToBottom()` call after a successful message send in `SessionChatBoxContainer`.
- Updates the `handleSend` callback dependency array to remove the now-unused `onScrollToBottom` dependency.

## What Changed
- In `packages/web-core/src/features/workspace-chat/ui/SessionChatBoxContainer.tsx`, the success path in `handleSend` no longer forces an immediate scroll to the end of the conversation.
- The related `useCallback` dependency list was cleaned up to reflect the removal.

## Why
This branch was created to remove the automatic scroll-to-bottom behavior that fires immediately after sending a message. The previous behavior could unexpectedly move the viewport even when users were reviewing earlier messages. Removing this call keeps the user’s current reading position intact and avoids forced jumps after send.

## Implementation Details
- The change is intentionally minimal and scoped to one code path: successful send handling.
- Only two lines were deleted, with no additional logic introduced.
- Existing scrolling mechanisms remain available (for example, list update scroll modifiers and manual "scroll to bottom" controls), so this only removes the forced post-send jump.

This PR was written using [Vibe Kanban](https://vibekanban.com)
