### PR TITLE
feat: add project/issue/workspace shortcuts and chat input focus

### DIFF
--- a/packages/local-web/src/routes/_app.tsx
+++ b/packages/local-web/src/routes/_app.tsx
@@ -4,6 +4,7 @@ import { SequenceTrackerProvider } from '@/shared/keyboard/SequenceTracker';
 import { SequenceIndicator } from '@/shared/keyboard/SequenceIndicator';
 import { useWorkspaceShortcuts } from '@/shared/keyboard/useWorkspaceShortcuts';
 import { useIssueShortcuts } from '@/shared/keyboard/useIssueShortcuts';
+import { useProjectShortcuts } from '@/shared/keyboard/useProjectShortcuts';
 import { useKeyShowHelp, Scope } from '@/shared/keyboard';
 import { KeyboardShortcutsDialog } from '@/shared/dialogs/shared/KeyboardShortcutsDialog';
 import { TerminalProvider } from '@/shared/providers/TerminalProvider';
@@ -18,6 +19,7 @@ function KeyboardShortcutsHandler() {
   );
   useWorkspaceShortcuts();
   useIssueShortcuts();
+  useProjectShortcuts();
   return null;
 }
 

--- a/packages/web-core/src/shared/dialogs/command-bar/OpenProjectDialog.tsx
+++ b/packages/web-core/src/shared/dialogs/command-bar/OpenProjectDialog.tsx
@@ -1,0 +1,142 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useNavigate, useLocation } from '@tanstack/react-router';
+import { create, useModal } from '@ebay/nice-modal-react';
+import { defineModal, type NoProps } from '@/shared/lib/modals';
+import { useAllOrganizationProjects } from '@/shared/hooks/useAllOrganizationProjects';
+import { useUserOrganizations } from '@/shared/hooks/useUserOrganizations';
+import { useOrganizationStore } from '@/shared/stores/useOrganizationStore';
+import { toProject } from '@/shared/lib/routes/navigation';
+import {
+  Command,
+  CommandDialog,
+  CommandInput,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+} from '@vibe/ui/components/Command';
+
+function OpenProjectDialogContent() {
+  const modal = useModal();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+  const [search, setSearch] = useState('');
+  const setSelectedOrgId = useOrganizationStore((s) => s.setSelectedOrgId);
+  const { data: projects, isLoading } = useAllOrganizationProjects();
+  const { data: organizationsData } = useUserOrganizations();
+
+  const currentProjectId = location.pathname.startsWith('/projects/')
+    ? location.pathname.split('/')[2]
+    : null;
+
+  const orgNameById = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const org of organizationsData?.organizations ?? []) {
+      map.set(org.id, org.name);
+    }
+    return map;
+  }, [organizationsData?.organizations]);
+
+  const sortedProjects = useMemo(
+    () =>
+      [...projects].sort((a, b) => {
+        const orgA = orgNameById.get(a.organization_id) ?? '';
+        const orgB = orgNameById.get(b.organization_id) ?? '';
+        if (orgA !== orgB) return orgA.localeCompare(orgB);
+        return a.name.localeCompare(b.name);
+      }),
+    [projects, orgNameById]
+  );
+
+  const filteredProjects = useMemo(() => {
+    const query = search.trim().toLowerCase();
+    if (!query) return sortedProjects;
+    return sortedProjects.filter((project) => {
+      const orgName = orgNameById.get(project.organization_id) ?? '';
+      return (
+        project.name.toLowerCase().includes(query) ||
+        orgName.toLowerCase().includes(query)
+      );
+    });
+  }, [search, sortedProjects, orgNameById]);
+
+  useEffect(() => {
+    if (modal.visible) {
+      previousFocusRef.current = document.activeElement as HTMLElement;
+      setSearch('');
+    }
+  }, [modal.visible]);
+
+  const handleOpenProject = useCallback(
+    (projectId: string, organizationId: string) => {
+      setSelectedOrgId(organizationId);
+      navigate(toProject(projectId));
+      modal.resolve();
+      modal.hide();
+    },
+    [modal, navigate, setSelectedOrgId]
+  );
+
+  const handleCloseAutoFocus = useCallback((event: Event) => {
+    event.preventDefault();
+    previousFocusRef.current?.focus();
+  }, []);
+
+  const handleOpenAutoFocus = useCallback((event: Event) => {
+    event.preventDefault();
+  }, []);
+
+  return (
+    <CommandDialog
+      open={modal.visible}
+      onOpenChange={(open) => !open && modal.hide()}
+      onCloseAutoFocus={handleCloseAutoFocus}
+      onOpenAutoFocus={handleOpenAutoFocus}
+    >
+      <Command
+        className="rounded-sm border border-border [&_[cmdk-group-heading]]:px-base [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-low [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-half [&_[cmdk-input-wrapper]_svg]:h-4 [&_[cmdk-input-wrapper]_svg]:w-4 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-base [&_[cmdk-item]]:py-half"
+        loop
+      >
+        <div className="flex items-center border-b border-border">
+          <CommandInput
+            placeholder="Open project..."
+            value={search}
+            onValueChange={setSearch}
+          />
+        </div>
+        <CommandList className="min-h-[200px]">
+          <CommandEmpty>
+            {isLoading ? 'Loading projects...' : 'No projects found'}
+          </CommandEmpty>
+          <CommandGroup heading="Projects">
+            {filteredProjects.map((project) => {
+              const orgName = orgNameById.get(project.organization_id) ?? '';
+              return (
+                <CommandItem
+                  key={project.id}
+                  value={`${project.name} ${orgName}`}
+                  onSelect={() =>
+                    handleOpenProject(project.id, project.organization_id)
+                  }
+                  className="flex items-center justify-between"
+                >
+                  <span className="truncate">{project.name}</span>
+                  <span className="ml-base text-low text-xs truncate">
+                    {currentProjectId === project.id
+                      ? 'Current'
+                      : orgName || 'Organization'}
+                  </span>
+                </CommandItem>
+              );
+            })}
+          </CommandGroup>
+        </CommandList>
+      </Command>
+    </CommandDialog>
+  );
+}
+
+const OpenProjectDialogImpl = create<NoProps>(() => <OpenProjectDialogContent />);
+
+export const OpenProjectDialog = defineModal<void, void>(OpenProjectDialogImpl);

--- a/packages/web-core/src/shared/keyboard/registry.ts
+++ b/packages/web-core/src/shared/keyboard/registry.ts
@@ -87,6 +87,20 @@ export const sequentialBindings: SequentialBinding[] = [
     group: 'Navigation',
     actionId: 'new-workspace',
   },
+  {
+    id: 'seq-go-new-project',
+    keys: ['g', 'c'],
+    description: 'Create Project',
+    group: 'Navigation',
+    actionId: 'create-project',
+  },
+  {
+    id: 'seq-go-open-project',
+    keys: ['g', 'p'],
+    description: 'Open Project',
+    group: 'Navigation',
+    actionId: 'open-project',
+  },
 
   // Workspace (W)
   {
@@ -160,6 +174,13 @@ export const sequentialBindings: SequentialBinding[] = [
     description: 'Toggle Chat panel',
     group: 'View',
     actionId: 'toggle-left-main-panel',
+  },
+  {
+    id: 'seq-view-chat-input',
+    keys: ['v', 'i'],
+    description: 'Open chat and focus input',
+    group: 'View',
+    actionId: 'open-chat-focus-input',
   },
 
   // Git (X = eXecute)
@@ -314,6 +335,27 @@ export const sequentialBindings: SequentialBinding[] = [
     description: 'Link Workspace',
     group: 'Issue',
     actionId: 'link-workspace',
+  },
+  {
+    id: 'seq-issue-open-workspace',
+    keys: ['i', 'o'],
+    description: 'Open linked workspace',
+    group: 'Issue',
+    actionId: 'open-linked-workspace',
+  },
+  {
+    id: 'seq-issue-next-workspace',
+    keys: ['i', 'j'],
+    description: 'Next linked workspace',
+    group: 'Issue',
+    actionId: 'next-linked-workspace',
+  },
+  {
+    id: 'seq-issue-prev-workspace',
+    keys: ['i', 'k'],
+    description: 'Previous linked workspace',
+    group: 'Issue',
+    actionId: 'previous-linked-workspace',
   },
   {
     id: 'seq-issue-duplicate',

--- a/packages/web-core/src/shared/keyboard/useIssueShortcuts.ts
+++ b/packages/web-core/src/shared/keyboard/useIssueShortcuts.ts
@@ -2,12 +2,15 @@ import { useCallback, useRef, useEffect, useMemo } from 'react';
 import { useParams, useLocation } from '@tanstack/react-router';
 import { useHotkeys } from 'react-hotkeys-hook';
 import { useActions } from '@/shared/hooks/useActions';
+import { useUserContext } from '@/shared/hooks/useUserContext';
+import { useKanbanNavigation } from '@/shared/hooks/useKanbanNavigation';
 import { Actions } from '@/shared/actions';
 import {
   type ActionDefinition,
   ActionTargetType,
 } from '@/shared/types/actions';
 import { Scope } from '@/shared/keyboard/registry';
+import type { Workspace as RemoteWorkspace } from 'shared/remote-types';
 
 const SEQUENCE_TIMEOUT_MS = 1500;
 
@@ -18,8 +21,10 @@ const OPTIONS = {
 
 export function useIssueShortcuts() {
   const { executeAction } = useActions();
-  const { projectId, issueId } = useParams({ strict: false });
+  const { projectId, issueId, workspaceId } = useParams({ strict: false });
   const location = useLocation();
+  const { workspaces } = useUserContext();
+  const { openIssueWorkspace } = useKanbanNavigation();
 
   const isKanban = location.pathname.startsWith('/projects');
   // Detect create mode from the URL path (e.g. /projects/:id/issues/new)
@@ -29,6 +34,9 @@ export function useIssueShortcuts() {
   const executeActionRef = useRef(executeAction);
   const projectIdRef = useRef(projectId);
   const issueIdRef = useRef(issueId);
+  const workspaceIdRef = useRef(workspaceId);
+  const workspacesRef = useRef(workspaces);
+  const openIssueWorkspaceRef = useRef(openIssueWorkspace);
   const isKanbanRef = useRef(isKanban);
   const isCreatingIssueRef = useRef(isCreatingIssue);
 
@@ -36,6 +44,9 @@ export function useIssueShortcuts() {
     executeActionRef.current = executeAction;
     projectIdRef.current = projectId;
     issueIdRef.current = issueId;
+    workspaceIdRef.current = workspaceId;
+    workspacesRef.current = workspaces;
+    openIssueWorkspaceRef.current = openIssueWorkspace;
     isKanbanRef.current = isKanban;
     isCreatingIssueRef.current = isCreatingIssue;
   });
@@ -73,6 +84,23 @@ export function useIssueShortcuts() {
   );
 
   const enabled = isKanban;
+
+  const getLinkedLocalWorkspaceIds = useCallback(
+    (currentProjectId: string, currentIssueId: string): string[] => {
+      return workspacesRef.current
+        .filter(
+          (workspace) =>
+            workspace.project_id === currentProjectId &&
+            workspace.issue_id === currentIssueId &&
+            workspace.local_workspace_id !== null
+        )
+        .sort((a: RemoteWorkspace, b: RemoteWorkspace) =>
+          b.updated_at.localeCompare(a.updated_at)
+        )
+        .map((workspace) => workspace.local_workspace_id as string);
+    },
+    []
+  );
 
   useHotkeys('i>c', (e) => executeIssueAction(Actions.CreateIssue, e), {
     ...OPTIONS,
@@ -127,6 +155,77 @@ export function useIssueShortcuts() {
     ...OPTIONS,
     enabled,
   });
+  useHotkeys(
+    'i>o',
+    (e) => {
+      if (!isKanbanRef.current) return;
+      e?.preventDefault();
+      const currentProjectId = projectIdRef.current;
+      const currentIssueId = issueIdRef.current;
+      if (!currentProjectId || !currentIssueId) return;
+      const linkedWorkspaceIds = getLinkedLocalWorkspaceIds(
+        currentProjectId,
+        currentIssueId
+      );
+      const firstWorkspaceId = linkedWorkspaceIds[0];
+      if (!firstWorkspaceId) return;
+      openIssueWorkspaceRef.current(currentIssueId, firstWorkspaceId);
+    },
+    { ...OPTIONS, enabled }
+  );
+  useHotkeys(
+    'i>j',
+    (e) => {
+      if (!isKanbanRef.current) return;
+      e?.preventDefault();
+      const currentProjectId = projectIdRef.current;
+      const currentIssueId = issueIdRef.current;
+      if (!currentProjectId || !currentIssueId) return;
+      const linkedWorkspaceIds = getLinkedLocalWorkspaceIds(
+        currentProjectId,
+        currentIssueId
+      );
+      if (linkedWorkspaceIds.length === 0) return;
+      const currentWorkspaceId = workspaceIdRef.current;
+      const currentIndex = currentWorkspaceId
+        ? linkedWorkspaceIds.indexOf(currentWorkspaceId)
+        : -1;
+      const nextWorkspaceId =
+        currentIndex === -1
+          ? linkedWorkspaceIds[0]
+          : linkedWorkspaceIds[(currentIndex + 1) % linkedWorkspaceIds.length];
+      openIssueWorkspaceRef.current(currentIssueId, nextWorkspaceId);
+    },
+    { ...OPTIONS, enabled }
+  );
+  useHotkeys(
+    'i>k',
+    (e) => {
+      if (!isKanbanRef.current) return;
+      e?.preventDefault();
+      const currentProjectId = projectIdRef.current;
+      const currentIssueId = issueIdRef.current;
+      if (!currentProjectId || !currentIssueId) return;
+      const linkedWorkspaceIds = getLinkedLocalWorkspaceIds(
+        currentProjectId,
+        currentIssueId
+      );
+      if (linkedWorkspaceIds.length === 0) return;
+      const currentWorkspaceId = workspaceIdRef.current;
+      const currentIndex = currentWorkspaceId
+        ? linkedWorkspaceIds.indexOf(currentWorkspaceId)
+        : -1;
+      const previousWorkspaceId =
+        currentIndex === -1
+          ? linkedWorkspaceIds[linkedWorkspaceIds.length - 1]
+          : linkedWorkspaceIds[
+              (currentIndex - 1 + linkedWorkspaceIds.length) %
+                linkedWorkspaceIds.length
+            ];
+      openIssueWorkspaceRef.current(currentIssueId, previousWorkspaceId);
+    },
+    { ...OPTIONS, enabled }
+  );
   useHotkeys('i>d', (e) => executeIssueAction(Actions.DuplicateIssue, e), {
     ...OPTIONS,
     enabled,

--- a/packages/web-core/src/shared/keyboard/useProjectShortcuts.ts
+++ b/packages/web-core/src/shared/keyboard/useProjectShortcuts.ts
@@ -1,0 +1,50 @@
+import { useCallback } from 'react';
+import { useHotkeys } from 'react-hotkeys-hook';
+import { useLocation, useNavigate } from '@tanstack/react-router';
+import { useOrganizationStore } from '@/shared/stores/useOrganizationStore';
+import { CreateRemoteProjectDialog } from '@/shared/dialogs/org/CreateRemoteProjectDialog';
+import { OpenProjectDialog } from '@/shared/dialogs/command-bar/OpenProjectDialog';
+import { toProject } from '@/shared/lib/routes/navigation';
+import { Scope } from '@/shared/keyboard/registry';
+
+const SEQUENCE_TIMEOUT_MS = 1500;
+
+const OPTIONS = {
+  scopes: [Scope.WORKSPACE, Scope.KANBAN, Scope.PROJECTS],
+  sequenceTimeout: SEQUENCE_TIMEOUT_MS,
+} as const;
+
+export function useProjectShortcuts() {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const selectedOrgId = useOrganizationStore((s) => s.selectedOrgId);
+  const setSelectedOrgId = useOrganizationStore((s) => s.setSelectedOrgId);
+
+  const handleCreateProject = useCallback(async () => {
+    if (!selectedOrgId) return;
+    const result = await CreateRemoteProjectDialog.show({
+      organizationId: selectedOrgId,
+    });
+    if (result.action === 'created' && result.project) {
+      setSelectedOrgId(result.project.organization_id);
+      navigate(toProject(result.project.id));
+    }
+  }, [navigate, selectedOrgId, setSelectedOrgId]);
+
+  const handleOpenProject = useCallback(async () => {
+    await OpenProjectDialog.show();
+  }, []);
+
+  const isInsideApp =
+    location.pathname.startsWith('/projects') ||
+    location.pathname.startsWith('/workspaces');
+
+  useHotkeys('g>c', () => void handleCreateProject(), {
+    ...OPTIONS,
+    enabled: isInsideApp,
+  });
+  useHotkeys('g>p', () => void handleOpenProject(), {
+    ...OPTIONS,
+    enabled: isInsideApp,
+  });
+}

--- a/packages/web-core/src/shared/keyboard/useWorkspaceShortcuts.ts
+++ b/packages/web-core/src/shared/keyboard/useWorkspaceShortcuts.ts
@@ -3,6 +3,7 @@ import { useHotkeys } from 'react-hotkeys-hook';
 import { useActions } from '@/shared/hooks/useActions';
 import { useWorkspaceContext } from '@/shared/hooks/useWorkspaceContext';
 import { Actions } from '@/shared/actions';
+import { useUiPreferencesStore } from '@/shared/stores/useUiPreferencesStore';
 import {
   type ActionDefinition,
   ActionTargetType,
@@ -50,6 +51,26 @@ export function useWorkspaceShortcuts() {
     }
   }, []);
 
+  const openChatAndFocusInput = useCallback(() => {
+    const currentWorkspaceId = workspaceIdRef.current;
+    if (!currentWorkspaceId) return;
+
+    useUiPreferencesStore
+      .getState()
+      .setLeftMainPanelVisible(true, currentWorkspaceId);
+
+    const focusEditor = () => {
+      const editor = document.querySelector(
+        '[aria-label="Markdown editor"]'
+      ) as HTMLElement | null;
+      editor?.focus();
+    };
+
+    // The panel/editor can mount asynchronously after opening.
+    window.setTimeout(focusEditor, 0);
+    window.setTimeout(focusEditor, 120);
+  }, []);
+
   useHotkeys('g>s', () => execute(Actions.Settings), OPTIONS);
   useHotkeys('g>n', () => execute(Actions.NewWorkspace), OPTIONS);
 
@@ -64,6 +85,7 @@ export function useWorkspaceShortcuts() {
   useHotkeys('v>p', () => execute(Actions.TogglePreviewMode), OPTIONS);
   useHotkeys('v>s', () => execute(Actions.ToggleLeftSidebar), OPTIONS);
   useHotkeys('v>h', () => execute(Actions.ToggleLeftMainPanel), OPTIONS);
+  useHotkeys('v>i', () => openChatAndFocusInput(), OPTIONS);
 
   useHotkeys('x>p', () => execute(Actions.GitCreatePR), OPTIONS);
   useHotkeys('x>m', () => execute(Actions.GitMerge), OPTIONS);


### PR DESCRIPTION
## Summary
- add `g>c` to create project
- add `g>p` to open project via searchable picker
- add `i>o` to open linked workspace from issue
- add `i>j` / `i>k` to cycle linked workspaces in issue context
- add `v>i` to open chat panel in workspace and focus chat input

## Implementation
- new project shortcut hook wired in app shortcut handler
- new OpenProjectDialog command-palette style project picker
- issue shortcut logic extended to resolve and navigate linked local workspaces
- workspace shortcut logic extended to force-open chat panel and focus editor
- keyboard shortcut registry updated so help overlay includes new sequences

## Validation
- `corepack pnpm --filter @vibe/local-web run check` passes
