### PR TITLE
Show script command in chat for setup/cleanup/archive scripts (Vibe Kanban)

### DIFF
--- a/packages/ui/src/components/ChatScriptEntry.tsx
+++ b/packages/ui/src/components/ChatScriptEntry.tsx
@@ -5,6 +5,7 @@ import { ToolStatusDot, type ToolStatusLike } from './ToolStatusDot';
 
 interface ChatScriptEntryProps {
   title: string;
+  command?: string;
   processId: string;
   exitCode?: number | null;
   className?: string;
@@ -15,6 +16,7 @@ interface ChatScriptEntryProps {
 
 export function ChatScriptEntry({
   title,
+  command,
   processId,
   exitCode,
   className,
@@ -74,6 +76,11 @@ export function ChatScriptEntry({
       </span>
       <div className="flex flex-col min-w-0 flex-1">
         <span className="text-normal font-medium">{title}</span>
+        {command && (
+          <code className="text-low text-xs font-mono truncate block">
+            {command}
+          </code>
+        )}
         <span className="text-low text-xs">{getSubtitle()}</span>
       </div>
       {isFailed && onFix && (

--- a/packages/web-core/src/features/workspace-chat/ui/NewDisplayConversationEntry.tsx
+++ b/packages/web-core/src/features/workspace-chat/ui/NewDisplayConversationEntry.tsx
@@ -243,6 +243,7 @@ function renderToolUseEntry(
     return (
       <ScriptEntryWithFix
         title={entryType.tool_name}
+        command={action_type.command}
         processId={executionProcessId ?? ''}
         exitCode={exitCode}
         status={status}
@@ -903,6 +904,7 @@ function SystemMessageEntry({
  */
 function ScriptEntryWithFix({
   title,
+  command,
   processId,
   exitCode,
   status,
@@ -910,6 +912,7 @@ function ScriptEntryWithFix({
   sessionId,
 }: {
   title: string;
+  command?: string;
   processId: string;
   exitCode: number | null;
   status: ToolStatus;
@@ -959,6 +962,7 @@ function ScriptEntryWithFix({
   return (
     <ChatScriptEntry
       title={title}
+      command={command}
       processId={processId}
       exitCode={exitCode}
       status={status}


### PR DESCRIPTION
## Summary

When running setup, cleanup, or archive scripts, the chat UI only displayed a generic title (e.g. "Setup Script") without showing the actual command being executed. This made it difficult for users to understand what was happening during script execution.

This PR threads the script command content through the component hierarchy and displays it as a truncated monospace line beneath the script title in the chat conversation view.

## Changes

- **`ChatScriptEntry`** (`packages/ui/src/components/ChatScriptEntry.tsx`): Added an optional `command` prop and renders it as a `<code>` element with monospace font, truncated to prevent overflow
- **`ScriptEntryWithFix`** (`packages/web-core/src/features/workspace-chat/ui/NewDisplayConversationEntry.tsx`): Added `command` prop passthrough to `ChatScriptEntry`
- **`renderToolUseEntry`** (`NewDisplayConversationEntry.tsx`): Passes `action_type.command` (already available in the data pipeline from `useConversationHistory`) to `ScriptEntryWithFix`

## Why

The script command was already available in the normalized conversation data (`action_type.command`, populated from `executor_action.typ.script`) but was never surfaced in the UI. Regular tool entries (like Bash commands) already display their command — this brings script entries to parity.

---

This PR was written using [Vibe Kanban](https://vibekanban.com)