### PR TITLE
fix: reorder accordion sections to place Running between Needs Attention and Idle (Vibe Kanban)

### DIFF
--- a/packages/ui/src/components/WorkspacesSidebar.tsx
+++ b/packages/ui/src/components/WorkspacesSidebar.tsx
@@ -289,28 +289,6 @@ export function WorkspacesSidebar({
               </div>
             </CollapsibleSectionHeader>
 
-            {/* Idle section */}
-            <CollapsibleSectionHeader
-              title={t('common:workspaces.idle')}
-              persistKey={persistKeys.notRunning}
-              defaultExpanded={true}
-            >
-              <div className="flex flex-col gap-base py-half">
-                {idleWorkspaces.length === 0 ? (
-                  <span className="text-sm text-low opacity-60 pl-base">
-                    {t('common:workspaces.noWorkspaces')}
-                  </span>
-                ) : (
-                  <WorkspaceList
-                    workspaces={idleWorkspaces}
-                    selectedWorkspaceId={selectedWorkspaceId}
-                    onSelectWorkspace={onSelectWorkspace}
-                    onOpenWorkspaceActions={handleOpenWorkspaceActions}
-                  />
-                )}
-              </div>
-            </CollapsibleSectionHeader>
-
             {/* Running section */}
             <CollapsibleSectionHeader
               title={t('common:workspaces.running')}
@@ -325,6 +303,28 @@ export function WorkspacesSidebar({
                 ) : (
                   <WorkspaceList
                     workspaces={runningWorkspaces}
+                    selectedWorkspaceId={selectedWorkspaceId}
+                    onSelectWorkspace={onSelectWorkspace}
+                    onOpenWorkspaceActions={handleOpenWorkspaceActions}
+                  />
+                )}
+              </div>
+            </CollapsibleSectionHeader>
+
+            {/* Idle section */}
+            <CollapsibleSectionHeader
+              title={t('common:workspaces.idle')}
+              persistKey={persistKeys.notRunning}
+              defaultExpanded={true}
+            >
+              <div className="flex flex-col gap-base py-half">
+                {idleWorkspaces.length === 0 ? (
+                  <span className="text-sm text-low opacity-60 pl-base">
+                    {t('common:workspaces.noWorkspaces')}
+                  </span>
+                ) : (
+                  <WorkspaceList
+                    workspaces={idleWorkspaces}
                     selectedWorkspaceId={selectedWorkspaceId}
                     onSelectWorkspace={onSelectWorkspace}
                     onOpenWorkspaceActions={handleOpenWorkspaceActions}


### PR DESCRIPTION
## Summary

Reorders the workspace sidebar accordion sections so that **Running** appears between **Needs Attention** and **Idle**, instead of after both.

- **Before:** Needs Attention → Idle → Running
- **After:** Needs Attention → Running → Idle

## Changes

- Swapped the order of the "Running" and "Idle" `<CollapsibleSectionHeader>` blocks in `WorkspacesSidebar.tsx`
- No logic, categorization, or translation changes — purely a JSX render order swap

## Why

Running workspaces are more actionable than idle ones, so placing them directly after "Needs Attention" gives them better visibility and creates a more intuitive priority ordering: attention-needed first, then active work, then idle.

---

This PR was written using [Vibe Kanban](https://vibekanban.com)