### PR TITLE
fix: allow follow-up messages while parallel setup script is running (Vibe Kanban)

### DIFF
--- a/crates/db/.sqlx/query-1b186dc075846fc1f7270a942afbf82a88806ee6ababdb437ab5e97ddd2122da.json
+++ b/crates/db/.sqlx/query-1b186dc075846fc1f7270a942afbf82a88806ee6ababdb437ab5e97ddd2122da.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "SQLite",
+  "query": "SELECT COUNT(*) as \"count!: i64\"\n               FROM execution_processes ep\n               WHERE ep.session_id = $1\n                 AND ep.status = 'running'\n                 AND ep.run_reason = 'codingagent'",
+  "describe": {
+    "columns": [
+      {
+        "name": "count!: i64",
+        "ordinal": 0,
+        "type_info": "Integer"
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "1b186dc075846fc1f7270a942afbf82a88806ee6ababdb437ab5e97ddd2122da"
+}

--- a/crates/db/src/models/execution_process.rs
+++ b/crates/db/src/models/execution_process.rs
@@ -279,6 +279,24 @@ impl ExecutionProcess {
         .await
     }
 
+    /// Check if there's a running coding agent process for a session
+    pub async fn has_running_coding_agent_for_session(
+        pool: &SqlitePool,
+        session_id: Uuid,
+    ) -> Result<bool, sqlx::Error> {
+        let count: i64 = sqlx::query_scalar!(
+            r#"SELECT COUNT(*) as "count!: i64"
+               FROM execution_processes ep
+               WHERE ep.session_id = $1
+                 AND ep.status = 'running'
+                 AND ep.run_reason = 'codingagent'"#,
+            session_id
+        )
+        .fetch_one(pool)
+        .await?;
+        Ok(count > 0)
+    }
+
     /// Check if there are running processes (excluding dev servers) for a workspace (across all sessions)
     pub async fn has_running_non_dev_server_processes_for_workspace(
         pool: &SqlitePool,

--- a/crates/local-deployment/src/container.rs
+++ b/crates/local-deployment/src/container.rs
@@ -592,6 +592,51 @@ impl LocalContainerService {
                     }
                 }
 
+                // When a parallel setup script finishes and no coding agent is running,
+                // consume any queued message that was stuck waiting
+                if matches!(
+                    ctx.execution_process.run_reason,
+                    ExecutionProcessRunReason::SetupScript
+                ) && !container.should_finalize(&ctx)
+                {
+                    let has_running_agent = ExecutionProcess::has_running_coding_agent_for_session(
+                        &db.pool,
+                        ctx.session.id,
+                    )
+                    .await
+                    .unwrap_or(true);
+
+                    if !has_running_agent
+                        && let Some(queued_msg) =
+                            container.queued_message_service.take_queued(ctx.session.id)
+                    {
+                        tracing::info!(
+                            "Parallel setup script finished with queued message for session {}, starting follow-up",
+                            ctx.session.id
+                        );
+
+                        if let Err(e) =
+                            Scratch::delete(&db.pool, ctx.session.id, &ScratchType::DraftFollowUp)
+                                .await
+                        {
+                            tracing::warn!(
+                                "Failed to delete scratch after consuming queued message: {}",
+                                e
+                            );
+                        }
+
+                        if let Err(e) = container
+                            .start_queued_follow_up(&ctx, &queued_msg.data)
+                            .await
+                        {
+                            tracing::error!(
+                                "Failed to start queued follow-up from setup script completion: {}",
+                                e
+                            );
+                        }
+                    }
+                }
+
                 // Fire analytics event when CodingAgent execution has finished
                 if config.read().await.analytics_enabled
                     && matches!(

--- a/packages/web-core/src/shared/providers/ExecutionProcessesProvider.tsx
+++ b/packages/web-core/src/shared/providers/ExecutionProcessesProvider.tsx
@@ -35,7 +35,6 @@ export const ExecutionProcessesProvider: React.FC<{
       visible.some(
         (process) =>
           (process.run_reason === 'codingagent' ||
-            process.run_reason === 'setupscript' ||
             process.run_reason === 'cleanupscript' ||
             process.run_reason === 'archivescript') &&
           process.status === 'running'


### PR DESCRIPTION
## Summary

Fixes a bug where users couldn't send follow-up messages after the coding agent's first turn if the setup script was still running in parallel mode.

## Problem

When a workspace starts with `all_parallel` mode, both the setup script and coding agent run simultaneously. After the coding agent completed its first turn:

1. **Frontend deadlock**: `isAttemptRunningVisible` counted a running `setupscript` as equivalent to a running `codingagent`, forcing the chat UI into "Queue" mode (showing only a "Queue" button instead of "Send")
2. **Backend deadlock**: Parallel setup scripts explicitly skip finalization (`should_finalize` returns `false`), so any queued message was never consumed — the coding agent had already finalized, and the setup script would never trigger queue consumption

This created a permanent deadlock: the user could only queue (not send), and the queue was never drained.

## Changes

### Frontend (`packages/web-core/src/shared/providers/ExecutionProcessesProvider.tsx`)
- Removed `setupscript` from the `isAttemptRunningVisible` computation. Only `codingagent`, `cleanupscript`, and `archivescript` processes now block the send button. This allows users to send follow-ups directly via the API while a setup script runs in the background.

### Backend (`crates/local-deployment/src/container.rs`)
- Added queue consumption logic for parallel setup script completion in the exit monitor. When a parallel setup script finishes and no coding agent is running for that session, any queued message is consumed and executed as a follow-up. This handles edge cases where a message was queued before the frontend fix applies.

### Database (`crates/db/src/models/execution_process.rs`)
- Added `has_running_coding_agent_for_session()` query to check if a coding agent process is currently running for a given session, used by the backend fix above.

---

This PR was written using [Vibe Kanban](https://vibekanban.com)