### PR TITLE
fix: mark workspace as seen when viewed from kanban board (Vibe Kanban)

### DIFF
--- a/packages/web-core/src/shared/providers/WorkspaceProvider.tsx
+++ b/packages/web-core/src/shared/providers/WorkspaceProvider.tsx
@@ -111,22 +111,27 @@ export function WorkspaceProvider({ children }: WorkspaceProviderProps) {
 
   const isLoading = isLoadingList || isLoadingWorkspace;
 
+  // Mark workspace as seen whenever the active workspaceId changes.
+  // This covers all navigation paths: sidebar clicks, kanban card clicks,
+  // direct URL navigation, and post-creation redirects.
+  useEffect(() => {
+    if (!workspaceId || isCreateMode) return;
+
+    attemptsApi
+      .markSeen(workspaceId)
+      .then(() => {
+        queryClient.invalidateQueries({ queryKey: workspaceSummaryKeys.all });
+      })
+      .catch((error) => {
+        console.warn('Failed to mark workspace as seen:', error);
+      });
+  }, [workspaceId, isCreateMode, queryClient]);
+
   const selectWorkspace = useCallback(
     (id: string) => {
-      // Fire-and-forget mark as seen (don't block navigation)
-      attemptsApi
-        .markSeen(id)
-        .then(() => {
-          // Invalidate summary cache to refresh unseen indicators
-          queryClient.invalidateQueries({ queryKey: workspaceSummaryKeys.all });
-        })
-        .catch((error) => {
-          // Silently fail - this is not critical
-          console.warn('Failed to mark workspace as seen:', error);
-        });
       appNavigation.goToWorkspace(id);
     },
-    [queryClient, appNavigation]
+    [appNavigation]
   );
 
   const navigateToCreate = useMemo(


### PR DESCRIPTION
## Summary

Fixes the bug where workspaces attached to kanban board issue cards always show the "unseen" indicator (orange circle), even after the user has viewed the workspace from the kanban board.

## Problem

The `markSeen` API call was only triggered from one place: `selectWorkspace()` in `WorkspaceProvider`, which was exclusively wired to the **workspace sidebar** click handler. All other navigation paths to a workspace — kanban card clicks, issue panel workspace clicks, direct URL navigation, post-creation redirects — bypassed `markSeen` entirely.

This meant 9 out of 11 navigation paths never cleared the unseen indicator.

## Solution

Moved the `markSeen` logic from the `selectWorkspace` callback into a `useEffect` in `WorkspaceProvider` that fires whenever `workspaceId` changes. Since `WorkspaceProvider` wraps the entire app at root level and reads `workspaceId` from URL params, this single change covers **all** navigation paths:

- Workspace sidebar clicks
- Kanban board card → workspace card clicks
- Issue panel → workspace card clicks
- Kanban right sidebar → workspace clicks
- "Expand to full view" button
- Post-creation redirects
- Direct URL navigation

The `useEffect` skips create mode (`isCreateMode`) to avoid marking workspaces as seen before they exist.

## Changes

- **`packages/web-core/src/shared/providers/WorkspaceProvider.tsx`**
  - Added `useEffect` that calls `attemptsApi.markSeen(workspaceId)` on workspace ID change
  - Simplified `selectWorkspace` to only handle navigation (markSeen is now handled by the effect)

---

This PR was written using [Vibe Kanban](https://vibekanban.com)