### PR TITLE
Use root execution-process provider for workspace logs (Vibe Kanban)

### DIFF
--- a/packages/local-web/src/routes/__root.tsx
+++ b/packages/local-web/src/routes/__root.tsx
@@ -22,7 +22,6 @@ function ExecutionProcessesProviderWrapper({
   children: ReactNode;
 }) {
   const { selectedSessionId } = useWorkspaceContext();
-
   return (
     <ExecutionProcessesProvider sessionId={selectedSessionId}>
       {children}

--- a/packages/web-core/src/features/workspace-chat/model/hooks/useConversationHistory.ts
+++ b/packages/web-core/src/features/workspace-chat/model/hooks/useConversationHistory.ts
@@ -11,12 +11,6 @@ import { useExecutionProcessesContext } from '@/shared/hooks/useExecutionProcess
 import { useEntries } from '../contexts/EntriesContext';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { streamJsonPatchEntries } from '@/shared/lib/streamJsonPatchEntries';
-import {
-  makeLoadingPatch,
-  MIN_INITIAL_ENTRIES,
-  nextActionPatch,
-  REMAINING_BATCH_SIZE,
-} from '@/shared/hooks/useConversationHistory/constants';
 import type {
   AddEntryType,
   ExecutionProcessStateStore,
@@ -36,6 +30,12 @@ export interface UseConversationHistoryResult {
   /** Whether the conversation only has a single coding agent turn (no follow-ups) */
   isFirstTurn: boolean;
 }
+import {
+  makeLoadingPatch,
+  MIN_INITIAL_ENTRIES,
+  nextActionPatch,
+  REMAINING_BATCH_SIZE,
+} from '@/shared/hooks/useConversationHistory/constants';
 
 export const useConversationHistory = ({
   attempt,


### PR DESCRIPTION
## Summary
- Kept execution-process stream ownership at the root provider layer instead of nesting `ExecutionProcessesProvider` in `WorkspacesLayout`.
- Fixed cross-session/workspace leakage by filtering streamed execution processes to the active `sessionId` inside `useExecutionProcesses`.
- Included minor cleanup-only changes (`useConversationHistory` import ordering, local root formatting).

## Why
The original profiling work showed we should avoid extra provider churn during workspace viewing to keep logs loading fast.

After moving provider ownership to root, we observed a correctness regression: stale execution processes could briefly appear when switching workspaces/sessions. A keyed provider remount fixed correctness but regressed speed by forcing broader subtree remounts.

This version keeps the speed benefit while restoring correctness by enforcing session-scoped data at the hook boundary.

## Implementation Details
- `packages/web-core/src/pages/workspaces/WorkspacesLayout.tsx`
  - Removed nested `ExecutionProcessesProvider` wrappers from both mobile and desktop non-create flows.
  - Removed now-unused `selectedSessionId` usage and provider import.

- `packages/web-core/src/shared/hooks/useExecutionProcesses.ts`
  - Renamed the raw sorted stream list to `streamedExecutionProcesses`.
  - Added a session guard:
    - when `sessionId` exists, only expose processes where `executionProcess.session_id === sessionId`.
  - Rebuilt `executionProcessesById` from the filtered list so both array and map stay consistent.
  - Kept running-state derivation based on the filtered result.

- `packages/web-core/src/features/workspace-chat/model/hooks/useConversationHistory.ts`
  - Import ordering cleanup only (no runtime behavior change).

## Note
This PR was written using [Vibe Kanban](https://vibekanban.com)
