### PR TITLE
fix: enable keyboard hotkeys on remote web (Vibe Kanban)

### DIFF
--- a/packages/remote-web/package.json
+++ b/packages/remote-web/package.json
@@ -25,6 +25,7 @@
     "posthog-js": "^1.283.0",
     "prettier": "^3.6.1",
     "react": "^18.2.0",
+    "react-hotkeys-hook": "^5.1.0",
     "react-compiler-runtime": "^1.0.0",
     "react-dom": "^18.2.0",
     "simple-icons": "^15.16.0",

--- a/packages/remote-web/src/app/entry/App.tsx
+++ b/packages/remote-web/src/app/entry/App.tsx
@@ -1,11 +1,16 @@
 import { RouterProvider } from "@tanstack/react-router";
+import { HotkeysProvider } from "react-hotkeys-hook";
 import { router } from "@remote/app/router";
 import { AppRuntimeProvider } from "@/shared/hooks/useAppRuntime";
 
 export function AppRouter() {
   return (
     <AppRuntimeProvider runtime="remote">
-      <RouterProvider router={router} />
+      <HotkeysProvider
+        initiallyActiveScopes={["global", "workspace", "kanban", "projects"]}
+      >
+        <RouterProvider router={router} />
+      </HotkeysProvider>
     </AppRuntimeProvider>
   );
 }

--- a/packages/remote-web/src/routes/__root.tsx
+++ b/packages/remote-web/src/routes/__root.tsx
@@ -20,6 +20,15 @@ import { useAuth } from "@/shared/hooks/auth/useAuth";
 import { useWorkspaceContext } from "@/shared/hooks/useWorkspaceContext";
 import { AppNavigationProvider } from "@/shared/hooks/useAppNavigation";
 import {
+  SequenceTrackerProvider,
+  SequenceIndicator,
+  useWorkspaceShortcuts,
+  useIssueShortcuts,
+  useKeyShowHelp,
+  Scope,
+} from "@/shared/keyboard";
+import { KeyboardShortcutsDialog } from "@/shared/dialogs/shared/KeyboardShortcutsDialog";
+import {
   createRemoteHostAppNavigation,
   remoteFallbackAppNavigation,
   resolveRemoteDestinationFromPath,
@@ -54,13 +63,40 @@ function ExecutionProcessesProviderWrapper({
   );
 }
 
+/**
+ * Global keyboard shortcut that doesn't require workspace/actions context.
+ * Renders inside HotkeysProvider (from App.tsx) but outside WorkspaceProvider.
+ */
+function GlobalKeyboardShortcuts() {
+  useKeyShowHelp(
+    () => {
+      KeyboardShortcutsDialog.show();
+    },
+    { scope: Scope.GLOBAL },
+  );
+  return null;
+}
+
+/**
+ * Workspace & issue keyboard shortcuts that require ActionsProvider + WorkspaceProvider.
+ * Must be rendered inside WorkspaceRouteProviders.
+ */
+function WorkspaceKeyboardShortcuts() {
+  useWorkspaceShortcuts();
+  useIssueShortcuts();
+  return null;
+}
+
 function WorkspaceRouteProviders({ children }: { children: ReactNode }) {
   return (
     <WorkspaceProvider>
       <ExecutionProcessesProviderWrapper>
         <TerminalProvider>
           <LogsPanelProvider>
-            <ActionsProvider>{children}</ActionsProvider>
+            <ActionsProvider>
+              <WorkspaceKeyboardShortcuts />
+              {children}
+            </ActionsProvider>
           </LogsPanelProvider>
         </TerminalProvider>
       </ExecutionProcessesProviderWrapper>
@@ -103,9 +139,13 @@ function RootLayout() {
   const pageContent = isStandaloneRoute ? (
     <Outlet />
   ) : (
-    <RemoteAppShell>
-      <Outlet />
-    </RemoteAppShell>
+    <SequenceTrackerProvider>
+      <SequenceIndicator />
+      <GlobalKeyboardShortcuts />
+      <RemoteAppShell>
+        <Outlet />
+      </RemoteAppShell>
+    </SequenceTrackerProvider>
   );
 
   const content = isWorkspaceProviderRoute ? (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -390,6 +390,9 @@ importers:
       react-dom:
         specifier: ^18.2.0
         version: 18.3.1(react@18.3.1)
+      react-hotkeys-hook:
+        specifier: ^5.1.0
+        version: 5.2.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       simple-icons:
         specifier: ^15.16.0
         version: 15.18.0


### PR DESCRIPTION
## Summary

Keyboard hotkeys (workspace shortcuts, issue shortcuts, sequence indicators) were completely non-functional on the remote web app, while working correctly on local web. This PR adds the missing hotkey infrastructure to `remote-web`.

## Problem

The remote web app was missing **all three layers** of the keyboard shortcut system that local web had:

1. **`HotkeysProvider`** — the React context from `react-hotkeys-hook` that all `useHotkeys()` calls depend on. Without it, scopes are never activated and handlers never fire.
2. **Shortcut registration hooks** — `useWorkspaceShortcuts()`, `useIssueShortcuts()`, and `useKeyShowHelp()` were never called anywhere in the remote-web component tree.
3. **Visual feedback** — `SequenceTrackerProvider` and `SequenceIndicator` (the HUD that shows key sequences like `g > s`) were absent.

## Changes

### `packages/remote-web/src/app/entry/App.tsx`
- Added `<HotkeysProvider>` wrapping the router with the same active scopes as local-web (`global`, `workspace`, `kanban`, `projects`).

### `packages/remote-web/src/routes/__root.tsx`
- Added `GlobalKeyboardShortcuts` component — registers `useKeyShowHelp()` (the `?` key). This has no dependency on `WorkspaceProvider`/`ActionsProvider`, so it lives at the `RemoteAppShell` level.
- Added `WorkspaceKeyboardShortcuts` component — registers `useWorkspaceShortcuts()` and `useIssueShortcuts()`. These hooks call `useWorkspaceContext()` and `useActions()` internally, which **throw** without their providers. Placed inside `WorkspaceRouteProviders` where those contexts exist.
- Wrapped non-standalone routes with `<SequenceTrackerProvider>` + `<SequenceIndicator>` for visual key sequence feedback. Standalone routes (login, account, upgrade, invitations) are intentionally excluded.

### `packages/remote-web/package.json`
- Added `react-hotkeys-hook@^5.1.0` as a direct dependency (same version as `local-web`, `web-core`, and `ui`).

## Architecture Decision

The shortcut handlers are split into two components (`GlobalKeyboardShortcuts` and `WorkspaceKeyboardShortcuts`) to respect provider boundaries. In remote-web, `WorkspaceProvider` and `ActionsProvider` are conditionally rendered only for workspace/project routes, unlike local-web where they wrap everything. Placing workspace shortcuts inside the provider boundary prevents runtime crashes on routes without workspace context.

---

This PR was written using [Vibe Kanban](https://vibekanban.com)