### PR TITLE
fix: open VS Code remote SSH links in a new window

### DIFF
--- a/crates/services/src/services/config/editor/mod.rs
+++ b/crates/services/src/services/config/editor/mod.rs
@@ -195,7 +195,7 @@ impl EditorConfig {
         // files must contain a line and column number
         let line_col = if path.is_file() { ":1:1" } else { "" };
         Some(format!(
-            "{scheme}://vscode-remote/ssh-remote+{user_part}{remote_host}{path_str}{line_col}"
+            "{scheme}://vscode-remote/ssh-remote+{user_part}{remote_host}{path_str}{line_col}?windowId=_blank"
         ))
     }
 


### PR DESCRIPTION
## Summary
- Appends `?windowId=_blank` to `vscode-remote://` URLs generated for the open-in-editor button when using remote SSH
- This makes VS Code open a new window instead of reusing (and replacing) the current one

Fixes #3029

## Test plan
- Configure Vibe Kanban with a remote SSH host for VS Code
- Click the open-in-editor button
- Verify the generated URL ends with `?windowId=_blank` and opens in a new VS Code window