### PR TITLE
Restore scratch draft repo branches during create-mode hydration (Vibe Kanban)

### DIFF
--- a/packages/web-core/src/integrations/useCreateModeState.ts
+++ b/packages/web-core/src/integrations/useCreateModeState.ts
@@ -672,6 +672,20 @@ async function initializeState({
         restoredData.images = scratchData.images;
       }
 
+      // Restore repos + branches from scratch draft (e.g., spin-off/duplicate)
+      if (scratchData.repos?.length > 0) {
+        const restoredRepos = await resolveNavPreferredRepos(
+          scratchData.repos.map((repo) => ({
+            repo_id: repo.repo_id,
+            target_branch: repo.target_branch || null,
+          }))
+        );
+
+        if (restoredRepos.length > 0) {
+          restoredData.repos = restoredRepos;
+        }
+      }
+
       dispatch({ type: 'INIT_COMPLETE', data: restoredData });
       return;
     }


### PR DESCRIPTION
## Summary
This PR fixes workspace creation drafts losing repo branch selections (often falling back to `main`) when opened from flows like **Spin off workspace**.

## What changed
- Updated `initializeState` in `packages/web-core/src/integrations/useCreateModeState.ts`.
- In the scratch-draft restore path (`DRAFT_WORKSPACE`), we now restore `repos` in addition to message/config/linked issue/images.
- Draft repo entries are mapped into the existing `resolveNavPreferredRepos(...)` flow to rehydrate full repo objects.
- `target_branch` values are normalized with `repo.target_branch || null` so empty strings become `null` consistently.
- Restored repos are only applied when resolution succeeds (`restoredRepos.length > 0`).

## Why this was needed
The spin-off flow already persisted intended target branches into the draft scratch payload, but create-mode hydration was not restoring scratch `repos`. That left `state.repos` empty, which allowed downstream defaulting logic to repopulate branches from workspace defaults (commonly `main`).

This change preserves the branch selections that were explicitly saved in the draft, so spin-off/duplicate-style create flows keep the correct branch context.

## Implementation details
- No API/type/schema changes.
- No changes to `SpinOffWorkspace` action payload construction were required.
- Scope is intentionally in hydration logic so all draft-based workspace-create flows benefit.

This PR was written using [Vibe Kanban](https://vibekanban.com)
