### PR TITLE
Expose app version from /api/info in app bar footer (Vibe Kanban)

### DIFF
--- a/crates/server/src/routes/config.rs
+++ b/crates/server/src/routes/config.rs
@@ -86,6 +86,7 @@ impl Environment {
 
 #[derive(Debug, Serialize, Deserialize, TS)]
 pub struct UserSystemInfo {
+    pub version: String,
     pub config: Config,
     pub analytics_user_id: String,
     pub login_status: LoginStatus,
@@ -112,6 +113,7 @@ async fn get_user_system_info(
     .unwrap_or(LoginStatus::LoggedOut);
 
     let user_system_info = UserSystemInfo {
+        version: env!("CARGO_PKG_VERSION").to_string(),
         config: config.clone(),
         analytics_user_id: deployment.user_id().to_string(),
         login_status,

--- a/packages/local-web/src/app/providers/ConfigProvider.tsx
+++ b/packages/local-web/src/app/providers/ConfigProvider.tsx
@@ -29,6 +29,7 @@ export function UserSystemProvider({ children }: UserSystemProviderProps) {
   });
 
   const config = userSystemInfo?.config || null;
+  const appVersion = userSystemInfo?.version || null;
   const environment = userSystemInfo?.environment || null;
   const analyticsUserId = userSystemInfo?.analytics_user_id || null;
   const loginStatus = userSystemInfo?.login_status || null;
@@ -143,6 +144,7 @@ export function UserSystemProvider({ children }: UserSystemProviderProps) {
   const value = useMemo<UserSystemContextType>(
     () => ({
       system: {
+        appVersion,
         config,
         environment,
         profiles,
@@ -150,6 +152,7 @@ export function UserSystemProvider({ children }: UserSystemProviderProps) {
         analyticsUserId,
         loginStatus,
       },
+      appVersion,
       config,
       environment,
       profiles,
@@ -166,6 +169,7 @@ export function UserSystemProvider({ children }: UserSystemProviderProps) {
       loading: isLoading,
     }),
     [
+      appVersion,
       config,
       environment,
       profiles,

--- a/packages/remote-web/src/app/providers/RemoteUserSystemProvider.tsx
+++ b/packages/remote-web/src/app/providers/RemoteUserSystemProvider.tsx
@@ -38,6 +38,7 @@ export function RemoteUserSystemProvider({
   });
 
   const config = userSystemInfo?.config || null;
+  const appVersion = userSystemInfo?.version || null;
   const environment = userSystemInfo?.environment || null;
   const analyticsUserId = userSystemInfo?.analytics_user_id || null;
   const loginStatus = userSystemInfo?.login_status || null;
@@ -146,6 +147,7 @@ export function RemoteUserSystemProvider({
   const value = useMemo<UserSystemContextType>(
     () => ({
       system: {
+        appVersion,
         config,
         environment,
         profiles,
@@ -153,6 +155,7 @@ export function RemoteUserSystemProvider({
         analyticsUserId,
         loginStatus,
       },
+      appVersion,
       config,
       environment,
       profiles,
@@ -169,6 +172,7 @@ export function RemoteUserSystemProvider({
       loading,
     }),
     [
+      appVersion,
       config,
       environment,
       profiles,

--- a/packages/ui/src/components/AppBar.tsx
+++ b/packages/ui/src/components/AppBar.tsx
@@ -67,6 +67,7 @@ interface AppBarProps {
   userPopover?: ReactNode;
   starCount?: number | null;
   onlineCount?: number | null;
+  appVersion?: string | null;
   githubIconPath: string;
   discordIconPath: string;
 }
@@ -122,6 +123,7 @@ export function AppBar({
   userPopover,
   starCount,
   onlineCount,
+  appVersion,
   githubIconPath,
   discordIconPath,
 }: AppBarProps) {
@@ -400,6 +402,11 @@ export function AppBar({
             onlineCount != null && (onlineCount > 999 ? '999+' : onlineCount)
           }
         />
+        {appVersion && (
+          <p className="text-[9px] font-ibm-plex-mono text-low leading-none">
+            v{appVersion}
+          </p>
+        )}
       </div>
     </div>
   );

--- a/packages/web-core/src/shared/components/ui-new/containers/SharedAppLayout.tsx
+++ b/packages/web-core/src/shared/components/ui-new/containers/SharedAppLayout.tsx
@@ -17,6 +17,7 @@ import { useOrganizationStore } from '@/shared/stores/useOrganizationStore';
 import { useAuth } from '@/shared/hooks/auth/useAuth';
 import { useDiscordOnlineCount } from '@/shared/hooks/useDiscordOnlineCount';
 import { useGitHubStars } from '@/shared/hooks/useGitHubStars';
+import { useUserSystem } from '@/shared/hooks/useUserSystem';
 import { useAppNavigation } from '@/shared/hooks/useAppNavigation';
 import { useCurrentAppDestination } from '@/shared/hooks/useCurrentAppDestination';
 import {
@@ -50,6 +51,7 @@ export function SharedAppLayout() {
   const mobileFontScale = useUiPreferencesStore((s) => s.mobileFontScale);
   const setAppBarHovered = useUiPreferencesStore((s) => s.setAppBarHovered);
   const { isSignedIn } = useAuth();
+  const { appVersion } = useUserSystem();
   const { data: onlineCount } = useDiscordOnlineCount();
   const { data: starCount } = useGitHubStars();
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
@@ -311,6 +313,7 @@ export function SharedAppLayout() {
             }
             starCount={starCount}
             onlineCount={onlineCount}
+            appVersion={appVersion}
             githubIconPath={siGithub.path}
             discordIconPath={siDiscord.path}
           />

--- a/packages/web-core/src/shared/hooks/useUserSystem.ts
+++ b/packages/web-core/src/shared/hooks/useUserSystem.ts
@@ -9,6 +9,7 @@ import type {
 import type { ExecutorProfile } from 'shared/types';
 
 export interface UserSystemState {
+  appVersion: string | null;
   config: Config | null;
   environment: Environment | null;
   profiles: Record<string, ExecutorProfile> | null;
@@ -22,6 +23,7 @@ export interface UserSystemContextType {
   system: UserSystemState;
 
   // Hot path - config helpers (most frequently used)
+  appVersion: string | null;
   config: Config | null;
   updateConfig: (updates: Partial<Config>) => void;
   updateAndSaveConfig: (updates: Partial<Config>) => Promise<boolean>;

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -270,7 +270,7 @@ export type TagSearchParams = { search: string | null, };
 
 export type TokenResponse = { access_token: string, expires_at: string | null, };
 
-export type UserSystemInfo = { config: Config, analytics_user_id: string, login_status: LoginStatus, environment: Environment, 
+export type UserSystemInfo = { version: string, config: Config, analytics_user_id: string, login_status: LoginStatus, environment: Environment, 
 /**
  * Capabilities supported per executor (e.g., { "CLAUDE_CODE": ["SESSION_FORK"] })
  */


### PR DESCRIPTION
## What changed
- Added a `version` field to `UserSystemInfo` in the backend `/api/info` response.
- Set `version` from the running server package version (`env!("CARGO_PKG_VERSION")`).
- Regenerated shared TypeScript types so `UserSystemInfo` includes `version`.
- Extended user-system context/state to expose `appVersion` in both local and remote providers.
- Wired `appVersion` into `SharedAppLayout` and passed it to `AppBar`.
- Updated `AppBar` to render a muted bottom-footer indicator in the form `v{version}` when available.

## Why
This task requires showing the current app version at the bottom of the app bar, sourced from the info endpoint. Using `/api/info` ensures the displayed value reflects the runtime backend version rather than a hardcoded or build-only frontend value.

## Important implementation details
- The version is now part of the API contract (`UserSystemInfo`).
- The app bar indicator is conditional and hidden if a version is unavailable.
- UI changes are scoped to the shared app bar footer rendering path used by the local shell.
- Remote user-system provider was updated as well to keep shared context types aligned.

This PR was written using [Vibe Kanban](https://vibekanban.com)
