### PR TITLE
fix(ui): stabilize typeahead menu positioning when results load

### DIFF
--- a/packages/ui/src/components/TypeaheadMenu.tsx
+++ b/packages/ui/src/components/TypeaheadMenu.tsx
@@ -69,7 +69,8 @@ function placementsEqual(
 function computePlacement(
   anchorEl: HTMLElement,
   menuEl: HTMLElement,
-  editorEl?: HTMLElement | null
+  editorEl?: HTMLElement | null,
+  lockedSide?: VerticalSide | null
 ): TypeaheadPlacement {
   const anchorRect = anchorEl.getBoundingClientRect();
   const menuRect = menuEl.getBoundingClientRect();
@@ -97,8 +98,11 @@ function computePlacement(
     : cursorTopBoundary;
   const aboveSpace = topBoundary - marginBottom;
   const belowSpace = viewportHeight - anchorRect.bottom - marginTop;
-  const side: VerticalSide =
-    belowSpace >= measuredHeight || belowSpace >= aboveSpace ? 'bottom' : 'top';
+  const side: VerticalSide = lockedSide
+    ? lockedSide
+    : belowSpace >= measuredHeight || belowSpace >= aboveSpace
+      ? 'bottom'
+      : 'top';
   const availableSpace = Math.max(
     side === 'bottom' ? belowSpace : aboveSpace,
     0
@@ -152,12 +156,19 @@ function TypeaheadMenuRoot({
 }: TypeaheadMenuProps) {
   const menuRef = useRef<HTMLDivElement>(null);
   const [placement, setPlacement] = useState<TypeaheadPlacement | null>(null);
+  const lockedSideRef = useRef<VerticalSide | null>(null);
 
   const syncPlacement = useCallback(() => {
     const menuEl = menuRef.current;
     if (!menuEl) return;
 
-    const nextPlacement = computePlacement(anchorEl, menuEl, editorEl);
+    const nextPlacement = computePlacement(
+      anchorEl,
+      menuEl,
+      editorEl,
+      lockedSideRef.current
+    );
+    lockedSideRef.current = nextPlacement.side;
     setPlacement((previous) => {
       if (previous && placementsEqual(previous, nextPlacement)) {
         return previous;


### PR DESCRIPTION
## Summary
- Lock the vertical side (top/bottom) of the typeahead menu after the first placement computation
- Prevents the menu from flipping between above/below the cursor as async search results load and change the menu height
- Fixes the "file selector files move around too much" issue when using `@` to search files

Closes #122

## Test plan
- [ ] Open the chat input and type `@` followed by a file name query
- [ ] Verify the dropdown menu stays in a consistent position as results load
- [ ] Test with the cursor at different vertical positions in the editor to confirm no flipping

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change, but locking the side could leave the menu on a suboptimal side if available space changes significantly after the first measurement (e.g., scrolling/resizing).
> 
> **Overview**
> **Stabilizes typeahead dropdown placement** by locking the computed vertical side (`top`/`bottom`) after the first measurement.
> 
> `computePlacement` now accepts an optional `lockedSide`, and `TypeaheadMenuRoot` stores the initially chosen side in a ref and reuses it on subsequent recalculations, preventing the menu from flipping as its height changes (e.g., while async results load).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f25c3f063599f4d02e0d37b4bf5000a988c0c5d6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->