### PR TITLE
Improve create-and-start error visibility and safe client messaging (Vibe Kanban)

### DIFF
--- a/crates/server/src/error.rs
+++ b/crates/server/src/error.rs
@@ -379,17 +379,6 @@ fn deployment_error_message(err: &DeploymentError) -> Option<String> {
     }
 }
 
-fn client_message_for_error(error: &ApiError) -> Option<String> {
-    match error {
-        ApiError::Deployment(err) => deployment_error_message(err),
-        ApiError::Container(err) => container_error_message(err),
-        ApiError::Executor(err) => executor_error_message(err),
-        ApiError::Worktree(err) => worktree_error_message(err),
-        ApiError::GitService(err) => git_service_error_message(err),
-        _ => None,
-    }
-}
-
 impl IntoResponse for ApiError {
     fn into_response(self) -> Response {
         let info = match &self {
@@ -538,7 +527,7 @@ impl IntoResponse for ApiError {
                 ErrorInfo::with_status(StatusCode::GONE, "PtyError", "PTY session closed.")
             }
             ApiError::Pty(_) => ErrorInfo::internal("PtyError"),
-            ApiError::Deployment(_) => client_message_for_error(&self)
+            ApiError::Deployment(err) => deployment_error_message(err)
                 .map(|msg| {
                     ErrorInfo::with_status(
                         StatusCode::INTERNAL_SERVER_ERROR,
@@ -547,19 +536,19 @@ impl IntoResponse for ApiError {
                     )
                 })
                 .unwrap_or_else(|| ErrorInfo::internal("DeploymentError")),
-            ApiError::Container(_) => client_message_for_error(&self)
+            ApiError::Container(err) => container_error_message(err)
                 .map(|msg| {
                     ErrorInfo::with_status(StatusCode::INTERNAL_SERVER_ERROR, "ContainerError", msg)
                 })
                 .unwrap_or_else(|| ErrorInfo::internal("ContainerError")),
-            ApiError::Executor(_) => client_message_for_error(&self)
+            ApiError::Executor(err) => executor_error_message(err)
                 .map(|msg| {
                     ErrorInfo::with_status(StatusCode::INTERNAL_SERVER_ERROR, "ExecutorError", msg)
                 })
                 .unwrap_or_else(|| ErrorInfo::internal("ExecutorError")),
             ApiError::CommandBuilder(_) => ErrorInfo::internal("CommandBuildError"),
             ApiError::Database(_) => ErrorInfo::internal("DatabaseError"),
-            ApiError::Worktree(_) => client_message_for_error(&self)
+            ApiError::Worktree(err) => worktree_error_message(err)
                 .map(|msg| {
                     ErrorInfo::with_status(StatusCode::INTERNAL_SERVER_ERROR, "WorktreeError", msg)
                 })

--- a/crates/server/src/error.rs
+++ b/crates/server/src/error.rs
@@ -655,6 +655,46 @@ impl IntoResponse for ApiError {
     }
 }
 
+impl From<TrustedKeyAuthError> for ApiError {
+    fn from(err: TrustedKeyAuthError) -> Self {
+        match err {
+            TrustedKeyAuthError::Unauthorized => ApiError::Unauthorized,
+            TrustedKeyAuthError::BadRequest(msg) => ApiError::BadRequest(msg),
+            TrustedKeyAuthError::Forbidden(msg) => ApiError::Forbidden(msg),
+            TrustedKeyAuthError::TooManyRequests(msg) => ApiError::TooManyRequests(msg),
+            TrustedKeyAuthError::Io(e) => ApiError::Io(e),
+        }
+    }
+}
+
+impl From<RepoServiceError> for ApiError {
+    fn from(err: RepoServiceError) -> Self {
+        match err {
+            RepoServiceError::Database(db_err) => ApiError::Database(db_err),
+            RepoServiceError::Io(io_err) => ApiError::Io(io_err),
+            RepoServiceError::PathNotFound(path) => {
+                ApiError::BadRequest(format!("Path does not exist: {}", path.display()))
+            }
+            RepoServiceError::PathNotDirectory(path) => {
+                ApiError::BadRequest(format!("Path is not a directory: {}", path.display()))
+            }
+            RepoServiceError::NotGitRepository(path) => {
+                ApiError::BadRequest(format!("Path is not a git repository: {}", path.display()))
+            }
+            RepoServiceError::NotFound => ApiError::BadRequest("Repository not found".to_string()),
+            RepoServiceError::DirectoryAlreadyExists(path) => {
+                ApiError::BadRequest(format!("Directory already exists: {}", path.display()))
+            }
+            RepoServiceError::Git(git_err) => {
+                ApiError::BadRequest(format!("Git error: {}", git_err))
+            }
+            RepoServiceError::InvalidFolderName(name) => {
+                ApiError::BadRequest(format!("Invalid folder name: {}", name))
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use axum::{body::to_bytes, http::StatusCode, response::IntoResponse};
@@ -696,45 +736,5 @@ mod tests {
             json.get("message").and_then(Value::as_str),
             Some("An internal error occurred. Please try again.")
         );
-    }
-}
-
-impl From<TrustedKeyAuthError> for ApiError {
-    fn from(err: TrustedKeyAuthError) -> Self {
-        match err {
-            TrustedKeyAuthError::Unauthorized => ApiError::Unauthorized,
-            TrustedKeyAuthError::BadRequest(msg) => ApiError::BadRequest(msg),
-            TrustedKeyAuthError::Forbidden(msg) => ApiError::Forbidden(msg),
-            TrustedKeyAuthError::TooManyRequests(msg) => ApiError::TooManyRequests(msg),
-            TrustedKeyAuthError::Io(e) => ApiError::Io(e),
-        }
-    }
-}
-
-impl From<RepoServiceError> for ApiError {
-    fn from(err: RepoServiceError) -> Self {
-        match err {
-            RepoServiceError::Database(db_err) => ApiError::Database(db_err),
-            RepoServiceError::Io(io_err) => ApiError::Io(io_err),
-            RepoServiceError::PathNotFound(path) => {
-                ApiError::BadRequest(format!("Path does not exist: {}", path.display()))
-            }
-            RepoServiceError::PathNotDirectory(path) => {
-                ApiError::BadRequest(format!("Path is not a directory: {}", path.display()))
-            }
-            RepoServiceError::NotGitRepository(path) => {
-                ApiError::BadRequest(format!("Path is not a git repository: {}", path.display()))
-            }
-            RepoServiceError::NotFound => ApiError::BadRequest("Repository not found".to_string()),
-            RepoServiceError::DirectoryAlreadyExists(path) => {
-                ApiError::BadRequest(format!("Directory already exists: {}", path.display()))
-            }
-            RepoServiceError::Git(git_err) => {
-                ApiError::BadRequest(format!("Git error: {}", git_err))
-            }
-            RepoServiceError::InvalidFolderName(name) => {
-                ApiError::BadRequest(format!("Invalid folder name: {}", name))
-            }
-        }
     }
 }

--- a/crates/server/src/error.rs
+++ b/crates/server/src/error.rs
@@ -23,6 +23,7 @@ use services::services::{
     repo::RepoError as RepoServiceError,
 };
 use thiserror::Error;
+use tracing::{error, warn};
 use trusted_key_auth::error::TrustedKeyAuthError;
 use utils::response::ApiResponse;
 use workspace_manager::WorkspaceError as WorkspaceManagerError;
@@ -274,6 +275,121 @@ fn remote_client_error(err: &RemoteClientError) -> ErrorInfo {
     }
 }
 
+fn executor_error_message(err: &ExecutorError) -> Option<String> {
+    match err {
+        ExecutorError::FollowUpNotSupported(_)
+        | ExecutorError::UnknownExecutorType(_)
+        | ExecutorError::ExecutableNotFound { .. }
+        | ExecutorError::SetupHelperNotSupported
+        | ExecutorError::AuthRequired(_) => Some(err.to_string()),
+        ExecutorError::SpawnError(_)
+        | ExecutorError::Io(_)
+        | ExecutorError::Json(_)
+        | ExecutorError::TomlSerialize(_)
+        | ExecutorError::TomlDeserialize(_)
+        | ExecutorError::ExecutorApprovalError(_)
+        | ExecutorError::CommandBuild(_) => None,
+    }
+}
+
+fn git_service_error_message(err: &GitServiceError) -> Option<String> {
+    match err {
+        GitServiceError::GitCLI(git::GitCliError::NotAvailable)
+        | GitServiceError::GitCLI(git::GitCliError::AuthFailed(_))
+        | GitServiceError::GitCLI(git::GitCliError::PushRejected(_))
+        | GitServiceError::GitCLI(git::GitCliError::RebaseInProgress)
+        | GitServiceError::InvalidRepository(_)
+        | GitServiceError::BranchNotFound(_)
+        | GitServiceError::MergeConflicts { .. }
+        | GitServiceError::BranchesDiverged(_)
+        | GitServiceError::WorktreeDirty(_, _)
+        | GitServiceError::RebaseInProgress => Some(err.to_string()),
+        GitServiceError::Git(_)
+        | GitServiceError::GitCLI(git::GitCliError::CommandFailed(_))
+        | GitServiceError::IoError(_) => None,
+    }
+}
+
+fn worktree_error_message(err: &WorktreeError) -> Option<String> {
+    match err {
+        WorktreeError::GitService(err) => git_service_error_message(err),
+        WorktreeError::GitCli(_)
+        | WorktreeError::InvalidPath(_)
+        | WorktreeError::BranchNotFound(_)
+        | WorktreeError::Repository(_) => Some(err.to_string()),
+        WorktreeError::Git(_) | WorktreeError::TaskJoin(_) | WorktreeError::Io(_) => None,
+    }
+}
+
+fn container_error_message(err: &ContainerError) -> Option<String> {
+    match err {
+        ContainerError::GitServiceError(err) => git_service_error_message(err),
+        ContainerError::ExecutorError(err) => executor_error_message(err),
+        ContainerError::Worktree(err) => worktree_error_message(err),
+        ContainerError::Workspace(WorkspaceError::ValidationError(msg)) => Some(msg.clone()),
+        ContainerError::Workspace(WorkspaceError::BranchNotFound(branch)) => {
+            Some(format!("Branch '{}' not found.", branch))
+        }
+        ContainerError::Session(SessionError::ExecutorMismatch { expected, actual }) => {
+            Some(format!(
+                "Executor mismatch: session uses {} but request specified {}.",
+                expected, actual
+            ))
+        }
+        ContainerError::Session(SessionError::NotFound) => Some("Session not found.".to_string()),
+        ContainerError::Session(SessionError::WorkspaceNotFound) => {
+            Some("Workspace not found.".to_string())
+        }
+        ContainerError::ExecutionProcess(ExecutionProcessError::ExecutionProcessNotFound) => {
+            Some("Execution process not found.".to_string())
+        }
+        ContainerError::ExecutionProcess(_) => None,
+        ContainerError::Sqlx(_)
+        | ContainerError::Workspace(WorkspaceError::Database(_))
+        | ContainerError::Workspace(WorkspaceError::WorkspaceNotFound)
+        | ContainerError::Session(SessionError::Database(_))
+        | ContainerError::Io(_)
+        | ContainerError::KillFailed(_)
+        | ContainerError::Other(_) => None,
+    }
+}
+
+fn deployment_error_message(err: &DeploymentError) -> Option<String> {
+    match err {
+        DeploymentError::RemoteClientNotConfigured => Some("Remote client not configured".into()),
+        DeploymentError::Container(err) => container_error_message(err),
+        DeploymentError::Executor(err) => executor_error_message(err),
+        DeploymentError::Worktree(err) => worktree_error_message(err),
+        DeploymentError::GitServiceError(err) => git_service_error_message(err),
+        DeploymentError::Workspace(WorkspaceError::ValidationError(msg)) => Some(msg.clone()),
+        DeploymentError::Workspace(WorkspaceError::BranchNotFound(branch)) => {
+            Some(format!("Branch '{}' not found.", branch))
+        }
+        DeploymentError::Sqlx(_)
+        | DeploymentError::Io(_)
+        | DeploymentError::Git2(_)
+        | DeploymentError::FilesystemWatcherError(_)
+        | DeploymentError::Workspace(WorkspaceError::Database(_))
+        | DeploymentError::Workspace(WorkspaceError::WorkspaceNotFound)
+        | DeploymentError::Image(_)
+        | DeploymentError::Filesystem(_)
+        | DeploymentError::Event(_)
+        | DeploymentError::Config(_)
+        | DeploymentError::Other(_) => None,
+    }
+}
+
+fn client_message_for_error(error: &ApiError) -> Option<String> {
+    match error {
+        ApiError::Deployment(err) => deployment_error_message(err),
+        ApiError::Container(err) => container_error_message(err),
+        ApiError::Executor(err) => executor_error_message(err),
+        ApiError::Worktree(err) => worktree_error_message(err),
+        ApiError::GitService(err) => git_service_error_message(err),
+        _ => None,
+    }
+}
+
 impl IntoResponse for ApiError {
     fn into_response(self) -> Response {
         let info = match &self {
@@ -422,33 +538,32 @@ impl IntoResponse for ApiError {
                 ErrorInfo::with_status(StatusCode::GONE, "PtyError", "PTY session closed.")
             }
             ApiError::Pty(_) => ErrorInfo::internal("PtyError"),
-
-            ApiError::Unauthorized => ErrorInfo::with_status(
-                StatusCode::UNAUTHORIZED,
-                "Unauthorized",
-                "Unauthorized. Please sign in again.",
-            ),
-            ApiError::BadRequest(msg) => ErrorInfo::bad_request("BadRequest", msg.clone()),
-            ApiError::Conflict(msg) => ErrorInfo::conflict("ConflictError", msg.clone()),
-            ApiError::Forbidden(msg) => {
-                ErrorInfo::with_status(StatusCode::FORBIDDEN, "ForbiddenError", msg.clone())
-            }
-            ApiError::TooManyRequests(msg) => ErrorInfo::with_status(
-                StatusCode::TOO_MANY_REQUESTS,
-                "TooManyRequests",
-                msg.clone(),
-            ),
-            ApiError::Multipart(_) => ErrorInfo::bad_request(
-                "MultipartError",
-                "Failed to upload file. Please ensure the file is valid and try again.",
-            ),
-
-            ApiError::Deployment(_) => ErrorInfo::internal("DeploymentError"),
-            ApiError::Container(_) => ErrorInfo::internal("ContainerError"),
-            ApiError::Executor(_) => ErrorInfo::internal("ExecutorError"),
+            ApiError::Deployment(_) => client_message_for_error(&self)
+                .map(|msg| {
+                    ErrorInfo::with_status(
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        "DeploymentError",
+                        msg,
+                    )
+                })
+                .unwrap_or_else(|| ErrorInfo::internal("DeploymentError")),
+            ApiError::Container(_) => client_message_for_error(&self)
+                .map(|msg| {
+                    ErrorInfo::with_status(StatusCode::INTERNAL_SERVER_ERROR, "ContainerError", msg)
+                })
+                .unwrap_or_else(|| ErrorInfo::internal("ContainerError")),
+            ApiError::Executor(_) => client_message_for_error(&self)
+                .map(|msg| {
+                    ErrorInfo::with_status(StatusCode::INTERNAL_SERVER_ERROR, "ExecutorError", msg)
+                })
+                .unwrap_or_else(|| ErrorInfo::internal("ExecutorError")),
             ApiError::CommandBuilder(_) => ErrorInfo::internal("CommandBuildError"),
             ApiError::Database(_) => ErrorInfo::internal("DatabaseError"),
-            ApiError::Worktree(_) => ErrorInfo::internal("WorktreeError"),
+            ApiError::Worktree(_) => client_message_for_error(&self)
+                .map(|msg| {
+                    ErrorInfo::with_status(StatusCode::INTERNAL_SERVER_ERROR, "WorktreeError", msg)
+                })
+                .unwrap_or_else(|| ErrorInfo::internal("WorktreeError")),
             ApiError::Config(_) => ErrorInfo::internal("ConfigError"),
             ApiError::Io(_) => ErrorInfo::internal("IoError"),
             ApiError::Migration(MigrationError::Database(_)) => {
@@ -492,13 +607,95 @@ impl IntoResponse for ApiError {
                 "MigrationError",
                 format!("Remote error: {}", msg),
             ),
+            ApiError::Unauthorized => ErrorInfo::with_status(
+                StatusCode::UNAUTHORIZED,
+                "Unauthorized",
+                "Unauthorized. Please sign in again.",
+            ),
+            ApiError::BadRequest(msg) => ErrorInfo::bad_request("BadRequest", msg.clone()),
+            ApiError::Conflict(msg) => ErrorInfo::conflict("ConflictError", msg.clone()),
+            ApiError::Forbidden(msg) => {
+                ErrorInfo::with_status(StatusCode::FORBIDDEN, "ForbiddenError", msg.clone())
+            }
+            ApiError::TooManyRequests(msg) => ErrorInfo::with_status(
+                StatusCode::TOO_MANY_REQUESTS,
+                "TooManyRequests",
+                msg.clone(),
+            ),
+            ApiError::Multipart(_) => ErrorInfo::bad_request(
+                "MultipartError",
+                "Failed to upload file. Please ensure the file is valid and try again.",
+            ),
         };
+
+        let log_message = format!("{}", self);
+        if info.status.is_server_error() {
+            error!(
+                status = %info.status,
+                error_type = info.error_type,
+                public_message = info.message.as_deref().unwrap_or(""),
+                internal_message = %log_message,
+                "API request failed"
+            );
+        } else {
+            warn!(
+                status = %info.status,
+                error_type = info.error_type,
+                public_message = info.message.as_deref().unwrap_or(""),
+                internal_message = %log_message,
+                "API request failed"
+            );
+        }
 
         let message = info
             .message
             .unwrap_or_else(|| format!("{}: {}", info.error_type, self));
         let response = ApiResponse::<()>::error(&message);
         (info.status, Json(response)).into_response()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{body::to_bytes, http::StatusCode, response::IntoResponse};
+    use deployment::DeploymentError;
+    use executors::executors::ExecutorError;
+    use serde_json::Value;
+
+    use super::ApiError;
+
+    #[tokio::test]
+    async fn executor_errors_return_safe_messages() {
+        let response = ApiError::Executor(ExecutorError::ExecutableNotFound {
+            program: "codex".to_string(),
+        })
+        .into_response();
+
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let json: Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(
+            json.get("message").and_then(Value::as_str),
+            Some("Executable `codex` not found in PATH")
+        );
+    }
+
+    #[tokio::test]
+    async fn opaque_internal_errors_stay_generic() {
+        let response = ApiError::Deployment(DeploymentError::Other(anyhow::anyhow!(
+            "sensitive failure details"
+        )))
+        .into_response();
+
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let json: Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(
+            json.get("message").and_then(Value::as_str),
+            Some("An internal error occurred. Please try again.")
+        );
     }
 }
 

--- a/crates/server/src/routes/task_attempts.rs
+++ b/crates/server/src/routes/task_attempts.rs
@@ -1953,6 +1953,15 @@ pub async fn create_and_start_workspace(
 
     let workspace_id = Uuid::new_v4();
     let branch_label = name.as_deref().unwrap_or("workspace");
+    tracing::info!(
+        workspace_id = %workspace_id,
+        executor = %executor_config.executor,
+        variant = executor_config.variant.as_deref().unwrap_or("DEFAULT"),
+        repo_count = repos.len(),
+        has_linked_issue = linked_issue.is_some(),
+        image_count = image_ids.as_ref().map_or(0, Vec::len),
+        "Starting create_and_start workspace request"
+    );
     let git_branch_name = deployment
         .container()
         .git_branch_from_workspace(&workspace_id, branch_label)
@@ -2011,12 +2020,22 @@ pub async fn create_and_start_workspace(
     }
 
     let workspace = managed_workspace.workspace.clone();
-    tracing::info!("Created workspace {}", workspace.id);
+    tracing::info!(workspace_id = %workspace.id, branch = %workspace.branch, "Created workspace");
 
     let execution_process = deployment
         .container()
         .start_workspace(&workspace, executor_config.clone(), workspace_prompt)
-        .await?;
+        .await
+        .map_err(|err| {
+            tracing::error!(
+                workspace_id = %workspace.id,
+                executor = %executor_config.executor,
+                variant = executor_config.variant.as_deref().unwrap_or("DEFAULT"),
+                error = %err,
+                "Failed to start workspace after creation"
+            );
+            ApiError::from(err)
+        })?;
 
     deployment
         .track_if_analytics_allowed(
@@ -2028,6 +2047,12 @@ pub async fn create_and_start_workspace(
             }),
         )
         .await;
+
+    tracing::info!(
+        workspace_id = %workspace.id,
+        execution_process_id = %execution_process.id,
+        "Workspace create_and_start completed"
+    );
 
     Ok(ResponseJson(ApiResponse::success(
         CreateAndStartWorkspaceResponse {


### PR DESCRIPTION
## Summary
This PR improves failure visibility for workspace `create_and_start` so backend errors are no longer effectively silent and users get better guidance than a generic internal error in known-safe cases.

## What Changed
- Added centralized API error logging in `ApiError::into_response` (`crates/server/src/error.rs`).
- Introduced safe client-message extraction helpers for selected internal error families:
  - `DeploymentError`
  - `ContainerError`
  - `ExecutorError`
  - `WorktreeError`
  - `GitServiceError`
- Updated response mapping so known, user-safe startup failures can surface their message, while opaque/internal failures continue to return the generic internal error text.
- Added unit tests for the error behavior:
  - Known safe executor errors return specific messages.
  - Opaque internal errors remain generic.
- Added stage-level observability in `create_and_start_workspace` (`crates/server/src/routes/task_attempts.rs`):
  - Request start context logging (workspace/executor/repo metadata).
  - Structured logging when workspace startup fails after workspace creation.
  - Completion logging with workspace and execution process IDs.

## Why These Changes Were Made
The task context reported that `create_and_start` failures were being swallowed: no useful terminal logs and only `"An internal error occurred. Please try again."` in the browser. This made troubleshooting difficult and slowed down diagnosis.

These changes improve both debugging and user feedback:
- Terminal logs now consistently record the underlying failure at the API boundary.
- The browser can show clearer messages for known-safe failure modes.
- Truly internal/unsafe error details remain hidden behind generic messaging to avoid leaking internals.

## Important Implementation Details
- Logging severity is status-aware:
  - `error!` for server-side failures.
  - `warn!` for non-5xx/API-client errors.
- Safe-message extraction is explicit and selective; it does not blindly forward all internal error strings.
- Existing route and API contracts were preserved (no schema changes).

This PR was written using [Vibe Kanban](https://vibekanban.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches global `ApiError::into_response` behavior by adding structured logging and selectively surfacing internal error messages, which can affect all API responses and risks accidental information leakage if the allowlist is incomplete.
> 
> **Overview**
> Improves API error handling by adding centralized, status-aware structured logging at the `ApiError::into_response` boundary, and by selectively exposing *allowlisted* “safe” messages for certain `DeploymentError`/`ContainerError`/`ExecutorError`/`WorktreeError`/`GitServiceError` variants while keeping other internal failures generic.
> 
> Adds more observability to `create_and_start_workspace` with structured start/created/completed logs and explicit error logging when `start_workspace` fails post-creation, plus unit tests asserting safe-message passthrough vs. generic internal-error messaging.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 220c903ca25dacfb22d2d57a0d899583c4b0e15f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->