### PR TITLE
fix: prevent zombie processes by using direct PID-level waitpid

### DIFF
--- a/crates/local-deployment/src/container.rs
+++ b/crates/local-deployment/src/container.rs
@@ -753,7 +753,11 @@ impl LocalContainerService {
                 let _ = tokio::time::timeout(Duration::from_secs(5), handle).await;
             }
 
-            // Cleanup child handle
+            // Reap zombie before dropping the child handle
+            if let Some(child_lock) = child_store.read().await.get(&exec_id).cloned() {
+                let mut child = child_lock.write().await;
+                let _ = child.inner().try_wait();
+            }
             child_store.write().await.remove(&exec_id);
         })
     }
@@ -772,7 +776,7 @@ impl LocalContainerService {
                 };
                 if let Some(child_lock) = child_lock {
                     let mut child_handler = child_lock.write().await;
-                    match child_handler.try_wait() {
+                    match child_handler.inner().try_wait() {
                         Ok(Some(status)) => {
                             let _ = tx.send(Ok(status));
                             break;


### PR DESCRIPTION
## Summary

- Fixes zombie (defunct) processes left behind when child processes exit
- Calls `child.inner().try_wait()` to reap zombies before dropping the child handle
- Fixes the status-check loop to also use `.inner().try_wait()` for direct PID-level waitpid

## Test plan

- [ ] Verify that spawned child processes no longer leave zombie/defunct entries after exit
- [ ] Confirm normal process lifecycle (spawn, run, exit, cleanup) still works correctly
- [ ] Run `cargo test --workspace` to ensure no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches process lifecycle/exit detection and cleanup, which can subtly affect termination behavior and exit status reporting despite the small diff.
> 
> **Overview**
> Prevents defunct (zombie) child processes in local deployments by explicitly calling `child.inner().try_wait()` to reap the OS process before removing the child handle from `child_store`.
> 
> Updates the OS exit watcher loop to also use `inner().try_wait()` for status polling, ensuring exit detection goes through the underlying PID-level wait.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1b912d59b4444c8f276ca6727252a56e6a211c79. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->