### PR TITLE
fix(preview): extract port from hostname prefix for proxies like Coder

### DIFF
--- a/packages/web-core/src/pages/workspaces/PreviewBrowserContainer.tsx
+++ b/packages/web-core/src/pages/workspaces/PreviewBrowserContainer.tsx
@@ -743,8 +743,17 @@ export function PreviewBrowserContainer({
     if (!parsed) return undefined;
 
     try {
+      // Some reverse proxies embed the target port as a numeric prefix in the
+      // hostname (e.g. Coder: "8080--workspace--user.coder.example.com").
+      // In that case parsed.port is empty (protocol default), so we extract
+      // the port from the hostname prefix before falling back to 443/80.
+      const hostnamePortMatch = !parsed.port
+        ? /^(\d+)--/.exec(parsed.hostname)
+        : null;
       const devServerPort =
-        parsed.port || (parsed.protocol === 'https:' ? '443' : '80');
+        parsed.port ||
+        hostnamePortMatch?.[1] ||
+        (parsed.protocol === 'https:' ? '443' : '80');
 
       // Don't proxy to Vibe Kanban's own ports (would create infinite loop)
       const vibeKanbanPort = window.location.port || '80';


### PR DESCRIPTION
## Problem

When using VK inside a [Coder](https://coder.com) workspace, the external proxy URL format is:

```
https://<port>--<workspace>--<user>.coder.example.com
```

The port is embedded as a **numeric prefix in the hostname**, not as an explicit port number. So for a dev server on port 8080 the user's URL is:

```
https://8080--main--myproject--user.coder.example.com
```

When the user pastes this URL into VK's preview bar, `parsed.port` is empty (HTTPS default). The `iframeUrl` builder was falling back to `'443'`, producing:

```
http://443.localhost:<proxyPort>/?_refresh=0
```

…which routes to the wrong service instead of the dev server.

## Fix

Before falling back to the protocol default, check whether the hostname starts with a numeric prefix followed by `--` (the Coder proxy convention) and use that as `devServerPort`:

```ts
const hostnamePortMatch = !parsed.port
  ? /^(\d+)--/.exec(parsed.hostname)
  : null;
const devServerPort =
  parsed.port ||
  hostnamePortMatch?.[1] ||
  (parsed.protocol === 'https:' ? '443' : '80');
```

For `https://8080--main--myproject--user.coder.example.com`:
- `parsed.port` → `""` (empty)  
- `hostnamePortMatch[1]` → `"8080"` ✓
- `iframeUrl` → `http://8080.localhost:<proxyPort>/` ✓ — correctly proxied to the dev server

The regex only matches when `parsed.port` is already empty, so it has no effect on URLs with explicit ports.

## Testing

Reproduce with a Coder workspace (or any reverse proxy that embeds the port in a hostname prefix):
1. Start a dev server on port 8080
2. Paste `https://8080--<your-coder-url>` into VK's preview URL bar  
3. **Before:** iframe loads `http://443.localhost:<proxyPort>` (wrong)  
4. **After:** iframe loads `http://8080.localhost:<proxyPort>` → correctly forwarded to dev server ✓

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized change to preview iframe URL construction that only affects URLs without an explicit port and with a numeric `--` hostname prefix; main risk is mis-routing if an unexpected hostname matches the pattern.
> 
> **Overview**
> Fixes preview iframe proxy URL generation to correctly route to dev servers when the input URL omits an explicit port but embeds it as a numeric hostname prefix (e.g. `8080--...` in Coder workspaces).
> 
> `PreviewBrowserContainer` now extracts that prefix as the dev server port before falling back to protocol defaults (80/443), preventing the iframe from incorrectly proxying to 443 in these environments.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0a1f48cbb09e6f87b1137a047d5d51af36450d0f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->