### PR TITLE
feat(npx-cli): add HTTP/HTTPS proxy support via environment variables

### DIFF
--- a/npx-cli/bin/download.js
+++ b/npx-cli/bin/download.js
@@ -2,6 +2,7 @@ const https = require("https");
 const fs = require("fs");
 const path = require("path");
 const crypto = require("crypto");
+const { HttpsProxyAgent } = require("https-proxy-agent");
 
 // Replaced during npm pack by workflow
 const R2_BASE_URL = "__R2_PUBLIC_URL__";
@@ -13,9 +14,36 @@ const CACHE_DIR = path.join(require("os").homedir(), ".vibe-kanban", "bin");
 const LOCAL_DIST_DIR = path.join(__dirname, "..", "dist");
 const LOCAL_DEV_MODE = fs.existsSync(LOCAL_DIST_DIR) || process.env.VIBE_KANBAN_LOCAL === "1";
 
+/**
+ * Returns an HttpsProxyAgent if a proxy is configured for the given URL,
+ * respecting HTTPS_PROXY / HTTP_PROXY and NO_PROXY (all case-insensitive).
+ */
+function getProxyAgent(urlString) {
+  const proxyUrl =
+    process.env.HTTPS_PROXY ||
+    process.env.https_proxy ||
+    process.env.HTTP_PROXY ||
+    process.env.http_proxy;
+
+  if (!proxyUrl) return undefined;
+
+  const noProxy = process.env.NO_PROXY || process.env.no_proxy;
+  if (noProxy) {
+    const hostname = new URL(urlString).hostname;
+    const entries = noProxy.split(",").map((s) => s.trim()).filter(Boolean);
+    for (const entry of entries) {
+      if (entry === "*") return undefined;
+      if (hostname === entry || hostname.endsWith("." + entry)) return undefined;
+    }
+  }
+
+  return new HttpsProxyAgent(proxyUrl);
+}
+
 async function fetchJson(url) {
   return new Promise((resolve, reject) => {
-    https.get(url, (res) => {
+    const agent = getProxyAgent(url);
+    https.get(url, agent ? { agent } : {}, (res) => {
       if (res.statusCode === 301 || res.statusCode === 302) {
         return fetchJson(res.headers.location).then(resolve).catch(reject);
       }
@@ -47,7 +75,8 @@ async function downloadFile(url, destPath, expectedSha256, onProgress) {
       } catch {}
     };
 
-    https.get(url, (res) => {
+    const agent = getProxyAgent(url);
+    https.get(url, agent ? { agent } : {}, (res) => {
       if (res.statusCode === 301 || res.statusCode === 302) {
         file.close();
         cleanup();

--- a/npx-cli/package.json
+++ b/npx-cli/package.json
@@ -15,7 +15,8 @@
   "license": "",
   "description": "NPX wrapper around vibe-kanban and vibe-kanban-mcp",
   "dependencies": {
-    "adm-zip": "^0.5.16"
+    "adm-zip": "^0.5.16",
+    "https-proxy-agent": "^7.0.6"
   },
   "files": [
     "bin",


### PR DESCRIPTION
This pull request makes a small change to the project dependencies by adding a new package. The `https-proxy-agent` library has been added to the `dependencies` section of `npx-cli/package.json` to support HTTP(S) proxy functionality.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to the npx CLI download path and only alter networking behavior when proxy env vars are set. Main risk is misconfigured `NO_PROXY`/proxy settings affecting binary fetches or redirects.
> 
> **Overview**
> Adds opt-in proxy support for `npx-cli` binary fetching by routing `https.get` calls through `https-proxy-agent` when `HTTPS_PROXY`/`HTTP_PROXY` are set, while honoring `NO_PROXY`.
> 
> Updates `download.js` to apply the proxy agent for both manifest JSON fetches and binary zip downloads (including redirect handling), and adds `https-proxy-agent` as a runtime dependency.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e0d6d8211bb3efa3d3fade7b894cef014be4eb74. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->