### PR TITLE
feat: add gpt-5.4 to copilot

### DIFF
--- a/crates/executors/src/executors/copilot.rs
+++ b/crates/executors/src/executors/copilot.rs
@@ -197,6 +197,7 @@ impl StandardCodingAgentExecutor for Copilot {
         let options = ExecutorDiscoveredOptions {
             model_selector: ModelSelectorConfig {
                 models: [
+                    ("gpt-5.4", "GPT-5.4"),
                     ("claude-opus-4.6", "Claude Opus 4.6"),
                     ("claude-opus-4.6-fast", "Claude Opus 4.6 Fast"),
                     ("gpt-5.3-codex", "GPT-5.3 Codex"),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only extends the Copilot model list used for discovered options, with no changes to execution flow or permissions.
> 
> **Overview**
> Copilot executor option discovery now includes **`gpt-5.4`** in the `model_selector` model list, making it available for selection/configuration alongside existing models.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7c0d893f02fe69ff8030865de387cae170fbf8ca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->