### PR TITLE
feat(editor): add dedicated Code Server support

### DIFF
--- a/crates/server/src/routes/config.rs
+++ b/crates/server/src/routes/config.rs
@@ -486,16 +486,21 @@ pub struct CheckEditorAvailabilityResponse {
 }
 
 async fn check_editor_availability(
-    State(_deployment): State<DeploymentImpl>,
+    State(deployment): State<DeploymentImpl>,
     Query(query): Query<CheckEditorAvailabilityQuery>,
 ) -> ResponseJson<ApiResponse<CheckEditorAvailabilityResponse>> {
+    let config = deployment.config().read().await;
+    let custom_command = (config.editor.editor_type == query.editor_type)
+        .then(|| config.editor.custom_command.clone())
+        .flatten();
+
     // Construct a minimal EditorConfig for checking
     let editor_config = EditorConfig::new(
         query.editor_type,
-        None,  // custom_command
-        None,  // remote_ssh_host
-        None,  // remote_ssh_user
-        false, // auto_install_extension
+        custom_command, // custom_command
+        None,           // remote_ssh_host
+        None,           // remote_ssh_user
+        false,          // auto_install_extension
     );
 
     let available = editor_config.check_availability().await;

--- a/crates/server/src/routes/config.rs
+++ b/crates/server/src/routes/config.rs
@@ -489,10 +489,10 @@ async fn check_editor_availability(
     State(deployment): State<DeploymentImpl>,
     Query(query): Query<CheckEditorAvailabilityQuery>,
 ) -> ResponseJson<ApiResponse<CheckEditorAvailabilityResponse>> {
-    let config = deployment.config().read().await;
-    let editor_config = config
-        .editor
-        .with_override(Some(query.editor_type.as_str()));
+    let editor_config = {
+        let config = deployment.config().read().await;
+        config.editor.with_override(Some(query.editor_type.as_ref()))
+    };
 
     let available = editor_config.check_availability().await;
     ResponseJson(ApiResponse::success(CheckEditorAvailabilityResponse {

--- a/crates/server/src/routes/config.rs
+++ b/crates/server/src/routes/config.rs
@@ -22,7 +22,7 @@ use serde_json::Value;
 use services::services::{
     config::{
         Config, ConfigError, SoundFile,
-        editor::{EditorConfig, EditorType},
+        editor::EditorType,
         save_config_to_file,
     },
     container::ContainerService,
@@ -490,18 +490,9 @@ async fn check_editor_availability(
     Query(query): Query<CheckEditorAvailabilityQuery>,
 ) -> ResponseJson<ApiResponse<CheckEditorAvailabilityResponse>> {
     let config = deployment.config().read().await;
-    let custom_command = (config.editor.editor_type == query.editor_type)
-        .then(|| config.editor.custom_command.clone())
-        .flatten();
-
-    // Construct a minimal EditorConfig for checking
-    let editor_config = EditorConfig::new(
-        query.editor_type,
-        custom_command, // custom_command
-        None,           // remote_ssh_host
-        None,           // remote_ssh_user
-        false,          // auto_install_extension
-    );
+    let editor_config = config
+        .editor
+        .with_override(Some(query.editor_type.as_str()));
 
     let available = editor_config.check_availability().await;
     ResponseJson(ApiResponse::success(CheckEditorAvailabilityResponse {

--- a/crates/services/src/services/config/editor/mod.rs
+++ b/crates/services/src/services/config/editor/mod.rs
@@ -2,7 +2,7 @@ use std::{path::Path, str::FromStr};
 
 use executors::{command::CommandBuilder, executors::ExecutorError};
 use serde::{Deserialize, Serialize};
-use strum_macros::{EnumIter, EnumString};
+use strum_macros::{AsRefStr, EnumIter, EnumString};
 use thiserror::Error;
 use ts_rs::TS;
 use url::Url;
@@ -45,7 +45,7 @@ pub struct EditorConfig {
     auto_install_extension: bool,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, TS, EnumString, EnumIter)]
+#[derive(Debug, Clone, Serialize, Deserialize, TS, EnumString, EnumIter, AsRefStr)]
 #[ts(use_ts_enum)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 #[strum(serialize_all = "SCREAMING_SNAKE_CASE")]
@@ -60,23 +60,6 @@ pub enum EditorType {
     GoogleAntigravity,
     CodeServer,
     Custom,
-}
-
-impl EditorType {
-    pub fn as_str(&self) -> &'static str {
-        match self {
-            EditorType::VsCode => "VS_CODE",
-            EditorType::VsCodeInsiders => "VS_CODE_INSIDERS",
-            EditorType::Cursor => "CURSOR",
-            EditorType::Windsurf => "WINDSURF",
-            EditorType::IntelliJ => "INTELLI_J",
-            EditorType::Zed => "ZED",
-            EditorType::Xcode => "XCODE",
-            EditorType::GoogleAntigravity => "GOOGLE_ANTIGRAVITY",
-            EditorType::CodeServer => "CODE_SERVER",
-            EditorType::Custom => "CUSTOM",
-        }
-    }
 }
 
 impl Default for EditorConfig {

--- a/crates/services/src/services/config/editor/mod.rs
+++ b/crates/services/src/services/config/editor/mod.rs
@@ -62,6 +62,23 @@ pub enum EditorType {
     Custom,
 }
 
+impl EditorType {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            EditorType::VsCode => "VS_CODE",
+            EditorType::VsCodeInsiders => "VS_CODE_INSIDERS",
+            EditorType::Cursor => "CURSOR",
+            EditorType::Windsurf => "WINDSURF",
+            EditorType::IntelliJ => "INTELLI_J",
+            EditorType::Zed => "ZED",
+            EditorType::Xcode => "XCODE",
+            EditorType::GoogleAntigravity => "GOOGLE_ANTIGRAVITY",
+            EditorType::CodeServer => "CODE_SERVER",
+            EditorType::Custom => "CUSTOM",
+        }
+    }
+}
+
 impl Default for EditorConfig {
     fn default() -> Self {
         Self {

--- a/crates/services/src/services/config/editor/mod.rs
+++ b/crates/services/src/services/config/editor/mod.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 use strum_macros::{EnumIter, EnumString};
 use thiserror::Error;
 use ts_rs::TS;
+use url::Url;
 
 fn default_auto_install_extension() -> bool {
     true
@@ -57,6 +58,7 @@ pub enum EditorType {
     Zed,
     Xcode,
     GoogleAntigravity,
+    CodeServer,
     Custom,
 }
 
@@ -100,6 +102,7 @@ impl EditorConfig {
             EditorType::Zed => "zed",
             EditorType::Xcode => "xed",
             EditorType::GoogleAntigravity => "antigravity",
+            EditorType::CodeServer => "code-server",
             EditorType::Custom => {
                 // Custom editor - use user-provided command or fallback to VSCode
                 self.custom_command.as_deref().unwrap_or("code")
@@ -137,6 +140,9 @@ impl EditorConfig {
     /// Check if the editor is available on the system.
     /// Uses the same command resolution logic as spawn_local().
     pub async fn check_availability(&self) -> bool {
+        if matches!(self.editor_type, EditorType::CodeServer) {
+            return self.code_server_url_base().is_ok();
+        }
         self.resolve_command().await.is_ok()
     }
 
@@ -144,7 +150,10 @@ impl EditorConfig {
         self.auto_install_extension
             && matches!(
                 self.editor_type,
-                EditorType::VsCode | EditorType::VsCodeInsiders | EditorType::Cursor
+                EditorType::VsCode
+                    | EditorType::VsCodeInsiders
+                    | EditorType::Cursor
+                    | EditorType::CodeServer
             )
     }
 
@@ -164,11 +173,70 @@ impl EditorConfig {
         if let Some(url) = self.remote_url(path) {
             return Ok(Some(url));
         }
+
+        if matches!(self.editor_type, EditorType::CodeServer) {
+            if self.should_auto_install_extension() {
+                self.try_install_extension().await;
+            }
+            let url = self.code_server_url(path)?;
+            return Ok(Some(url));
+        }
         if self.should_auto_install_extension() {
             self.try_install_extension().await;
         }
         self.spawn_local(path).await?;
         Ok(None)
+    }
+
+    fn code_server_url_base(&self) -> Result<Url, EditorOpenError> {
+        if !matches!(self.editor_type, EditorType::CodeServer) {
+            return Err(EditorOpenError::InvalidCommand {
+                details: "Code Server URL is only valid for CODE_SERVER editor type".to_string(),
+                editor_type: self.editor_type.clone(),
+            });
+        }
+
+        let command = self
+            .custom_command
+            .as_deref()
+            .map(str::trim)
+            .ok_or_else(|| EditorOpenError::InvalidCommand {
+                details: "Code Server URL is required".to_string(),
+                editor_type: self.editor_type.clone(),
+            })?;
+
+        if command.is_empty() {
+            return Err(EditorOpenError::InvalidCommand {
+                details: "Code Server URL is required".to_string(),
+                editor_type: self.editor_type.clone(),
+            });
+        }
+
+        let url = Url::parse(command).map_err(|e| EditorOpenError::InvalidCommand {
+            details: format!("Invalid Code Server URL: {e}"),
+            editor_type: self.editor_type.clone(),
+        })?;
+
+        match url.scheme() {
+            "http" | "https" => Ok(url),
+            _ => Err(EditorOpenError::InvalidCommand {
+                details: "Code Server URL must start with http:// or https://".to_string(),
+                editor_type: self.editor_type.clone(),
+            }),
+        }
+    }
+
+    fn code_server_url(&self, path: &Path) -> Result<String, EditorOpenError> {
+        let mut url = self.code_server_url_base()?;
+        let folder_path = if path.is_file() {
+            path.parent().unwrap_or(path)
+        } else {
+            path
+        };
+
+        url.query_pairs_mut()
+            .append_pair("folder", &folder_path.to_string_lossy());
+        Ok(url.to_string())
     }
 
     fn remote_url(&self, path: &Path) -> Option<String> {
@@ -226,5 +294,94 @@ impl EditorConfig {
         } else {
             self.clone()
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use tempfile::tempdir;
+    use url::Url;
+
+    use super::{EditorConfig, EditorOpenError, EditorType};
+
+    #[test]
+    fn code_server_url_requires_http_or_https_scheme() {
+        let config = EditorConfig::new(
+            EditorType::CodeServer,
+            Some("code-server://workspace".to_string()),
+            None,
+            None,
+            false,
+        );
+
+        let result = config.code_server_url_base();
+        assert!(matches!(
+            result,
+            Err(EditorOpenError::InvalidCommand { .. })
+        ));
+    }
+
+    #[test]
+    fn code_server_url_is_required() {
+        let config = EditorConfig::new(EditorType::CodeServer, None, None, None, false);
+
+        let result = config.code_server_url_base();
+        assert!(matches!(
+            result,
+            Err(EditorOpenError::InvalidCommand { .. })
+        ));
+    }
+
+    #[test]
+    fn code_server_url_for_directory_sets_folder_query() {
+        let dir = tempdir().expect("tempdir");
+        let repo_path = dir.path().join("repo");
+        fs::create_dir_all(&repo_path).expect("create repo dir");
+
+        let config = EditorConfig::new(
+            EditorType::CodeServer,
+            Some("https://code-server.example.com/".to_string()),
+            None,
+            None,
+            false,
+        );
+
+        let url = config.code_server_url(&repo_path).expect("code server url");
+        let parsed = Url::parse(&url).expect("valid url");
+        let folder = parsed
+            .query_pairs()
+            .find_map(|(k, v)| (k == "folder").then(|| v.to_string()))
+            .expect("folder query exists");
+
+        assert_eq!(folder, repo_path.to_string_lossy());
+    }
+
+    #[test]
+    fn code_server_url_for_file_uses_parent_directory() {
+        let dir = tempdir().expect("tempdir");
+        let repo_path = dir.path().join("repo");
+        fs::create_dir_all(&repo_path).expect("create repo dir");
+        let file_path = repo_path.join("src/main.rs");
+        fs::create_dir_all(file_path.parent().expect("parent path")).expect("create file parent");
+        fs::write(&file_path, "fn main() {}\n").expect("write file");
+
+        let config = EditorConfig::new(
+            EditorType::CodeServer,
+            Some("https://code-server.example.com/?theme=dark".to_string()),
+            None,
+            None,
+            false,
+        );
+
+        let url = config.code_server_url(&file_path).expect("code server url");
+        let parsed = Url::parse(&url).expect("valid url");
+        let folder = parsed
+            .query_pairs()
+            .find_map(|(k, v)| (k == "folder").then(|| v.to_string()))
+            .expect("folder query exists");
+
+        assert_eq!(folder, repo_path.join("src").to_string_lossy());
     }
 }

--- a/packages/web-core/src/features/onboarding/ui/LandingPage.tsx
+++ b/packages/web-core/src/features/onboarding/ui/LandingPage.tsx
@@ -252,9 +252,18 @@ export function LandingPage() {
     void playSound(value);
   };
 
-  const isCustomEditorValid =
-    editorType !== EditorType.CUSTOM || customCommand.trim() !== '';
-  const canContinue = !saving && isCustomEditorValid;
+  const trimmedEditorCommand = customCommand.trim();
+  const isCustomEditor = editorType === EditorType.CUSTOM;
+  const isCodeServerEditor = editorType === EditorType.CODE_SERVER;
+  const hasEditorCommand = trimmedEditorCommand !== '';
+  const hasValidCodeServerUrl =
+    hasEditorCommand && /^https?:\/\//i.test(trimmedEditorCommand);
+
+  const isEditorCommandValid =
+    (!isCustomEditor && !isCodeServerEditor) ||
+    (isCustomEditor && hasEditorCommand) ||
+    (isCodeServerEditor && hasValidCodeServerUrl);
+  const canContinue = !saving && isEditorCommandValid;
 
   const handleContinue = async () => {
     if (!config || !canContinue) return;
@@ -262,7 +271,7 @@ export function LandingPage() {
     const editorConfig: EditorConfig = {
       editor_type: editorType,
       custom_command:
-        editorType === EditorType.CUSTOM ? customCommand.trim() : null,
+        isCustomEditor || isCodeServerEditor ? trimmedEditorCommand : null,
       remote_ssh_host: null,
       remote_ssh_user: null,
       auto_install_extension: true,
@@ -274,7 +283,8 @@ export function LandingPage() {
       selected_agent: selectedAgent,
       editor_type: editorType,
       custom_editor_command_set:
-        editorType === EditorType.CUSTOM && customCommand.trim() !== '',
+        (isCustomEditor || isCodeServerEditor) && hasEditorCommand,
+      code_server_url_set: isCodeServerEditor && hasEditorCommand,
       sound_enabled: soundEnabled,
       sound_file: soundEnabled ? soundFile : null,
     });
@@ -461,25 +471,35 @@ export function LandingPage() {
               })}
             </div>
 
-            {editorType === EditorType.CUSTOM && (
+            {(isCustomEditor || isCodeServerEditor) && (
               <div className="space-y-half">
                 <label className="text-sm font-medium text-normal">
-                  Custom Command
+                  {isCodeServerEditor ? 'Code Server URL' : 'Custom Command'}
                 </label>
                 <input
                   type="text"
                   value={customCommand}
                   onChange={(e) => setCustomCommand(e.target.value)}
-                  placeholder="e.g. code --wait"
+                  placeholder={
+                    isCodeServerEditor
+                      ? 'https://code-server.example.com'
+                      : 'e.g. code --wait'
+                  }
                   className={cn(
                     'w-full bg-panel border rounded-sm px-base py-half text-sm text-high',
                     'placeholder:text-low placeholder:opacity-80 focus:outline-none',
                     'focus:ring-1 focus:ring-brand',
-                    customCommand.trim() === ''
+                    !hasEditorCommand ||
+                      (isCodeServerEditor && !hasValidCodeServerUrl)
                       ? 'border-warning/60'
                       : 'border-border'
                   )}
                 />
+                {isCodeServerEditor && !hasValidCodeServerUrl && (
+                  <p className="text-xs text-warning">
+                    Enter a valid URL starting with http:// or https://
+                  </p>
+                )}
               </div>
             )}
           </section>

--- a/packages/web-core/src/i18n/locales/en/settings.json
+++ b/packages/web-core/src/i18n/locales/en/settings.json
@@ -79,6 +79,9 @@
           "placeholder": "e.g., code, subl, vim",
           "helper": "Enter the command to launch your custom editor. This will be used to open files."
         },
+        "codeServerUrl": {
+          "placeholder": "https://code-server.example.com"
+        },
         "remoteSsh": {
           "host": {
             "label": "Remote SSH Host (Optional)",
@@ -93,7 +96,7 @@
         },
         "autoInstallExtension": {
           "label": "Auto-install VS Code Extension",
-          "helper": "Automatically install the Vibe Kanban extension when opening a project in VS Code or Cursor. This runs in the background and has no effect if the extension is already installed."
+          "helper": "Automatically install the Vibe Kanban extension when opening a project in VS Code, Cursor, or Code Server. This runs in the background and has no effect if the extension is already installed."
         },
         "availability": {
           "checking": "Checking availability...",

--- a/packages/web-core/src/i18n/locales/en/settings.json
+++ b/packages/web-core/src/i18n/locales/en/settings.json
@@ -80,6 +80,8 @@
           "helper": "Enter the command to launch your custom editor. This will be used to open files."
         },
         "codeServerUrl": {
+          "label": "Code Server URL",
+          "helper": "Required. Browser URL to your code-server instance. Vibe Kanban will open this URL in a new tab and append the workspace folder path.",
           "placeholder": "https://code-server.example.com"
         },
         "remoteSsh": {

--- a/packages/web-core/src/i18n/locales/es/settings.json
+++ b/packages/web-core/src/i18n/locales/es/settings.json
@@ -79,6 +79,11 @@
           "placeholder": "ej., code, subl, vim",
           "helper": "Ingresa el comando para lanzar tu editor personalizado. Se utilizará para abrir archivos."
         },
+        "codeServerUrl": {
+          "label": "URL de Code Server",
+          "helper": "Obligatorio. URL del navegador a tu instancia de code-server. Vibe Kanban abrirá esta URL en una nueva pestaña y añadirá la ruta de la carpeta del espacio de trabajo.",
+          "placeholder": "https://code-server.example.com"
+        },
         "remoteSsh": {
           "host": {
             "label": "Host SSH Remoto (Opcional)",

--- a/packages/web-core/src/i18n/locales/fr/settings.json
+++ b/packages/web-core/src/i18n/locales/fr/settings.json
@@ -79,6 +79,11 @@
           "placeholder": "ex: code, subl, vim",
           "helper": "Saisissez la commande pour lancer votre éditeur personnalisé. Elle sera utilisée pour ouvrir les fichiers."
         },
+        "codeServerUrl": {
+          "label": "URL de Code Server",
+          "helper": "Requis. URL du navigateur vers votre instance code-server. Vibe Kanban ouvrira cette URL dans un nouvel onglet et ajoutera le chemin du dossier de l'espace de travail.",
+          "placeholder": "https://code-server.example.com"
+        },
         "remoteSsh": {
           "host": {
             "label": "Hôte SSH distant (optionnel)",

--- a/packages/web-core/src/i18n/locales/ja/settings.json
+++ b/packages/web-core/src/i18n/locales/ja/settings.json
@@ -79,6 +79,11 @@
           "placeholder": "例: code, subl, vim",
           "helper": "カスタムエディターを起動するコマンドを入力してください。ファイルを開くために使用されます。"
         },
+        "codeServerUrl": {
+          "label": "Code Server URL",
+          "helper": "必須。code-serverインスタンスのブラウザURL。Vibe KanbanはこのURLを新しいタブで開き、ワークスペースフォルダのパスを追加します。",
+          "placeholder": "https://code-server.example.com"
+        },
         "remoteSsh": {
           "host": {
             "label": "リモートSSHホスト（オプション）",

--- a/packages/web-core/src/i18n/locales/ko/settings.json
+++ b/packages/web-core/src/i18n/locales/ko/settings.json
@@ -79,6 +79,11 @@
           "placeholder": "예: code, subl, vim",
           "helper": "사용자 정의 에디터를 실행하는 명령을 입력하세요. 파일을 여는 데 사용됩니다."
         },
+        "codeServerUrl": {
+          "label": "Code Server URL",
+          "helper": "필수. code-server 인스턴스의 브라우저 URL입니다. Vibe Kanban이 이 URL을 새 탭에서 열고 작업 공간 폴더 경로를 추가합니다.",
+          "placeholder": "https://code-server.example.com"
+        },
         "remoteSsh": {
           "host": {
             "label": "원격 SSH 호스트 (선택사항)",

--- a/packages/web-core/src/i18n/locales/zh-Hans/settings.json
+++ b/packages/web-core/src/i18n/locales/zh-Hans/settings.json
@@ -79,6 +79,11 @@
           "placeholder": "例如：code、subl、vim",
           "helper": "输入启动自定义编辑器的命令。这将用于打开文件。"
         },
+        "codeServerUrl": {
+          "label": "Code Server URL",
+          "helper": "必填。code-server 实例的浏览器 URL。Vibe Kanban 将在新标签页中打开此 URL 并附加工作区文件夹路径。",
+          "placeholder": "https://code-server.example.com"
+        },
         "remoteSsh": {
           "host": {
             "label": "远程 SSH 主机（可选）",

--- a/packages/web-core/src/i18n/locales/zh-Hant/settings.json
+++ b/packages/web-core/src/i18n/locales/zh-Hant/settings.json
@@ -79,6 +79,11 @@
           "placeholder": "例如：code、subl、vim",
           "helper": "輸入啟動自訂編輯器的指令，用於開啟檔案。"
         },
+        "codeServerUrl": {
+          "label": "Code Server URL",
+          "helper": "必填。code-server 實例的瀏覽器 URL。Vibe Kanban 將在新分頁中開啟此 URL 並附加工作區資料夾路徑。",
+          "placeholder": "https://code-server.example.com"
+        },
         "remoteSsh": {
           "host": {
             "label": "遠端 SSH 主機（選填）",

--- a/packages/web-core/src/shared/actions/index.ts
+++ b/packages/web-core/src/shared/actions/index.ts
@@ -66,6 +66,7 @@ import { RenameWorkspaceDialog } from '@vibe/ui/components/RenameWorkspaceDialog
 import { ProjectsGuideDialog } from '@vibe/ui/components/ProjectsGuideDialog';
 import { CreatePRDialog } from '@/shared/dialogs/command-bar/CreatePRDialog';
 import { getIdeName } from '@/shared/lib/ideName';
+import { alertIfCodeServerNotConfigured } from '@/shared/lib/editorWarnings';
 import { EditorSelectionDialog } from '@/shared/dialogs/command-bar/EditorSelectionDialog';
 import { StartReviewDialog } from '@/shared/dialogs/command-bar/StartReviewDialog';
 import posthog from 'posthog-js';
@@ -770,7 +771,10 @@ export const Actions = {
         if (response.url) {
           window.open(response.url, '_blank');
         }
-      } catch {
+      } catch (err) {
+        if (alertIfCodeServerNotConfigured(err)) {
+          return;
+        }
         // Show editor selection dialog on failure
         EditorSelectionDialog.show({
           selectedAttemptId: ctx.currentWorkspaceId,
@@ -1140,6 +1144,9 @@ export const Actions = {
           window.open(response.url, '_blank');
         }
       } catch (err) {
+        if (alertIfCodeServerNotConfigured(err)) {
+          return;
+        }
         console.error('Failed to open repo in editor:', err);
         throw new Error('Failed to open repository in IDE');
       }

--- a/packages/web-core/src/shared/components/IdeIcon.tsx
+++ b/packages/web-core/src/shared/components/IdeIcon.tsx
@@ -16,7 +16,11 @@ export function IdeIcon({ editorType, className = 'h-4 w-4' }: IdeIconProps) {
   const ideName = getIdeName(editorType);
   let ideIconPath = '';
 
-  if (!editorType || editorType === EditorType.CUSTOM) {
+  if (
+    !editorType ||
+    editorType === EditorType.CUSTOM ||
+    editorType === EditorType.CODE_SERVER
+  ) {
     // Generic fallback for other IDEs or no IDE configured
     return <Code2 className={className} />;
   }

--- a/packages/web-core/src/shared/dialogs/settings/settings/GeneralSettingsSection.tsx
+++ b/packages/web-core/src/shared/dialogs/settings/settings/GeneralSettingsSection.tsx
@@ -340,12 +340,12 @@ export function GeneralSettingsSection() {
           <SettingsField
             label={
               draft?.editor.editor_type === EditorType.CODE_SERVER
-                ? 'Code Server URL'
+                ? t('settings.general.editor.codeServerUrl.label')
                 : t('settings.general.editor.customCommand.label')
             }
             description={
               draft?.editor.editor_type === EditorType.CODE_SERVER
-                ? 'Required. Browser URL to your code-server instance. Vibe Kanban will open this URL in a new tab and append the workspace folder path.'
+                ? t('settings.general.editor.codeServerUrl.helper')
                 : t('settings.general.editor.customCommand.helper')
             }
           >

--- a/packages/web-core/src/shared/dialogs/settings/settings/GeneralSettingsSection.tsx
+++ b/packages/web-core/src/shared/dialogs/settings/settings/GeneralSettingsSection.tsx
@@ -335,10 +335,19 @@ export function GeneralSettingsSection() {
           />
         </SettingsField>
 
-        {draft?.editor.editor_type === EditorType.CUSTOM && (
+        {(draft?.editor.editor_type === EditorType.CUSTOM ||
+          draft?.editor.editor_type === EditorType.CODE_SERVER) && (
           <SettingsField
-            label={t('settings.general.editor.customCommand.label')}
-            description={t('settings.general.editor.customCommand.helper')}
+            label={
+              draft?.editor.editor_type === EditorType.CODE_SERVER
+                ? 'Code Server URL'
+                : t('settings.general.editor.customCommand.label')
+            }
+            description={
+              draft?.editor.editor_type === EditorType.CODE_SERVER
+                ? 'Required. Browser URL to your code-server instance. Vibe Kanban will open this URL in a new tab and append the workspace folder path.'
+                : t('settings.general.editor.customCommand.helper')
+            }
           >
             <SettingsInput
               value={draft?.editor.custom_command || ''}
@@ -351,7 +360,9 @@ export function GeneralSettingsSection() {
                 })
               }
               placeholder={t(
-                'settings.general.editor.customCommand.placeholder'
+                draft?.editor.editor_type === EditorType.CODE_SERVER
+                  ? 'settings.general.editor.codeServerUrl.placeholder'
+                  : 'settings.general.editor.customCommand.placeholder'
               )}
             />
           </SettingsField>
@@ -409,7 +420,8 @@ export function GeneralSettingsSection() {
 
         {(draft?.editor.editor_type === EditorType.VS_CODE ||
           draft?.editor.editor_type === EditorType.VS_CODE_INSIDERS ||
-          draft?.editor.editor_type === EditorType.CURSOR) && (
+          draft?.editor.editor_type === EditorType.CURSOR ||
+          draft?.editor.editor_type === EditorType.CODE_SERVER) && (
           <SettingsCheckbox
             id="auto-install-extension"
             label={t('settings.general.editor.autoInstallExtension.label')}

--- a/packages/web-core/src/shared/hooks/useOpenInEditor.ts
+++ b/packages/web-core/src/shared/hooks/useOpenInEditor.ts
@@ -1,6 +1,7 @@
 import { useCallback } from 'react';
 import { workspacesApi } from '@/shared/lib/api';
 import { EditorSelectionDialog } from '@/shared/dialogs/command-bar/EditorSelectionDialog';
+import { alertIfCodeServerNotConfigured } from '@/shared/lib/editorWarnings';
 import type { EditorType } from 'shared/types';
 
 type OpenEditorOptions = {
@@ -29,6 +30,9 @@ export function useOpenInEditor(
           window.open(response.url, '_blank');
         }
       } catch (err) {
+        if (alertIfCodeServerNotConfigured(err)) {
+          return;
+        }
         console.error('Failed to open editor:', err);
         if (!editorType) {
           if (onShowEditorDialog) {

--- a/packages/web-core/src/shared/lib/editorWarnings.ts
+++ b/packages/web-core/src/shared/lib/editorWarnings.ts
@@ -1,4 +1,8 @@
-const MISSING_CODE_SERVER_URL_ERROR = 'Code Server URL is required';
+const CODE_SERVER_ERROR_PATTERNS = [
+  'Code Server URL is required',
+  'Invalid Code Server URL',
+  'Code Server URL must start with http://',
+];
 
 export function alertIfCodeServerNotConfigured(error: unknown): boolean {
   const message =
@@ -8,13 +12,13 @@ export function alertIfCodeServerNotConfigured(error: unknown): boolean {
         ? error
         : '';
 
-  if (!message.includes(MISSING_CODE_SERVER_URL_ERROR)) {
+  if (!CODE_SERVER_ERROR_PATTERNS.some((pattern) => message.includes(pattern))) {
     return false;
   }
 
   // eslint-disable-next-line no-alert
   window.alert(
-    'Code Server URL is not configured. Please set it in Settings > General > Editor.'
+    'Code Server URL is not configured or invalid. Please check it in Settings > General > Editor.'
   );
   return true;
 }

--- a/packages/web-core/src/shared/lib/editorWarnings.ts
+++ b/packages/web-core/src/shared/lib/editorWarnings.ts
@@ -1,0 +1,20 @@
+const MISSING_CODE_SERVER_URL_ERROR = 'Code Server URL is required';
+
+export function alertIfCodeServerNotConfigured(error: unknown): boolean {
+  const message =
+    error instanceof Error
+      ? error.message
+      : typeof error === 'string'
+        ? error
+        : '';
+
+  if (!message.includes(MISSING_CODE_SERVER_URL_ERROR)) {
+    return false;
+  }
+
+  // eslint-disable-next-line no-alert
+  window.alert(
+    'Code Server URL is not configured. Please set it in Settings > General > Editor.'
+  );
+  return true;
+}

--- a/packages/web-core/src/shared/lib/ideName.ts
+++ b/packages/web-core/src/shared/lib/ideName.ts
@@ -18,6 +18,8 @@ export function getIdeName(editorType: EditorType | undefined | null): string {
       return 'Zed';
     case EditorType.XCODE:
       return 'Xcode';
+    case EditorType.CODE_SERVER:
+      return 'Code Server';
     case EditorType.CUSTOM:
       return i18n.t('common:editorNames.custom');
     case EditorType.GOOGLE_ANTIGRAVITY:

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -484,7 +484,7 @@ export enum ThemeMode { LIGHT = "LIGHT", DARK = "DARK", SYSTEM = "SYSTEM" }
 
 export type EditorConfig = { editor_type: EditorType, custom_command: string | null, remote_ssh_host: string | null, remote_ssh_user: string | null, auto_install_extension: boolean, };
 
-export enum EditorType { VS_CODE = "VS_CODE", VS_CODE_INSIDERS = "VS_CODE_INSIDERS", CURSOR = "CURSOR", WINDSURF = "WINDSURF", INTELLI_J = "INTELLI_J", ZED = "ZED", XCODE = "XCODE", GOOGLE_ANTIGRAVITY = "GOOGLE_ANTIGRAVITY", CUSTOM = "CUSTOM" }
+export enum EditorType { VS_CODE = "VS_CODE", VS_CODE_INSIDERS = "VS_CODE_INSIDERS", CURSOR = "CURSOR", WINDSURF = "WINDSURF", INTELLI_J = "INTELLI_J", ZED = "ZED", XCODE = "XCODE", GOOGLE_ANTIGRAVITY = "GOOGLE_ANTIGRAVITY", CODE_SERVER = "CODE_SERVER", CUSTOM = "CUSTOM" }
 
 export type EditorOpenError = { "type": "executable_not_found", executable: string, editor_type: EditorType, } | { "type": "invalid_command", details: string, editor_type: EditorType, } | { "type": "launch_failed", executable: string, details: string, editor_type: EditorType, };
 


### PR DESCRIPTION
## Summary
- add a dedicated `CODE_SERVER` editor type (separate from generic custom editor)
- require and validate a Code Server URL (`http`/`https`) and open workspace via `?folder=...`
- wire Code Server through onboarding/settings UX, including URL placeholder and validation messaging
- include Code Server in extension auto-install flow and show a user alert when URL is missing

## Notes
- this PR is scoped to Code Server support only
- tests were not run in this pass

Issue: https://github.com/BloopAI/vibe-kanban/issues/2190


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new editor type with URL validation and different open/availability behavior across backend and frontend, which could break “open in editor” flows or onboarding if edge cases aren’t handled. No auth or data-model migrations beyond enum/config shape changes.
> 
> **Overview**
> Adds a dedicated `CodeServer`/`CODE_SERVER` editor type end-to-end, including TS/Rust enum updates and display naming.
> 
> Backend editor handling now treats Code Server as URL-driven: availability checks validate an `http(s)` URL, `open_file` returns a Code Server URL with a `?folder=...` query, and Code Server is included in the extension auto-install path (with new unit tests for URL validation/building).
> 
> Frontend onboarding and settings UIs now collect and validate a Code Server URL (with localized labels/help text), treat it similarly to `CUSTOM` for storing `custom_command`, and surface a user alert when “open in editor” fails due to missing/invalid Code Server configuration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f962c7a1212cbef6714e785aca29ec5365236ac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->