### PR TITLE
Add a copy button for diff file paths (Vibe Kanban)

### DIFF
--- a/packages/web-core/src/pages/workspaces/PierreDiffCard.tsx
+++ b/packages/web-core/src/pages/workspaces/PierreDiffCard.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import {
   CaretDownIcon,
   ChatCircleIcon,
+  CopyIcon,
   GithubLogoIcon,
   PlusIcon,
 } from '@phosphor-icons/react';
@@ -31,7 +32,9 @@ import { useWorkspaceContext } from '@/shared/hooks/useWorkspaceContext';
 import { isRealMobileDevice } from '@/shared/hooks/useIsMobile';
 import { getFileIcon } from '@/shared/lib/fileTypeIcon';
 import { OpenInIdeButton } from '@/shared/components/OpenInIdeButton';
+import { CopyButton } from '@/shared/components/CopyButton';
 import { useOpenInEditor } from '@/shared/hooks/useOpenInEditor';
+import { writeClipboardViaBridge } from '@/shared/lib/clipboard';
 import { ReviewCommentRenderer } from './ReviewCommentRenderer';
 import { GitHubCommentRenderer } from './GitHubCommentRenderer';
 import { CommentWidgetLine } from './CommentWidgetLine';
@@ -234,6 +237,9 @@ export function PierreDiffCard({
   const handleOpenInIde = useCallback(() => {
     openInEditor({ filePath });
   }, [openInEditor, filePath]);
+  const handleCopyFilePath = useCallback(() => {
+    void writeClipboardViaBridge(filePath);
+  }, [filePath]);
 
   // Transform diff to pierre/diffs metadata
   const fileDiffMetadata = useMemo(
@@ -486,13 +492,23 @@ export function PierreDiffCard({
             {changeLabel}
           </span>
         )}
-        <div
-          className={cn(
-            'text-sm flex-1 min-w-0',
-            changeKind === 'deleted' && 'text-error line-through'
-          )}
-        >
-          <DisplayTruncatedPath path={filePath} />
+        <div className="flex items-center gap-half flex-1 min-w-0">
+          <div
+            className={cn(
+              'text-sm min-w-0 flex-1',
+              changeKind === 'deleted' && 'text-error line-through'
+            )}
+          >
+            <DisplayTruncatedPath path={filePath} />
+          </div>
+          <span onClick={(e) => e.stopPropagation()} className="shrink-0">
+            <CopyButton
+              onCopy={handleCopyFilePath}
+              disabled={false}
+              iconSize="size-icon-xs"
+              icon={CopyIcon}
+            />
+          </span>
         </div>
         {(changeKind === 'renamed' || changeKind === 'copied') && oldPath && (
           <span className="text-low text-sm shrink-0">


### PR DESCRIPTION
## Summary
This PR adds a copy action to the file path shown in the `PierreDiffCard` header.

## What changed
- Added a copy icon immediately to the right of the displayed file path in `packages/web-core/src/pages/workspaces/PierreDiffCard.tsx`
- Wired the new action to the existing shared `CopyButton` component so it reuses the standard tooltip and copied-state feedback
- Added a `handleCopyFilePath` callback that copies the resolved `filePath` value through `writeClipboardViaBridge`
- Updated the header layout so the truncated path and copy action sit together without affecting the existing stats, comments, or open-in-IDE controls
- Prevented the copy interaction from bubbling to the card header so clicking the icon does not toggle the diff card open or closed

## Why
The task for this branch was to make file paths easier to copy directly from the diff UI. Reviewers already see the path in the `PierreDiffCard` header, but without an inline action they would need to select text manually or use another workflow. Adding a dedicated copy affordance makes the common action faster and more reliable.

## Important implementation details
- The copied value is the full resolved path from `diff.newPath || diff.oldPath || 'unknown'`, not the truncated text shown in the UI
- The change reuses the existing clipboard bridge so it still works in environments where direct clipboard access can fall back through the VS Code/webview integration
- The implementation is isolated to a single file and does not change public APIs or shared types

This PR was written using [Vibe Kanban](https://vibekanban.com)
