### PR TITLE
feat(remote): add ALLOWED_EMAILS restriction for self-hosted deployments

### DIFF
--- a/crates/remote/src/app.rs
+++ b/crates/remote/src/app.rs
@@ -84,6 +84,7 @@ impl Server {
             registry.clone(),
             jwt.clone(),
             auth_config.public_base_url().to_string(),
+            auth_config.allowed_emails.clone(),
         ));
 
         let oauth_token_validator = Arc::new(OAuthTokenValidator::new(

--- a/crates/remote/src/auth/handoff.rs
+++ b/crates/remote/src/auth/handoff.rs
@@ -67,6 +67,8 @@ pub enum HandoffError {
     Jwt(#[from] JwtError),
     #[error(transparent)]
     Authorization(#[from] OAuthHandoffError),
+    #[error("email not in allowed list")]
+    EmailNotAllowed,
 }
 
 #[derive(Debug, Clone)]
@@ -103,6 +105,7 @@ pub struct OAuthHandoffService {
     providers: Arc<ProviderRegistry>,
     jwt: Arc<JwtService>,
     public_origin: String,
+    allowed_emails: Vec<String>,
 }
 
 impl OAuthHandoffService {
@@ -111,6 +114,7 @@ impl OAuthHandoffService {
         providers: Arc<ProviderRegistry>,
         jwt: Arc<JwtService>,
         public_origin: String,
+        allowed_emails: Vec<String>,
     ) -> Self {
         let trimmed_origin = public_origin.trim_end_matches('/').to_string();
         Self {
@@ -118,6 +122,7 @@ impl OAuthHandoffService {
             providers,
             jwt,
             public_origin: trimmed_origin,
+            allowed_emails,
         }
     }
 
@@ -431,6 +436,14 @@ impl OAuthHandoffService {
         let org_repo = OrganizationRepository::new(&self.pool);
 
         let email = ensure_email(provider.name(), profile);
+
+        if !self.allowed_emails.is_empty()
+            && !self.allowed_emails.contains(&email.to_lowercase())
+        {
+            tracing::warn!(email = %email, "sign-in rejected: email not in ALLOWED_EMAILS");
+            return Err(HandoffError::EmailNotAllowed);
+        }
+
         let username = derive_username(provider.name(), profile);
         let display_name = derive_display_name(profile);
 

--- a/crates/remote/src/config.rs
+++ b/crates/remote/src/config.rs
@@ -312,6 +312,7 @@ pub struct AuthConfig {
     google: Option<OAuthProviderConfig>,
     jwt_secret: SecretString,
     public_base_url: String,
+    pub allowed_emails: Vec<String>,
 }
 
 impl AuthConfig {
@@ -352,11 +353,31 @@ impl AuthConfig {
         let public_base_url =
             env::var("SERVER_PUBLIC_BASE_URL").unwrap_or_else(|_| "http://localhost:8081".into());
 
+        let allowed_emails = env::var("ALLOWED_EMAILS")
+            .ok()
+            .map(|s| {
+                s.split(',')
+                    .map(|e| e.trim().to_lowercase())
+                    .filter(|e| !e.is_empty())
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        if allowed_emails.is_empty() {
+            tracing::info!("ALLOWED_EMAILS not set — all authenticated users are allowed");
+        } else {
+            tracing::info!(
+                count = allowed_emails.len(),
+                "ALLOWED_EMAILS set — restricting sign-in to allowed list"
+            );
+        }
+
         Ok(Self {
             github,
             google,
             jwt_secret,
             public_base_url,
+            allowed_emails,
         })
     }
 

--- a/crates/remote/src/routes/oauth.rs
+++ b/crates/remote/src/routes/oauth.rs
@@ -293,6 +293,9 @@ fn classify_handoff_error(error: &HandoffError) -> (StatusCode, Cow<'_, str>) {
             StatusCode::INTERNAL_SERVER_ERROR,
             Cow::Borrowed("internal_error"),
         ),
+        HandoffError::EmailNotAllowed => {
+            (StatusCode::FORBIDDEN, Cow::Borrowed("email_not_allowed"))
+        }
         HandoffError::Authorization(auth_err) => match auth_err {
             OAuthHandoffError::NotAuthorized => (StatusCode::GONE, Cow::Borrowed("not_authorized")),
             OAuthHandoffError::AlreadyRedeemed => {


### PR DESCRIPTION
I have setup a self host vibe-kanban but I was looking to have settings to restrict the access to it. Here's my proposal which I've done using AI

## Summary

- Adds an optional `ALLOWED_EMAILS` environment variable (comma-separated list) to restrict sign-in to specific email addresses on self-hosted deployments
- When unset, all authenticated users are allowed (existing behaviour is preserved)
- Emails are matched case-insensitively

## Changes

- **`config.rs`**: Parse `ALLOWED_EMAILS` into `AuthConfig` with a startup log indicating whether the restriction is active
- **`handoff.rs`**: Check the authenticated user's email against the allowed list before upserting the identity; adds `EmailNotAllowed` error variant
- **`routes/oauth.rs`**: Map `EmailNotAllowed` to `403 FORBIDDEN` with `email_not_allowed` error code
- **`app.rs`**: Pass `allowed_emails` through to `OAuthHandoffService`

## Usage

```env
# Restrict sign-in to specific emails (comma-separated)
ALLOWED_EMAILS=alice@example.com,bob@example.com
```

When set, any user authenticating via OAuth whose email is not in the list will be rejected before any database writes occur.

## Test plan

- [ ] Sign in with an email in `ALLOWED_EMAILS` — should succeed
- [ ] Sign in with an email not in `ALLOWED_EMAILS` — should return 403 `email_not_allowed`
- [ ] Unset `ALLOWED_EMAILS` — all users should be able to sign in (existing behaviour)
- [ ] Verify startup log correctly reports whether the restriction is active


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the OAuth authentication flow by adding a new access restriction and error path; misconfiguration or case/normalization issues could inadvertently block legitimate logins.
> 
> **Overview**
> Adds an optional `ALLOWED_EMAILS` (comma-separated, case-insensitive) config to **restrict OAuth sign-ins to a specific allowlist** for self-hosted deployments.
> 
> The allowlist is parsed into `AuthConfig`, passed into `OAuthHandoffService`, enforced during `upsert_identity` (rejecting non-allowed users before DB writes), and surfaced to clients as a new `EmailNotAllowed` error mapped to `403` with `email_not_allowed`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 07bdc215bb2a32a18d3c00461bab5bf8adf3f655. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->