### PR TITLE
Allow image attachments during active agent runs (Vibe Kanban)

### DIFF
--- a/packages/ui/src/components/SessionChatBox.tsx
+++ b/packages/ui/src/components/SessionChatBox.tsx
@@ -279,6 +279,7 @@ export function SessionChatBox<TExecutor extends string = string>({
     hasContent && !['sending', 'stopping', 'queue-loading'].includes(status);
   const isQueued = status === 'queued';
   const isRunning = status === 'running' || status === 'queued';
+  const areContentInsertActionsDisabled = isDisabled || isQueued;
   const showRunningAnimation =
     (status === 'running' || status === 'queued' || status === 'sending') &&
     !isInApprovalMode &&
@@ -844,7 +845,7 @@ export function SessionChatBox<TExecutor extends string = string>({
             aria-label={t('tasks:taskFormDialog.attachImage')}
             title={t('tasks:taskFormDialog.attachImage')}
             onClick={handleAttachClick}
-            disabled={isDisabled || isRunning}
+            disabled={areContentInsertActionsDisabled}
           />
           <input
             ref={fileInputRef}
@@ -860,7 +861,7 @@ export function SessionChatBox<TExecutor extends string = string>({
               aria-label="Add PR Comments"
               title="Insert PR comments into message"
               onClick={onPrCommentClick}
-              disabled={isDisabled || isRunning}
+              disabled={areContentInsertActionsDisabled}
             />
           )}
           {toolbarActions?.items.map((item) => (

--- a/packages/web-core/src/features/workspace-chat/ui/SessionChatBoxContainer.tsx
+++ b/packages/web-core/src/features/workspace-chat/ui/SessionChatBoxContainer.tsx
@@ -396,26 +396,6 @@ export function SessionChatBoxContainer(props: SessionChatBoxContainerProps) {
   const { uploadFiles, localImages, clearUploadedImages } =
     useSessionAttachments(workspaceId, sessionId, handleInsertMarkdown);
 
-  const onDrop = useCallback(
-    (acceptedFiles: File[]) => {
-      const imageFiles = acceptedFiles.filter((f) =>
-        f.type.startsWith('image/')
-      );
-      if (imageFiles.length > 0) {
-        uploadFiles(imageFiles);
-      }
-    },
-    [uploadFiles]
-  );
-
-  const { getRootProps, getInputProps, isDragActive } = useDropzone({
-    onDrop,
-    accept: { 'image/*': [] },
-    disabled: mode === 'placeholder' || isAttemptRunning,
-    noClick: true,
-    noKeyboard: true,
-  });
-
   // Unified executor + variant + model selector options resolution
   const {
     executorConfig,
@@ -614,6 +594,37 @@ export function SessionChatBoxContainer(props: SessionChatBoxContainerProps) {
     editContext.cancelEdit();
     cancelDebouncedSave();
     setLocalMessage('');
+  });
+
+  const areAttachmentInputsDisabled =
+    mode === 'placeholder' ||
+    isQueued ||
+    isSending ||
+    isStopping ||
+    !!feedbackContext?.isSubmitting ||
+    editRetryMutation.isPending ||
+    isApproving ||
+    isDenying ||
+    isAnswering;
+
+  const onDrop = useCallback(
+    (acceptedFiles: File[]) => {
+      const imageFiles = acceptedFiles.filter((f) =>
+        f.type.startsWith('image/')
+      );
+      if (imageFiles.length > 0) {
+        uploadFiles(imageFiles);
+      }
+    },
+    [uploadFiles]
+  );
+
+  const { getRootProps, getInputProps, isDragActive } = useDropzone({
+    onDrop,
+    accept: { 'image/*': [] },
+    disabled: areAttachmentInputsDisabled,
+    noClick: true,
+    noKeyboard: true,
   });
 
   // Handle edit submission


### PR DESCRIPTION
## What changed
- Updated the session chat input controls so image insertion actions are no longer disabled just because an agent run is active.
- In `packages/ui/src/components/SessionChatBox.tsx`, introduced `areContentInsertActionsDisabled = isDisabled || isQueued` and applied it to:
  - the paperclip attach button
  - the "Add PR comments" insert button
- In `packages/web-core/src/features/workspace-chat/ui/SessionChatBoxContainer.tsx`, replaced the dropzone disable condition with `areAttachmentInputsDisabled`, which is disabled only for non-editable/transient states (`placeholder`, `queued`, `sending`, `stopping`, or submit-in-flight approval/feedback/edit states).

## Why
Users reported that while an agent response was processing, attach and drag-and-drop were blocked even though composing a follow-up was otherwise possible. This created an inconsistent UX where paste-based image insertion could work while other attachment entry points were disabled.

This change aligns all attachment entry points with the actual draft-editability model: allow adding content while an agent is running, but keep lockouts where the draft is not stable or is being submitted.

## Important implementation details
- `running` is no longer treated as a blanket disable for image attachment inputs.
- `queued` remains blocked for insertion actions to avoid conflicts with queued message state.
- Submission-related states (`sending`, `stopping`, approval/feedback/edit submit flows) still block image insertion.
- Existing behavior for unrelated toolbar actions that are intentionally disabled during running is unchanged.

This PR was written using [Vibe Kanban](https://vibekanban.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only gating changes to attachment inputs; low blast radius, with main risk being unintended uploads in edge execution states.
> 
> **Overview**
> Enables image attachment insertion while an agent run is *active* by relaxing disable rules for the paperclip button, “Insert PR comments”, and drag-and-drop uploads.
> 
> `SessionChatBox` now disables these content-insert actions only when the chat is generally disabled or `queued` (not merely `running`), and `SessionChatBoxContainer` centralizes dropzone disabling into `areAttachmentInputsDisabled` to block only placeholder/queued/sending/stopping and in-flight feedback/edit/approval submissions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 983de9062f490d638077d4f8ded8fdf37cad1902. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->