### PR TITLE
fix(codex): explicitly set collaboration mode and plan flag on mode switch

### DIFF
--- a/crates/executors/src/executors/codex.rs
+++ b/crates/executors/src/executors/codex.rs
@@ -197,11 +197,13 @@ impl StandardCodingAgentExecutor for Codex {
             match permission_policy {
                 crate::model_selector::PermissionPolicy::Auto => {
                     self.ask_for_approval = Some(AskForApproval::Never);
+                    self.plan = false;
                 }
                 crate::model_selector::PermissionPolicy::Supervised => {
                     if matches!(self.ask_for_approval, None | Some(AskForApproval::Never)) {
                         self.ask_for_approval = Some(AskForApproval::UnlessTrusted);
                     }
+                    self.plan = false;
                 }
                 crate::model_selector::PermissionPolicy::Plan => {
                     self.plan = true;
@@ -581,7 +583,7 @@ impl Codex {
                     text: combined_prompt,
                     text_elements: vec![],
                 }],
-                collaboration_mode,
+                Some(collaboration_mode),
             )
             .await?;
 

--- a/crates/executors/src/executors/codex/client.rs
+++ b/crates/executors/src/executors/codex/client.rs
@@ -192,11 +192,11 @@ impl AppServerClient {
         })
     }
 
-    pub fn initial_collaboration_mode(&self) -> Result<Option<CollaborationMode>, ExecutorError> {
+    pub fn initial_collaboration_mode(&self) -> Result<CollaborationMode, ExecutorError> {
         if self.plan_mode {
-            Ok(Some(self.collaboration_mode(ModeKind::Plan)?))
+            self.collaboration_mode(ModeKind::Plan)
         } else {
-            Ok(None)
+            self.collaboration_mode(ModeKind::Default)
         }
     }
 


### PR DESCRIPTION
When retrying after switching from plan to non-plan mode, the collaboration mode was left as None, causing Codex to fallback to plan mode from session history.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts Codex session mode selection by always sending an explicit `collaboration_mode` and resetting `plan` when switching to `Auto`/`Supervised`, which could change agent behavior across retries/mode changes. Scope is small but touches core executor control flow for planning vs default turns.
> 
> **Overview**
> Fixes a mode-switch bug where retrying after leaving plan mode could implicitly fall back to plan mode via session history by **always providing an explicit `CollaborationMode`** on `turn/start`.
> 
> Updates `AppServerClient::initial_collaboration_mode` to always return either `Plan` or `Default` (no `None` case), and ensures `Codex::apply_overrides` **clears `plan`** when `permission_policy` is `Auto` or `Supervised` so config changes reliably take effect.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f37d5e53e83e269298e466976f69118928d23ff3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->