### PR TITLE
chore: use `cargo-chef` to precompile dependencies

### DIFF
--- a/crates/relay-tunnel/Dockerfile
+++ b/crates/relay-tunnel/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.6
 
-FROM rust:1.93-slim-bookworm AS builder
+FROM rust:1.93-slim-bookworm AS rust-base
 
 ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
 ENV CARGO_TARGET_DIR=/app/target
@@ -13,9 +13,11 @@ WORKDIR /app
 
 COPY rust-toolchain.toml ./
 RUN cargo --version >/dev/null
+RUN --mount=type=cache,id=cargo-registry,sharing=locked,target=/usr/local/cargo/registry \
+    --mount=type=cache,id=cargo-git,sharing=locked,target=/usr/local/cargo/git \
+    cargo install cargo-chef --locked
 COPY Cargo.toml Cargo.lock ./
-# Copy workspace member manifests so Cargo can resolve workspace-shared deps
-# without invalidating the build on every unrelated source change.
+# Copy workspace member manifests so Cargo can resolve workspace-shared deps.
 COPY crates/server/Cargo.toml crates/server/Cargo.toml
 COPY crates/trusted-key-auth/Cargo.toml crates/trusted-key-auth/Cargo.toml
 COPY crates/mcp/Cargo.toml crates/mcp/Cargo.toml
@@ -35,11 +37,27 @@ COPY crates/review/Cargo.toml crates/review/Cargo.toml
 COPY crates/api-types crates/api-types
 COPY crates/relay-tunnel crates/relay-tunnel
 
+FROM rust-base AS planner
+
+RUN cargo chef prepare --recipe-path recipe.json --bin relay-server --features server
+
+FROM rust-base AS cacher
+
+COPY --from=planner /app/recipe.json recipe.json
+
+RUN --mount=type=cache,id=cargo-registry,sharing=locked,target=/usr/local/cargo/registry \
+    --mount=type=cache,id=cargo-git,sharing=locked,target=/usr/local/cargo/git \
+    --mount=type=cache,id=relay-target,sharing=locked,target=/app/target \
+    cargo chef cook --locked --release --recipe-path recipe.json \
+      --bin relay-server --features server
+
+FROM rust-base AS builder
+
 RUN mkdir -p /app/bin
 
-RUN --mount=type=cache,id=cargo-registry,target=/usr/local/cargo/registry \
-    --mount=type=cache,id=cargo-git,target=/usr/local/cargo/git \
-    --mount=type=cache,id=relay-target,target=/app/target \
+RUN --mount=type=cache,id=cargo-registry,sharing=locked,target=/usr/local/cargo/registry \
+    --mount=type=cache,id=cargo-git,sharing=locked,target=/usr/local/cargo/git \
+    --mount=type=cache,id=relay-target,sharing=locked,target=/app/target \
     cargo build --locked --release --manifest-path crates/relay-tunnel/Cargo.toml --features server \
  && cp /app/target/release/relay-server /app/bin/relay-server
 

--- a/crates/remote/Dockerfile
+++ b/crates/remote/Dockerfile
@@ -32,7 +32,7 @@ COPY shared/ shared/
 
 RUN pnpm -C packages/remote-web build
 
-FROM rust:1.93-slim-bookworm AS builder
+FROM rust:1.93-slim-bookworm AS rust-base
 ARG APP_NAME
 ARG FEATURES
 ARG POSTHOG_API_KEY=""
@@ -58,9 +58,11 @@ WORKDIR /app
 
 COPY rust-toolchain.toml ./
 RUN cargo --version >/dev/null
+RUN --mount=type=cache,id=cargo-registry,sharing=locked,target=/usr/local/cargo/registry \
+    --mount=type=cache,id=cargo-git,sharing=locked,target=/usr/local/cargo/git \
+    cargo install cargo-chef --locked
 COPY Cargo.toml Cargo.lock ./
-# Copy workspace member manifests so Cargo can resolve workspace-shared deps
-# without invalidating the build on every unrelated source change.
+# Copy workspace member manifests so Cargo can resolve workspace-shared deps.
 COPY crates/server/Cargo.toml crates/server/Cargo.toml
 COPY crates/trusted-key-auth/Cargo.toml crates/trusted-key-auth/Cargo.toml
 COPY crates/mcp/Cargo.toml crates/mcp/Cargo.toml
@@ -81,6 +83,31 @@ COPY crates/remote crates/remote
 COPY crates/utils crates/utils
 COPY assets assets
 
+FROM rust-base AS planner
+
+# Match the real build graph before generating the cargo-chef recipe.
+RUN if [ -z "${FEATURES}" ]; then \
+      sed -i '/^billing = {.*vibe-kanban-private.*/d' crates/remote/Cargo.toml; \
+      sed -i '/^# private crate for billing/d' crates/remote/Cargo.toml; \
+      sed -i 's/^vk-billing = \["dep:billing"\]/vk-billing = []/' crates/remote/Cargo.toml; \
+      rm -f crates/remote/Cargo.lock; \
+    fi
+
+RUN cargo chef prepare --recipe-path recipe.json --bin ${APP_NAME} ${FEATURES:+--features ${FEATURES}}
+
+FROM rust-base AS cacher
+
+COPY --from=planner /app/recipe.json recipe.json
+
+RUN --mount=type=cache,id=cargo-registry,sharing=locked,target=/usr/local/cargo/registry \
+    --mount=type=cache,id=cargo-git,sharing=locked,target=/usr/local/cargo/git \
+    --mount=type=cache,id=remote-target,sharing=locked,target=/app/target \
+    --mount=type=ssh \
+    cargo chef cook ${FEATURES:+--locked} --release --recipe-path recipe.json \
+      --bin ${APP_NAME} ${FEATURES:+--features ${FEATURES}}
+
+FROM rust-base AS builder
+
 RUN mkdir -p /app/bin
 
 # When building without FEATURES (self-hosted), strip the private billing dependency
@@ -93,9 +120,9 @@ RUN if [ -z "${FEATURES}" ]; then \
       rm -f crates/remote/Cargo.lock; \
     fi
 
-RUN --mount=type=cache,id=cargo-registry,target=/usr/local/cargo/registry \
-    --mount=type=cache,id=cargo-git,target=/usr/local/cargo/git \
-    --mount=type=cache,id=remote-target,target=/app/target \
+RUN --mount=type=cache,id=cargo-registry,sharing=locked,target=/usr/local/cargo/registry \
+    --mount=type=cache,id=cargo-git,sharing=locked,target=/usr/local/cargo/git \
+    --mount=type=cache,id=remote-target,sharing=locked,target=/app/target \
     --mount=type=ssh \
     cargo build ${FEATURES:+--locked} --release --manifest-path crates/remote/Cargo.toml ${FEATURES:+--features ${FEATURES}} \
  && cp /app/target/release/${APP_NAME} /app/bin/${APP_NAME}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the Docker build pipeline for `remote` and `relay-tunnel` to use `cargo-chef`, which can break CI/image builds if the recipe generation, feature flags, or cache mounts don’t match the real build graph (especially around the optional private billing dependency).
> 
> **Overview**
> Speeds up Rust Docker builds for `relay-tunnel` and `remote` by refactoring the Rust stages into `rust-base` + `planner`/`cacher`/`builder` stages using `cargo-chef` to precompile dependencies.
> 
> Updates cache mounts to use `sharing=locked` and, for `remote`, ensures the `cargo-chef` recipe is generated with the same conditional removal of the private billing dependency when `FEATURES` is empty.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 03fe0fce5daf41f1baa5e145c551d173a1c7c232. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->