### PR TITLE
fix: show user message for first turn with parallel setup scripts (Vibe Kanban)

### DIFF
--- a/packages/web-core/src/features/workspace-chat/model/hooks/useConversationHistory.ts
+++ b/packages/web-core/src/features/workspace-chat/model/hooks/useConversationHistory.ts
@@ -212,7 +212,9 @@ export const useConversationHistory = ({
       // next_action = null, so extractPromptFromActionChain returns null for
       // them; in that case we fall back to emitting from the coding-agent
       // branch as usual.
-      const hasSetupScriptWithPrompt = Object.values(executionProcessState).some(
+      const hasSetupScriptWithPrompt = Object.values(
+        executionProcessState
+      ).some(
         (p) =>
           p.executionProcess.executor_action.typ.type === 'ScriptRequest' &&
           p.executionProcess.executor_action.typ.context === 'SetupScript' &&


### PR DESCRIPTION
## What changed

In `packages/web-core/src/features/workspace-chat/model/hooks/useConversationHistory.ts`:

- Renamed the guard variable `hasSetupScriptProcess` → `hasSetupScriptWithPrompt` and added a check that the setup script's `next_action` chain actually contains a coding-agent prompt (via `extractPromptFromActionChain`).
- Updated `isInitialWithSetup` to use the new variable, so the coding-agent branch only suppresses its user-message emission when the setup-script branch can actually provide that message.

## Why

PR #2938 moved the initial user-message emission from the `CodingAgentInitialRequest` branch to the `ScriptRequest` branch to prevent a Virtuoso list-reorder glitch. The mechanism works by:

1. Suppressing the user message in the coding-agent branch when a setup script exists (`hasSetupScriptProcess = true`).
2. Re-emitting it from the setup-script branch by walking `executor_action.next_action` to find the prompt.

This works for **sequential** setup scripts (the default, `parallel_setup_script = false`) because the backend chains `ScriptRequest → CodingAgentInitialRequest` via `next_action`, so `extractPromptFromActionChain` can recover the prompt.

It **broke** for **parallel** setup scripts (`parallel_setup_script = true`). In parallel mode the backend starts each setup script independently with `next_action = null`, so `extractPromptFromActionChain` returns `null`. The user message was suppressed from the coding-agent branch but could never be emitted from the setup-script branch — causing the first-turn user message to disappear entirely.

## Implementation detail

The fix is minimal: gate the suppression on whether the setup script can *actually provide* the prompt, rather than on whether a setup script merely exists. For parallel-mode workspaces `hasSetupScriptWithPrompt` is `false`, so the user message falls through to the normal coding-agent branch unchanged.

| Scenario | `hasSetupScriptWithPrompt` | User message source |
|---|---|---|
| No setup script | `false` | coding-agent branch |
| Sequential setup script (default) | `true` | setup-script branch (after script finishes) |
| Parallel setup script (`parallel_setup_script = true`) | `false` | coding-agent branch |
| Sequential setup script **fails** (no coding-agent process) | `true` | setup-script branch |

---

This PR was written using [Vibe Kanban](https://vibekanban.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, localized change to client-side conversation history emission logic; main risk is unintended message ordering/duplication in edge cases around setup scripts.
> 
> **Overview**
> Ensures the first-turn user message is only suppressed when a `SetupScript` can actually supply the initial prompt via its `next_action` chain.
> 
> This changes the guard from “any setup script exists” to “setup script with extractable prompt exists”, restoring the initial user message for parallel setup scripts where `next_action` is `null` while preserving the existing Virtuoso reorder avoidance for sequential setup scripts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e0aa4c8aec21a0708c8c2b220d7aa00b4785e395. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->