### PR TITLE
fix: place auto-moved issues at top of target column

### DIFF
--- a/crates/remote/src/db/issues.rs
+++ b/crates/remote/src/db/issues.rs
@@ -358,6 +358,17 @@ impl IssueRepository {
             return Ok(());
         }
 
+        // Place the issue at the top of the target column by finding the
+        // minimum sort_order in that column and going one below it.
+        let min_sort_order: Option<f64> = sqlx::query_scalar(
+            "SELECT MIN(sort_order) FROM issues WHERE status_id = $1 AND project_id = $2",
+        )
+        .bind(target_status.id)
+        .bind(issue.project_id)
+        .fetch_one(pool)
+        .await?;
+        let top_sort_order = min_sort_order.map(|m| m - 1.0).unwrap_or(0.0);
+
         Self::update(
             pool,
             issue_id,
@@ -368,7 +379,7 @@ impl IssueRepository {
             None,
             None,
             None,
-            None,
+            Some(top_sort_order),
             None,
             None,
             None,

--- a/package.json
+++ b/package.json
@@ -44,6 +44,9 @@
     "remote:prepare-db": "cd crates/remote && bash scripts/prepare-db.sh",
     "remote:prepare-db:check": "cd crates/remote && bash scripts/prepare-db.sh --check"
   },
+  "dependencies": {
+    "adm-zip": "^0.5.16"
+  },
   "devDependencies": {
     "bippy": "0.5.28",
     "concurrently": "^8.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      adm-zip:
+        specifier: ^0.5.16
+        version: 0.5.16
     devDependencies:
       bippy:
         specifier: 0.5.28
@@ -2695,6 +2699,10 @@ packages:
     resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  adm-zip@0.5.16:
+    resolution: {integrity: sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==}
+    engines: {node: '>=12.0'}
 
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
@@ -6462,6 +6470,8 @@ snapshots:
       acorn: 8.15.0
 
   acorn@8.15.0: {}
+
+  adm-zip@0.5.16: {}
 
   agent-base@6.0.2:
     dependencies:


### PR DESCRIPTION
## Summary
- When issues are auto-moved to a new column (e.g. "Done" after merging, "In review" after PR opened), they now go to the **top** of the target column instead of an arbitrary position.
- Queries for the minimum `sort_order` in the target column and sets the moved issue's sort_order to `min - 1`, ensuring reverse-chronological ordering.

Closes #3116

## Test plan
- [ ] Merge a PR linked to a ticket and verify the ticket appears at the top of the Done column
- [ ] Open a PR linked to a ticket and verify the ticket appears at the top of the In Review column
- [ ] Verify drag-and-drop reordering within columns still works correctly