### PR TITLE
feat: add Devin CLI executor support

### DIFF
--- a/crates/executors/default_profiles.json
+++ b/crates/executors/default_profiles.json
@@ -63,6 +63,13 @@
           "autonomy": "skip-permissions-unsafe"
         }
       }
+    },
+    "DEVIN_CLI": {
+      "DEFAULT": {
+        "DEVIN_CLI": {
+          "permission_mode": "dangerous"
+        }
+      }
     }
   }
 }

--- a/crates/executors/src/executors/devin_cli.rs
+++ b/crates/executors/src/executors/devin_cli.rs
@@ -1,0 +1,255 @@
+pub mod normalize_logs;
+
+use std::{
+    path::{Path, PathBuf},
+    process::Stdio,
+    sync::Arc,
+};
+
+use async_trait::async_trait;
+use command_group::AsyncCommandGroup;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use strum_macros::AsRefStr;
+use tokio::process::Command;
+use ts_rs::TS;
+use workspace_utils::msg_store::MsgStore;
+
+use self::normalize_logs::normalize_logs;
+use crate::{
+    command::{CmdOverrides, CommandBuildError, CommandBuilder, CommandParts, apply_overrides},
+    env::ExecutionEnv,
+    executor_discovery::ExecutorDiscoveredOptions,
+    executors::{
+        AppendPrompt, AvailabilityInfo, BaseCodingAgent, ExecutorError, SlashCommandDescription,
+        SpawnedChild, StandardCodingAgentExecutor,
+    },
+    logs::utils::{EntryIndexProvider, patch},
+    model_selector::{ModelInfo, ModelSelectorConfig, PermissionPolicy},
+    profile::ExecutorConfig,
+};
+
+/// Permission mode for Devin CLI
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, TS, JsonSchema, AsRefStr)]
+#[serde(rename_all = "lowercase")]
+#[strum(serialize_all = "lowercase")]
+pub enum DevinPermissionMode {
+    /// Default: auto-approve read-only tools, ask for write/execute
+    Auto,
+    /// Auto-approve all tools including writes and shell commands
+    Dangerous,
+}
+
+fn default_permission_mode() -> DevinPermissionMode {
+    DevinPermissionMode::Dangerous
+}
+
+/// Devin CLI executor configuration
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, TS, JsonSchema)]
+pub struct DevinCli {
+    #[serde(default)]
+    pub append_prompt: AppendPrompt,
+
+    #[serde(default = "default_permission_mode")]
+    #[schemars(
+        title = "Permission Mode",
+        description = "Permission mode: auto (ask for writes) or dangerous (auto-approve all)"
+    )]
+    pub permission_mode: DevinPermissionMode,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(
+        title = "Model",
+        description = "Model to use (e.g., opus, sonnet, swe, codex, gemini)"
+    )]
+    pub model: Option<String>,
+
+    #[serde(flatten)]
+    pub cmd: CmdOverrides,
+}
+
+impl DevinCli {
+    pub fn base_command() -> &'static str {
+        "devin"
+    }
+
+    fn build_command_builder(&self) -> Result<CommandBuilder, CommandBuildError> {
+        let mut builder = CommandBuilder::new(Self::base_command()).params(["-p"]);
+
+        builder = builder.extend_params(["--permission-mode", self.permission_mode.as_ref()]);
+
+        if let Some(model) = &self.model {
+            builder = builder.extend_params(["--model", model.as_str()]);
+        }
+
+        apply_overrides(builder, &self.cmd)
+    }
+}
+
+async fn spawn_devin(
+    command_parts: CommandParts,
+    prompt: &str,
+    current_dir: &Path,
+    env: &ExecutionEnv,
+    cmd_overrides: &CmdOverrides,
+) -> Result<SpawnedChild, ExecutorError> {
+    let (program_path, mut args) = command_parts.into_resolved().await?;
+
+    // Append `--` separator and prompt as positional arguments
+    args.push("--".to_string());
+    args.push(prompt.to_string());
+
+    let mut command = Command::new(program_path);
+    command
+        .kill_on_drop(true)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .current_dir(current_dir)
+        .env("NO_COLOR", "1")
+        .args(&args);
+
+    env.clone()
+        .with_profile(cmd_overrides)
+        .apply_to_command(&mut command);
+
+    let child = command.group_spawn()?;
+
+    Ok(child.into())
+}
+
+#[async_trait]
+impl StandardCodingAgentExecutor for DevinCli {
+    fn apply_overrides(&mut self, executor_config: &ExecutorConfig) {
+        if let Some(model_id) = &executor_config.model_id {
+            self.model = Some(model_id.clone());
+        }
+        if let Some(permission_policy) = executor_config.permission_policy.clone() {
+            self.permission_mode = match permission_policy {
+                PermissionPolicy::Auto => DevinPermissionMode::Dangerous,
+                PermissionPolicy::Supervised | PermissionPolicy::Plan => DevinPermissionMode::Auto,
+            };
+        }
+    }
+
+    async fn spawn(
+        &self,
+        current_dir: &Path,
+        prompt: &str,
+        env: &ExecutionEnv,
+    ) -> Result<SpawnedChild, ExecutorError> {
+        let devin_command = self.build_command_builder()?.build_initial()?;
+        let combined_prompt = self.append_prompt.combine_prompt(prompt);
+
+        spawn_devin(devin_command, &combined_prompt, current_dir, env, &self.cmd).await
+    }
+
+    async fn spawn_follow_up(
+        &self,
+        current_dir: &Path,
+        prompt: &str,
+        session_id: &str,
+        _reset_to_message_id: Option<&str>,
+        env: &ExecutionEnv,
+    ) -> Result<SpawnedChild, ExecutorError> {
+        let continue_cmd = self
+            .build_command_builder()?
+            .build_follow_up(&["-r".to_string(), session_id.to_string()])?;
+        let combined_prompt = self.append_prompt.combine_prompt(prompt);
+
+        spawn_devin(continue_cmd, &combined_prompt, current_dir, env, &self.cmd).await
+    }
+
+    fn normalize_logs(
+        &self,
+        msg_store: Arc<MsgStore>,
+        current_dir: &Path,
+    ) -> Vec<tokio::task::JoinHandle<()>> {
+        normalize_logs(
+            msg_store.clone(),
+            current_dir,
+            EntryIndexProvider::start_from(&msg_store),
+        )
+    }
+
+    fn default_mcp_config_path(&self) -> Option<PathBuf> {
+        dirs::config_dir().map(|config| config.join("cognition").join("config.json"))
+    }
+
+    fn get_availability_info(&self) -> AvailabilityInfo {
+        // Check if the config directory exists as an indicator of installation
+        let config_found = dirs::config_dir()
+            .map(|config| config.join("cognition").exists())
+            .unwrap_or(false);
+
+        if config_found {
+            AvailabilityInfo::InstallationFound
+        } else {
+            AvailabilityInfo::NotFound
+        }
+    }
+
+    fn get_preset_options(&self) -> ExecutorConfig {
+        let permission_policy = if matches!(self.permission_mode, DevinPermissionMode::Dangerous) {
+            PermissionPolicy::Auto
+        } else {
+            PermissionPolicy::Supervised
+        };
+
+        ExecutorConfig {
+            executor: BaseCodingAgent::DevinCli,
+            variant: None,
+            model_id: self.model.clone(),
+            agent_id: None,
+            reasoning_id: None,
+            permission_policy: Some(permission_policy),
+        }
+    }
+
+    async fn discover_options(
+        &self,
+        _workdir: Option<&Path>,
+        _repo_path: Option<&Path>,
+    ) -> Result<futures::stream::BoxStream<'static, json_patch::Patch>, ExecutorError> {
+        let options = ExecutorDiscoveredOptions {
+            model_selector: ModelSelectorConfig {
+                models: [
+                    ("opus", "Claude Opus 4.6"),
+                    ("sonnet", "Claude Sonnet 4.5"),
+                    ("swe", "SWE 1.5"),
+                    ("codex", "Codex 5.3"),
+                    ("gemini", "Gemini 3 Pro"),
+                    ("gemini-3-flash", "Gemini 3 Flash"),
+                ]
+                .into_iter()
+                .map(|(id, name)| ModelInfo {
+                    id: id.to_string(),
+                    name: name.to_string(),
+                    provider_id: None,
+                    reasoning_options: vec![],
+                })
+                .collect(),
+                permissions: vec![PermissionPolicy::Auto, PermissionPolicy::Supervised],
+                ..Default::default()
+            },
+            slash_commands: vec![
+                SlashCommandDescription {
+                    name: "mode".to_string(),
+                    description: Some("show or switch mode (normal, plan, bypass)".to_string()),
+                },
+                SlashCommandDescription {
+                    name: "model".to_string(),
+                    description: Some("show or change the current model".to_string()),
+                },
+                SlashCommandDescription {
+                    name: "compact".to_string(),
+                    description: Some("force conversation compaction".to_string()),
+                },
+            ],
+            ..Default::default()
+        };
+        Ok(Box::pin(futures::stream::once(async move {
+            patch::executor_discovered_options(options)
+        })))
+    }
+}

--- a/crates/executors/src/executors/devin_cli/normalize_logs.rs
+++ b/crates/executors/src/executors/devin_cli/normalize_logs.rs
@@ -1,0 +1,77 @@
+use std::{sync::Arc, time::Duration};
+
+use futures::StreamExt;
+use workspace_utils::msg_store::MsgStore;
+
+use crate::logs::{
+    NormalizedEntry, NormalizedEntryError, NormalizedEntryType,
+    plain_text_processor::PlainTextLogProcessor, utils::EntryIndexProvider,
+};
+
+pub fn normalize_logs(
+    msg_store: Arc<MsgStore>,
+    _worktree_path: &std::path::Path,
+    entry_index_provider: EntryIndexProvider,
+) -> Vec<tokio::task::JoinHandle<()>> {
+    let h1 = normalize_stdout_logs(msg_store.clone(), entry_index_provider.clone());
+    let h2 = normalize_stderr_logs(msg_store, entry_index_provider);
+    vec![h1, h2]
+}
+
+/// Normalize Devin CLI stdout output as assistant messages.
+///
+/// Devin CLI in print mode (`-p`) outputs its response as plain text to stdout.
+fn normalize_stdout_logs(
+    msg_store: Arc<MsgStore>,
+    entry_index_provider: EntryIndexProvider,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut stdout = msg_store.stdout_chunked_stream();
+
+        let mut processor = PlainTextLogProcessor::builder()
+            .normalized_entry_producer(Box::new(|content: String| NormalizedEntry {
+                timestamp: None,
+                entry_type: NormalizedEntryType::AssistantMessage,
+                content: strip_ansi_escapes::strip_str(&content),
+                metadata: None,
+            }))
+            .time_gap(Duration::from_secs(3))
+            .index_provider(entry_index_provider)
+            .build();
+
+        while let Some(Ok(chunk)) = stdout.next().await {
+            for patch in processor.process(chunk) {
+                msg_store.push_patch(patch);
+            }
+        }
+    })
+}
+
+/// Normalize Devin CLI stderr output as error messages.
+fn normalize_stderr_logs(
+    msg_store: Arc<MsgStore>,
+    entry_index_provider: EntryIndexProvider,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut stderr = msg_store.stderr_chunked_stream();
+
+        let mut processor = PlainTextLogProcessor::builder()
+            .normalized_entry_producer(Box::new(|content: String| NormalizedEntry {
+                timestamp: None,
+                entry_type: NormalizedEntryType::ErrorMessage {
+                    error_type: NormalizedEntryError::Other,
+                },
+                content: strip_ansi_escapes::strip_str(&content),
+                metadata: None,
+            }))
+            .time_gap(Duration::from_secs(2))
+            .index_provider(entry_index_provider)
+            .build();
+
+        while let Some(Ok(chunk)) = stderr.next().await {
+            for patch in processor.process(chunk) {
+                msg_store.push_patch(patch);
+            }
+        }
+    })
+}

--- a/crates/executors/src/executors/mod.rs
+++ b/crates/executors/src/executors/mod.rs
@@ -23,7 +23,7 @@ use crate::{
     env::ExecutionEnv,
     executors::{
         amp::Amp, claude::ClaudeCode, codex::Codex, copilot::Copilot, cursor::CursorAgent,
-        droid::Droid, gemini::Gemini, opencode::Opencode, qwen::QwenCode,
+        devin_cli::DevinCli, droid::Droid, gemini::Gemini, opencode::Opencode, qwen::QwenCode,
     },
     logs::utils::patch,
     mcp_config::McpConfig,
@@ -36,6 +36,7 @@ pub mod claude;
 pub mod codex;
 pub mod copilot;
 pub mod cursor;
+pub mod devin_cli;
 pub mod droid;
 pub mod gemini;
 pub mod opencode;
@@ -119,6 +120,7 @@ pub enum CodingAgent {
     QwenCode,
     Copilot,
     Droid,
+    DevinCli,
     #[cfg(feature = "qa-mode")]
     QaMock(QaMockExecutor),
 }
@@ -192,6 +194,10 @@ impl CodingAgent {
             Self::Gemini(_) | Self::QwenCode(_) => {
                 vec![BaseAgentCapability::SessionFork]
             }
+            Self::DevinCli(_) => vec![
+                BaseAgentCapability::SessionFork,
+                BaseAgentCapability::SetupHelper,
+            ],
             Self::CursorAgent(_) => vec![BaseAgentCapability::SetupHelper],
             Self::Amp(_) | Self::Copilot(_) | Self::Droid(_) => vec![],
             #[cfg(feature = "qa-mode")]

--- a/crates/executors/src/mcp_config.rs
+++ b/crates/executors/src/mcp_config.rs
@@ -397,7 +397,10 @@ impl CodingAgent {
         use Adapter::*;
 
         let adapter = match self {
-            CodingAgent::ClaudeCode(_) | CodingAgent::Amp(_) | CodingAgent::Droid(_) => Passthrough,
+            CodingAgent::ClaudeCode(_)
+            | CodingAgent::Amp(_)
+            | CodingAgent::Droid(_)
+            | CodingAgent::DevinCli(_) => Passthrough,
             CodingAgent::QwenCode(_) | CodingAgent::Gemini(_) => Gemini,
             CodingAgent::CursorAgent(_) => Cursor,
             CodingAgent::Codex(_) => Codex,

--- a/crates/server/src/bin/generate_types.rs
+++ b/crates/server/src/bin/generate_types.rs
@@ -225,6 +225,8 @@ fn generate_types_content() -> String {
         executors::executors::droid::Droid::decl(),
         executors::executors::droid::Autonomy::decl(),
         executors::executors::droid::ReasoningEffortLevel::decl(),
+        executors::executors::devin_cli::DevinCli::decl(),
+        executors::executors::devin_cli::DevinPermissionMode::decl(),
         executors::executors::AppendPrompt::decl(),
         executors::actions::coding_agent_initial::CodingAgentInitialRequest::decl(),
         executors::actions::coding_agent_follow_up::CodingAgentFollowUpRequest::decl(),
@@ -337,6 +339,10 @@ fn generate_schemas() -> Result<HashMap<&'static str, String>, serde_json::Error
         (
             "droid",
             generate_json_schema::<executors::executors::droid::Droid>()?,
+        ),
+        (
+            "devin_cli",
+            generate_json_schema::<executors::executors::devin_cli::DevinCli>()?,
         ),
     ]);
     println!(

--- a/crates/server/src/routes/workspaces/devin_cli_setup.rs
+++ b/crates/server/src/routes/workspaces/devin_cli_setup.rs
@@ -1,0 +1,99 @@
+use db::models::{
+    execution_process::{ExecutionProcess, ExecutionProcessRunReason},
+    session::{CreateSession, Session},
+    workspace::{Workspace, WorkspaceError},
+};
+use deployment::Deployment;
+use executors::{
+    actions::{
+        ExecutorAction, ExecutorActionType,
+        script::{ScriptContext, ScriptRequest, ScriptRequestLanguage},
+    },
+    command::{CommandBuilder, apply_overrides},
+    executors::{ExecutorError, devin_cli::DevinCli},
+};
+use services::services::container::ContainerService;
+use uuid::Uuid;
+
+use crate::error::ApiError;
+
+pub async fn run_devin_cli_setup(
+    deployment: &crate::DeploymentImpl,
+    workspace: &Workspace,
+    devin_cli: &DevinCli,
+) -> Result<ExecutionProcess, ApiError> {
+    let latest_process = ExecutionProcess::find_latest_by_workspace_and_run_reason(
+        &deployment.db().pool,
+        workspace.id,
+        &ExecutionProcessRunReason::CodingAgent,
+    )
+    .await?;
+
+    let executor_action = if let Some(latest_process) = latest_process {
+        let latest_action = latest_process
+            .executor_action()
+            .map_err(|e| ApiError::Workspace(WorkspaceError::ValidationError(e.to_string())))?;
+        get_setup_helper_action(devin_cli)
+            .await?
+            .append_action(latest_action.to_owned())
+    } else {
+        get_setup_helper_action(devin_cli).await?
+    };
+
+    deployment
+        .container()
+        .ensure_container_exists(workspace)
+        .await?;
+
+    let session =
+        match Session::find_latest_by_workspace_id(&deployment.db().pool, workspace.id).await? {
+            Some(s) => s,
+            None => {
+                Session::create(
+                    &deployment.db().pool,
+                    &CreateSession {
+                        executor: Some("devin_cli".to_string()),
+                    },
+                    Uuid::new_v4(),
+                    workspace.id,
+                )
+                .await?
+            }
+        };
+
+    let execution_process = deployment
+        .container()
+        .start_execution(
+            workspace,
+            &session,
+            &executor_action,
+            &ExecutionProcessRunReason::SetupScript,
+        )
+        .await?;
+    Ok(execution_process)
+}
+
+async fn get_setup_helper_action(devin_cli: &DevinCli) -> Result<ExecutorAction, ApiError> {
+    let mut login_command = CommandBuilder::new(DevinCli::base_command());
+    login_command = login_command.extend_params(["auth", "login", "--force-manual-token-flow"]);
+    login_command = apply_overrides(login_command, &devin_cli.cmd)?;
+
+    let (program_path, args) = login_command
+        .build_initial()
+        .map_err(|err| ApiError::Executor(ExecutorError::from(err)))?
+        .into_resolved()
+        .await
+        .map_err(ApiError::Executor)?;
+    let login_script = format!("{} {}", program_path.to_string_lossy(), args.join(" "));
+    let login_request = ScriptRequest {
+        script: login_script,
+        language: ScriptRequestLanguage::Bash,
+        context: ScriptContext::ToolInstallScript,
+        working_dir: None,
+    };
+
+    Ok(ExecutorAction::new(
+        ExecutorActionType::ScriptRequest(login_request),
+        None,
+    ))
+}

--- a/crates/server/src/routes/workspaces/integration.rs
+++ b/crates/server/src/routes/workspaces/integration.rs
@@ -14,7 +14,7 @@ use services::services::container::ContainerService;
 use ts_rs::TS;
 use utils::response::ApiResponse;
 
-use super::{codex_setup, cursor_setup, gh_cli_setup::GhCliSetupError};
+use super::{codex_setup, cursor_setup, devin_cli_setup, gh_cli_setup::GhCliSetupError};
 use crate::{DeploymentImpl, error::ApiError};
 
 #[derive(Debug, Deserialize, Serialize, TS)]
@@ -58,6 +58,9 @@ pub async fn run_agent_setup(
         }
         CodingAgent::Codex(codex) => {
             codex_setup::run_codex_setup(&deployment, &workspace, &codex).await?;
+        }
+        CodingAgent::DevinCli(devin_cli) => {
+            devin_cli_setup::run_devin_cli_setup(&deployment, &workspace, &devin_cli).await?;
         }
         _ => return Err(ApiError::Executor(ExecutorError::SetupHelperNotSupported)),
     }

--- a/crates/server/src/routes/workspaces/mod.rs
+++ b/crates/server/src/routes/workspaces/mod.rs
@@ -2,6 +2,7 @@ pub mod codex_setup;
 pub mod core;
 pub mod create;
 pub mod cursor_setup;
+pub mod devin_cli_setup;
 pub mod execution;
 pub mod gh_cli_setup;
 pub mod git;

--- a/docs/agents/devin-cli.mdx
+++ b/docs/agents/devin-cli.mdx
@@ -1,0 +1,69 @@
+---
+title: "Devin CLI"
+description: "Set up Devin CLI integration"
+icon: https://www.vibekanban.com/images/logos/cognition-logo.svg
+---
+
+<Steps>
+<Step title="Install Devin CLI">
+  ```bash
+  curl -fsSL https://cli.devin.ai/install.sh | bash
+  ```
+</Step>
+
+<Step title="Authenticate with Devin">
+  Run the login command to authenticate:
+
+  ```bash
+  devin auth login
+  ```
+
+  Alternatively, Vibe Kanban includes a built-in setup helper that will guide you through authentication when you select Devin CLI as your agent.
+
+  <Note>Devin CLI requires a Windsurf Enterprise or Devin Enterprise account.</Note>
+</Step>
+
+<Step title="Start Vibe Kanban">
+  Once authenticated, launch Vibe Kanban:
+
+  ```bash
+  npx vibe-kanban
+  ```
+
+  You can now select Devin CLI when creating task attempts.
+</Step>
+</Steps>
+
+## Configuration Options
+
+Devin CLI can be configured with the following options:
+
+| Option | Values | Default | Description |
+|--------|--------|---------|-------------|
+| `model` | `opus`, `sonnet`, `swe`, `codex`, `gemini` | `opus` | The AI model to use for code generation |
+| `permission_mode` | `auto`, `dangerous` | `dangerous` | `auto` prompts before writes; `dangerous` auto-approves all operations |
+
+## MCP Configuration
+
+Devin CLI stores its MCP configuration at:
+
+```
+~/.config/cognition/config.json
+```
+
+## Session Resumption
+
+Devin CLI supports resuming previous sessions using the `-c` and `-r` flags:
+
+```bash
+# Continue the most recent session
+devin -c
+
+# Resume a specific session by ID
+devin -r <session-id>
+```
+
+This is useful for:
+- Picking up where you left off on a task
+- Reviewing and extending previous agent work
+- Maintaining context across multiple coding sessions

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -43,7 +43,8 @@
               "agents/opencode",
               "agents/droid",
               "agents/ccr",
-              "agents/qwen-code"
+              "agents/qwen-code",
+              "agents/devin-cli"
             ]
           }
         ]

--- a/docs/supported-coding-agents.mdx
+++ b/docs/supported-coding-agents.mdx
@@ -47,4 +47,8 @@ Claude Code Router - orchestrate multiple models
 <Card title="Qwen Code" icon="https://www.vibekanban.com/images/logos/qwen-logo.png#" href="/agents/qwen-code">
 Qwen Code CLI
 </Card>
+
+<Card title="Devin CLI" icon="https://www.vibekanban.com/images/logos/cognition-logo.svg" href="/agents/devin-cli">
+Devin CLI by Cognition
+</Card>
 </CardGroup>

--- a/packages/public/agents/devin-cli-dark.svg
+++ b/packages/public/agents/devin-cli-dark.svg
@@ -1,0 +1,5 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="8" cy="8" r="6" fill="white"/>
+<path d="M6 5H8.5C10.433 5 12 6.567 12 8.5C12 10.433 10.433 12 8.5 12H6V5Z" fill="none" stroke="#1a1a2e" stroke-width="1.5" stroke-linejoin="round"/>
+<line x1="6" y1="5" x2="6" y2="12" stroke="#1a1a2e" stroke-width="1.5" stroke-linecap="round"/>
+</svg>

--- a/packages/public/agents/devin-cli-light.svg
+++ b/packages/public/agents/devin-cli-light.svg
@@ -1,0 +1,5 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="8" cy="8" r="6" fill="#1a1a2e"/>
+<path d="M6 5H8.5C10.433 5 12 6.567 12 8.5C12 10.433 10.433 12 8.5 12H6V5Z" fill="none" stroke="white" stroke-width="1.5" stroke-linejoin="round"/>
+<line x1="6" y1="5" x2="6" y2="12" stroke="white" stroke-width="1.5" stroke-linecap="round"/>
+</svg>

--- a/packages/web-core/src/features/onboarding/ui/LandingPage.tsx
+++ b/packages/web-core/src/features/onboarding/ui/LandingPage.tsx
@@ -87,6 +87,7 @@ const SOUND_OPTIONS: SoundOption[] = [
 const AGENT_PRIORITY: BaseCodingAgent[] = [
   BaseCodingAgent.CLAUDE_CODE,
   BaseCodingAgent.CODEX,
+  BaseCodingAgent.DEVIN_CLI,
   BaseCodingAgent.OPENCODE,
   BaseCodingAgent.GEMINI,
 ];

--- a/packages/web-core/src/i18n/locales/en/settings.json
+++ b/packages/web-core/src/i18n/locales/en/settings.json
@@ -372,7 +372,7 @@
         "addServerFailed": "Failed to add preconfigured server",
         "mcpError": "MCP Configuration Error: {{error}}",
         "notSupported": "MCP Not Supported",
-        "supportMessage": "To use MCP servers, please select a different executor that supports MCP (Claude, Amp, Gemini, Codex, or Opencode) above."
+        "supportMessage": "To use MCP servers, please select a different executor that supports MCP (Claude, Amp, Gemini, Codex, Devin, or Opencode) above."
       },
       "save": {
         "button": "Save MCP Configuration",

--- a/packages/web-core/src/i18n/locales/es/settings.json
+++ b/packages/web-core/src/i18n/locales/es/settings.json
@@ -372,7 +372,7 @@
         "addServerFailed": "Error al agregar servidor preconfigurado",
         "mcpError": "Error de Configuración MCP: {{error}}",
         "notSupported": "MCP No Soportado",
-        "supportMessage": "Para usar servidores MCP, por favor selecciona un agente diferente que soporte MCP (Claude, Amp, Gemini, Codex, o Opencode) arriba."
+        "supportMessage": "Para usar servidores MCP, por favor selecciona un agente diferente que soporte MCP (Claude, Amp, Gemini, Codex, Devin, o Opencode) arriba."
       },
       "save": {
         "button": "Guardar Configuración MCP",

--- a/packages/web-core/src/i18n/locales/fr/settings.json
+++ b/packages/web-core/src/i18n/locales/fr/settings.json
@@ -372,7 +372,7 @@
         "addServerFailed": "Échec de l'ajout du serveur préconfiguré",
         "mcpError": "Erreur de configuration MCP : {{error}}",
         "notSupported": "MCP non pris en charge",
-        "supportMessage": "Pour utiliser les serveurs MCP, veuillez sélectionner un exécuteur différent prenant en charge MCP (Claude, Amp, Gemini, Codex ou Opencode) ci-dessus."
+        "supportMessage": "Pour utiliser les serveurs MCP, veuillez sélectionner un exécuteur différent prenant en charge MCP (Claude, Amp, Gemini, Codex, Devin ou Opencode) ci-dessus."
       },
       "save": {
         "button": "Enregistrer la configuration MCP",

--- a/packages/web-core/src/i18n/locales/ja/settings.json
+++ b/packages/web-core/src/i18n/locales/ja/settings.json
@@ -372,7 +372,7 @@
         "addServerFailed": "事前設定サーバーの追加に失敗しました",
         "mcpError": "MCP設定エラー：{{error}}",
         "notSupported": "MCPはサポートされていません",
-        "supportMessage": "MCPサーバーを使用するには、MCP（Claude、Amp、Gemini、Codex、またはOpencode）をサポートする別の実行器を上記で選択してください。"
+        "supportMessage": "MCPサーバーを使用するには、MCP（Claude、Amp、Gemini、Codex、Devin、またはOpencode）をサポートする別の実行器を上記で選択してください。"
       },
       "save": {
         "button": "MCP設定を保存",

--- a/packages/web-core/src/i18n/locales/ko/settings.json
+++ b/packages/web-core/src/i18n/locales/ko/settings.json
@@ -372,7 +372,7 @@
         "addServerFailed": "미리 구성된 서버를 추가하지 못했습니다",
         "mcpError": "MCP 구성 오류: {{error}}",
         "notSupported": "MCP가 지원되지 않습니다",
-        "supportMessage": "MCP 서버를 사용하려면 위에서 MCP를 지원하는 다른 실행자(Claude, Amp, Gemini, Codex 또는 Opencode)를 선택하세요."
+        "supportMessage": "MCP 서버를 사용하려면 위에서 MCP를 지원하는 다른 실행자(Claude, Amp, Gemini, Codex, Devin 또는 Opencode)를 선택하세요."
       },
       "save": {
         "button": "MCP 구성 저장",

--- a/packages/web-core/src/i18n/locales/zh-Hans/settings.json
+++ b/packages/web-core/src/i18n/locales/zh-Hans/settings.json
@@ -372,7 +372,7 @@
         "addServerFailed": "添加预配置服务器失败",
         "mcpError": "MCP 配置错误：{{error}}",
         "notSupported": "不支持 MCP",
-        "supportMessage": "要使用 MCP 服务器，请在上方选择支持 MCP 的其他执行器（Claude、Amp、Gemini、Codex 或 Opencode）。"
+        "supportMessage": "要使用 MCP 服务器，请在上方选择支持 MCP 的其他执行器（Claude、Amp、Gemini、Codex、Devin 或 Opencode）。"
       },
       "save": {
         "button": "保存 MCP 配置",

--- a/packages/web-core/src/i18n/locales/zh-Hant/settings.json
+++ b/packages/web-core/src/i18n/locales/zh-Hant/settings.json
@@ -372,7 +372,7 @@
         "addServerFailed": "新增預設伺服器失敗",
         "mcpError": "MCP 設定錯誤：{{error}}",
         "notSupported": "不支援 MCP",
-        "supportMessage": "要使用 MCP 伺服器，請在上方選擇支援 MCP 的其他執行器（Claude、Amp、Gemini、Codex 或 Opencode）。"
+        "supportMessage": "要使用 MCP 伺服器，請在上方選擇支援 MCP 的其他執行器（Claude、Amp、Gemini、Codex、Devin 或 Opencode）。"
       },
       "save": {
         "button": "儲存 MCP 設定",

--- a/packages/web-core/src/shared/components/AgentIcon.tsx
+++ b/packages/web-core/src/shared/components/AgentIcon.tsx
@@ -29,6 +29,8 @@ export function getAgentName(
       return 'Copilot';
     case BaseCodingAgent.DROID:
       return 'Droid';
+    case BaseCodingAgent.DEVIN_CLI:
+      return 'Devin';
   }
 }
 
@@ -72,6 +74,9 @@ export function AgentIcon({ agent, className = 'h-4 w-4' }: AgentIconProps) {
       break;
     case BaseCodingAgent.DROID:
       iconPath = `/agents/droid${suffix}.svg`;
+      break;
+    case BaseCodingAgent.DEVIN_CLI:
+      iconPath = `/agents/devin-cli${suffix}.svg`;
       break;
     default:
       return null;

--- a/shared/schemas/devin_cli.json
+++ b/shared/schemas/devin_cli.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "properties": {
+    "append_prompt": {
+      "title": "Append Prompt",
+      "description": "Extra text appended to the prompt",
+      "type": [
+        "string",
+        "null"
+      ],
+      "format": "textarea",
+      "default": null
+    },
+    "permission_mode": {
+      "title": "Permission Mode",
+      "description": "Permission mode: auto (ask for writes) or dangerous (auto-approve all)",
+      "oneOf": [
+        {
+          "description": "Default: auto-approve read-only tools, ask for write/execute",
+          "type": "string",
+          "const": "auto"
+        },
+        {
+          "description": "Auto-approve all tools including writes and shell commands",
+          "type": "string",
+          "const": "dangerous"
+        }
+      ],
+      "default": "dangerous"
+    },
+    "model": {
+      "title": "Model",
+      "description": "Model to use (e.g., opus, sonnet, swe, codex, gemini)",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "base_command_override": {
+      "title": "Base Command Override",
+      "description": "Override the base command with a custom command",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "additional_params": {
+      "title": "Additional Parameters",
+      "description": "Additional parameters to append to the base command",
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": "string"
+      }
+    },
+    "env": {
+      "title": "Environment Variables",
+      "description": "Environment variables to set when running the executor",
+      "type": [
+        "object",
+        "null"
+      ],
+      "additionalProperties": {
+        "type": "string"
+      }
+    }
+  },
+  "description": "Devin CLI executor configuration",
+  "type": "object"
+}

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -561,9 +561,9 @@ working_dir: string | null, };
 
 export type ScriptRequestLanguage = "Bash";
 
-export enum BaseCodingAgent { CLAUDE_CODE = "CLAUDE_CODE", AMP = "AMP", GEMINI = "GEMINI", CODEX = "CODEX", OPENCODE = "OPENCODE", CURSOR_AGENT = "CURSOR_AGENT", QWEN_CODE = "QWEN_CODE", COPILOT = "COPILOT", DROID = "DROID" }
+export enum BaseCodingAgent { CLAUDE_CODE = "CLAUDE_CODE", AMP = "AMP", GEMINI = "GEMINI", CODEX = "CODEX", OPENCODE = "OPENCODE", CURSOR_AGENT = "CURSOR_AGENT", QWEN_CODE = "QWEN_CODE", COPILOT = "COPILOT", DROID = "DROID", DEVIN_CLI = "DEVIN_CLI" }
 
-export type CodingAgent = { "CLAUDE_CODE": ClaudeCode } | { "AMP": Amp } | { "GEMINI": Gemini } | { "CODEX": Codex } | { "OPENCODE": Opencode } | { "CURSOR_AGENT": CursorAgent } | { "QWEN_CODE": QwenCode } | { "COPILOT": Copilot } | { "DROID": Droid };
+export type CodingAgent = { "CLAUDE_CODE": ClaudeCode } | { "AMP": Amp } | { "GEMINI": Gemini } | { "CODEX": Codex } | { "OPENCODE": Opencode } | { "CURSOR_AGENT": CursorAgent } | { "QWEN_CODE": QwenCode } | { "COPILOT": Copilot } | { "DROID": Droid } | { "DEVIN_CLI": DevinCli };
 
 export type SlashCommandDescription = { 
 /**
@@ -603,7 +603,7 @@ models?: Array<string>,
  */
 reasoning_by_model?: { [key in string]?: string }, };
 
-export type ExecutorProfile = { recently_used_models?: ExecutorRecentModels | null, } & ({ [key in string]?: { "CLAUDE_CODE": ClaudeCode } | { "AMP": Amp } | { "GEMINI": Gemini } | { "CODEX": Codex } | { "OPENCODE": Opencode } | { "CURSOR_AGENT": CursorAgent } | { "QWEN_CODE": QwenCode } | { "COPILOT": Copilot } | { "DROID": Droid } });
+export type ExecutorProfile = { recently_used_models?: ExecutorRecentModels | null, } & ({ [key in string]?: { "CLAUDE_CODE": ClaudeCode } | { "AMP": Amp } | { "GEMINI": Gemini } | { "CODEX": Codex } | { "OPENCODE": Opencode } | { "CURSOR_AGENT": CursorAgent } | { "QWEN_CODE": QwenCode } | { "COPILOT": Copilot } | { "DROID": Droid } | { "DEVIN_CLI": DevinCli } });
 
 export type ExecutorConfigs = { executors: { [key in BaseCodingAgent]?: ExecutorProfile }, };
 
@@ -650,6 +650,10 @@ export type Droid = { append_prompt: AppendPrompt, autonomy: Autonomy, model?: s
 export type Autonomy = "normal" | "low" | "medium" | "high" | "skip-permissions-unsafe";
 
 export type DroidReasoningEffort = "none" | "dynamic" | "off" | "low" | "medium" | "high";
+
+export type DevinCli = { append_prompt: AppendPrompt, permission_mode: DevinPermissionMode, model?: string | null, base_command_override?: string | null, additional_params?: Array<string> | null, env?: { [key in string]?: string } | null, };
+
+export type DevinPermissionMode = "auto" | "dangerous";
 
 export type AppendPrompt = string | null;
 


### PR DESCRIPTION
Add Devin CLI (https://cli.devin.ai/docs) (Devin for Terminal) as a new coding agent executor, enabling it to be used like Claude Code, Codex, and other supported agents in the vibe-kanban task orchestrator.
<img width="1866" height="944" alt="image" src="https://github.com/user-attachments/assets/dad09d85-524b-4246-ba1b-07532306a27e" />
<img width="837" height="464" alt="image" src="https://github.com/user-attachments/assets/920128f9-4950-47a3-8198-d72c55bd6353" />

Documentation:
- Create docs/agents/devin-cli.mdx with setup instructions
- Add to navigation in docs.json
- Add to supported coding agents list

Generated with [Devin](https://cli.devin.ai/docs)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new executor that spawns an external CLI with potentially auto-approved permissions and introduces a new setup-helper flow, which could affect workspace execution behavior and safety defaults.
> 
> **Overview**
> Adds **Devin CLI** as a first-class coding agent (`DEVIN_CLI`) with configurable `model` and `permission_mode`, including command spawning (`devin -p … -- <prompt>`), follow-up session resume (`-r <session_id>`), and stdout/stderr log normalization into assistant/error entries.
> 
> Wires Devin CLI into executor selection and capabilities (supports *setup helper* and MCP passthrough), adds a workspace setup route to run `devin auth login --force-manual-token-flow`, and updates generated schemas/types, default profiles, UI agent ordering/icons, MCP support copy, and documentation/navigation to expose the new agent.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6c09f57d847f8e1334d90175cd841bac515f9de7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->