### PR TITLE
feat(opencode): handle message.part.delta event type

### DIFF
--- a/crates/executors/src/executors/opencode/normalize_logs.rs
+++ b/crates/executors/src/executors/opencode/normalize_logs.rs
@@ -10,8 +10,9 @@ use workspace_utils::{
 };
 
 use super::types::{
-    MessageInfo, MessageRole, OpencodeExecutorEvent, Part, PermissionAskedEvent, QuestionInfo,
-    SdkEvent, SdkTodo, SessionStatus, ToolPart, ToolStateUpdate,
+    MessageInfo, MessagePartDeltaEvent, MessageRole, OpencodeExecutorEvent, Part,
+    PermissionAskedEvent, QuestionInfo, SdkEvent, SdkTodo, SessionStatus, ToolPart,
+    ToolStateUpdate,
 };
 use crate::{
     approvals::ToolCallMetadata,
@@ -257,6 +258,9 @@ impl LogState {
                     msg_store,
                 );
             }
+            SdkEvent::MessagePartDelta(event) => {
+                self.handle_part_delta(event, msg_store);
+            }
             SdkEvent::TodoUpdated(event) => {
                 self.handle_todo_updated(&event.todos, msg_store);
             }
@@ -472,6 +476,42 @@ impl LogState {
                 }
             }
             Part::Other => {}
+        }
+    }
+
+    fn handle_part_delta(&mut self, event: MessagePartDeltaEvent, msg_store: &Arc<MsgStore>) {
+        match event.field.as_str() {
+            "text" => {
+                // Only stream assistant text; check role if we know it, otherwise assume assistant
+                if self.message_roles.get(&event.message_id) == Some(&MessageRole::User) {
+                    return;
+                }
+                let entry_index = self.entry_index.clone();
+                update_streaming_text(
+                    &entry_index,
+                    &event.delta,
+                    NormalizedEntryType::AssistantMessage,
+                    &event.message_id,
+                    &mut self.assistant_text,
+                    msg_store,
+                    UpdateMode::Append,
+                );
+            }
+            "reasoning" => {
+                let entry_index = self.entry_index.clone();
+                update_streaming_text(
+                    &entry_index,
+                    &event.delta,
+                    NormalizedEntryType::Thinking,
+                    &event.message_id,
+                    &mut self.thinking_text,
+                    msg_store,
+                    UpdateMode::Append,
+                );
+            }
+            _ => {
+                // Silently ignore unknown fields (e.g. future additions)
+            }
         }
     }
 

--- a/crates/executors/src/executors/opencode/types.rs
+++ b/crates/executors/src/executors/opencode/types.rs
@@ -61,6 +61,7 @@ pub(super) struct SdkEventEnvelope {
 pub(super) enum SdkEvent {
     MessageUpdated(MessageUpdatedEvent),
     MessagePartUpdated(MessagePartUpdatedEvent),
+    MessagePartDelta(MessagePartDeltaEvent),
     MessageRemoved,
     MessagePartRemoved,
     PermissionAsked(PermissionAskedEvent),
@@ -89,6 +90,9 @@ impl SdkEvent {
             }
             "message.part.updated" => {
                 SdkEvent::MessagePartUpdated(serde_json::from_value(envelope.properties).ok()?)
+            }
+            "message.part.delta" => {
+                SdkEvent::MessagePartDelta(serde_json::from_value(envelope.properties).ok()?)
             }
             "message.removed" => SdkEvent::MessageRemoved,
             "message.part.removed" => SdkEvent::MessagePartRemoved,
@@ -205,6 +209,18 @@ pub(super) struct MessagePartUpdatedEvent {
     pub(super) part: Part,
     #[serde(default)]
     pub(super) delta: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct MessagePartDeltaEvent {
+    #[serde(rename = "sessionID")]
+    pub(super) session_id: String,
+    #[serde(rename = "messageID")]
+    pub(super) message_id: String,
+    #[serde(rename = "partID")]
+    pub(super) part_id: String,
+    pub(super) field: String,
+    pub(super) delta: String,
 }
 
 #[derive(Debug, Deserialize)]


### PR DESCRIPTION
## Summary

- Add `MessagePartDelta` variant to `SdkEvent` to recognize the new `message.part.delta` event from OpenCode
- Handle text and reasoning field deltas in `normalize_logs.rs` using existing `update_streaming_text` with `Append` mode
- Silently ignore unknown delta fields for forward compatibility

## Problem

OpenCode now emits `message.part.delta` events as a streaming optimization (sends incremental text deltas instead of full `Part` objects on every chunk). Since VK doesn't recognize this event type, two issues appear:

1. **Warning spam**: `Unrecognized OpenCode SDK event type 'message.part.delta': {...}` on every streaming chunk
2. **Garbled text**: Raw JSON payload (containing Unicode text in the `delta` field) rendered as a system message, producing mojibake in the UI

## Changes

**`types.rs`**:
- Added `MessagePartDelta(MessagePartDeltaEvent)` variant to `SdkEvent`
- Added `MessagePartDeltaEvent` struct with `session_id`, `message_id`, `part_id`, `field`, `delta` fields
- Added `"message.part.delta"` match arm in `SdkEvent::parse()`

**`normalize_logs.rs`**:
- Added `handle_part_delta()` method that dispatches on `event.field`:
  - `"text"` → appends delta to assistant streaming text (skips user messages)
  - `"reasoning"` → appends delta to thinking text
  - unknown fields → silently ignored
- Added `SdkEvent::MessagePartDelta` match arm in `handle_sdk_event()`

## Testing

- Compiled successfully with `cargo build --release -p mcp`
- Tested locally by replacing the MCP binary — warning and garbled text no longer appear

Closes #3123

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 6fd4ca869aaea25cb0b955786c1cbddf36a710b0. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->