### PR TITLE
chore: consistent versioning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,7 +199,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "api-types"
-version = "0.1.30-pthis.0"
+version = "0.1.29"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -1569,7 +1569,7 @@ checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "db"
-version = "0.1.30-pthis.0"
+version = "0.1.29"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1612,7 +1612,7 @@ dependencies = [
 
 [[package]]
 name = "deployment"
-version = "0.1.30-pthis.0"
+version = "0.1.29"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2246,7 +2246,7 @@ dependencies = [
 
 [[package]]
 name = "executors"
-version = "0.1.30-pthis.0"
+version = "0.1.29"
 dependencies = [
  "agent-client-protocol",
  "async-stream",
@@ -2867,7 +2867,7 @@ dependencies = [
 
 [[package]]
 name = "git"
-version = "0.1.30-pthis.0"
+version = "0.1.29"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -2882,7 +2882,7 @@ dependencies = [
 
 [[package]]
 name = "git-host"
-version = "0.1.30-pthis.0"
+version = "0.1.29"
 dependencies = [
  "async-trait",
  "backon",
@@ -4102,7 +4102,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "local-deployment"
-version = "0.1.30-pthis.0"
+version = "0.1.29"
 dependencies = [
  "anyhow",
  "api-types",
@@ -4291,7 +4291,7 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "mcp"
-version = "0.1.30-pthis.0"
+version = "0.1.29"
 dependencies = [
  "anyhow",
  "api-types",
@@ -6007,7 +6007,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "relay-control"
-version = "0.1.30-pthis.0"
+version = "0.1.29"
 dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",
@@ -6121,7 +6121,7 @@ dependencies = [
 
 [[package]]
 name = "review"
-version = "0.1.30-pthis.0"
+version = "0.1.29"
 dependencies = [
  "anyhow",
  "clap",
@@ -6997,7 +6997,7 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.1.30-pthis.0"
+version = "0.1.29"
 dependencies = [
  "anyhow",
  "api-types",
@@ -7056,14 +7056,14 @@ dependencies = [
 
 [[package]]
 name = "server-info"
-version = "0.1.30-pthis.0"
+version = "0.1.29"
 dependencies = [
  "tokio",
 ]
 
 [[package]]
 name = "services"
-version = "0.1.30-pthis.0"
+version = "0.1.29"
 dependencies = [
  "anyhow",
  "api-types",
@@ -8874,7 +8874,7 @@ dependencies = [
 
 [[package]]
 name = "trusted-key-auth"
-version = "0.1.30-pthis.0"
+version = "0.1.29"
 dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",
@@ -9200,7 +9200,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "utils"
-version = "0.1.30-pthis.0"
+version = "0.1.29"
 dependencies = [
  "api-types",
  "axum",
@@ -9276,7 +9276,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vibe-kanban-tauri"
-version = "0.1.30-pthis.0"
+version = "0.1.29"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10263,7 +10263,7 @@ dependencies = [
 
 [[package]]
 name = "workspace-manager"
-version = "0.1.30-pthis.0"
+version = "0.1.29"
 dependencies = [
  "db",
  "git",
@@ -10278,7 +10278,7 @@ dependencies = [
 
 [[package]]
 name = "worktree-manager"
-version = "0.1.30-pthis.0"
+version = "0.1.29"
 dependencies = [
  "dunce",
  "git",

--- a/crates/api-types/Cargo.toml
+++ b/crates/api-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "api-types"
-version = "0.1.30-pthis.0"
+version = "0.1.29"
 edition = "2024"
 
 [dependencies]

--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "db"
-version = "0.1.30-pthis.0"
+version = "0.1.29"
 edition = "2024"
 
 [dependencies]

--- a/crates/deployment/Cargo.toml
+++ b/crates/deployment/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deployment"
-version = "0.1.30-pthis.0"
+version = "0.1.29"
 edition = "2024"
 
 [dependencies]

--- a/crates/executors/Cargo.toml
+++ b/crates/executors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "executors"
-version = "0.1.30-pthis.0"
+version = "0.1.29"
 edition = "2024"
 
 [dependencies]

--- a/crates/git-host/Cargo.toml
+++ b/crates/git-host/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-host"
-version = "0.1.30-pthis.0"
+version = "0.1.29"
 edition = "2024"
 
 [dependencies]

--- a/crates/git/Cargo.toml
+++ b/crates/git/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git"
-version = "0.1.30-pthis.0"
+version = "0.1.29"
 edition = "2024"
 
 [features]

--- a/crates/local-deployment/Cargo.toml
+++ b/crates/local-deployment/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "local-deployment"
-version = "0.1.30-pthis.0"
+version = "0.1.29"
 edition = "2024"
 
 [dependencies]

--- a/crates/mcp/Cargo.toml
+++ b/crates/mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp"
-version = "0.1.30-pthis.0"
+version = "0.1.29"
 edition = "2024"
 autobins = false
 

--- a/crates/relay-control/Cargo.toml
+++ b/crates/relay-control/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "relay-control"
-version = "0.1.30-pthis.0"
+version = "0.1.29"
 edition = "2024"
 
 [dependencies]

--- a/crates/relay-tunnel/Cargo.lock
+++ b/crates/relay-tunnel/Cargo.lock
@@ -34,7 +34,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "api-types"
-version = "0.1.30-pthis.0"
+version = "0.1.29"
 dependencies = [
  "base64",
  "chrono",

--- a/crates/remote/Cargo.lock
+++ b/crates/remote/Cargo.lock
@@ -84,7 +84,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "api-types"
-version = "0.1.30-pthis.0"
+version = "0.1.29"
 dependencies = [
  "base64",
  "chrono",
@@ -4712,7 +4712,7 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utils"
-version = "0.1.30-pthis.0"
+version = "0.1.29"
 dependencies = [
  "api-types",
  "axum",

--- a/crates/review/Cargo.toml
+++ b/crates/review/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "review"
-version = "0.1.30-pthis.0"
+version = "0.1.29"
 edition = "2024"
 publish = false
 

--- a/crates/server-info/Cargo.toml
+++ b/crates/server-info/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "server-info"
-version = "0.1.30-pthis.0"
+version = "0.1.29"
 edition = "2024"
 
 [dependencies]

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "server"
-version = "0.1.30-pthis.0"
+version = "0.1.29"
 edition = "2024"
 default-run = "server"
 

--- a/crates/services/Cargo.toml
+++ b/crates/services/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "services"
-version = "0.1.30-pthis.0"
+version = "0.1.29"
 edition = "2024"
 
 [features]

--- a/crates/tauri-app/Cargo.toml
+++ b/crates/tauri-app/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vibe-kanban-tauri"
-version = "0.1.30-pthis.0"
+version = "0.1.29"
 edition = "2024"
 
 [[bin]]

--- a/crates/trusted-key-auth/Cargo.toml
+++ b/crates/trusted-key-auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusted-key-auth"
-version = "0.1.30-pthis.0"
+version = "0.1.29"
 edition = "2024"
 
 [dependencies]

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "utils"
-version = "0.1.30-pthis.0"
+version = "0.1.29"
 edition = "2024"
 
 [dependencies]

--- a/crates/workspace-manager/Cargo.toml
+++ b/crates/workspace-manager/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workspace-manager"
-version = "0.1.30-pthis.0"
+version = "0.1.29"
 edition = "2024"
 
 [dependencies]

--- a/crates/worktree-manager/Cargo.toml
+++ b/crates/worktree-manager/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "worktree-manager"
-version = "0.1.30-pthis.0"
+version = "0.1.29"
 edition = "2024"
 
 [dependencies]

--- a/npx-cli/package-lock.json
+++ b/npx-cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vibe-kanban",
-  "version": "0.1.30-pthis.0",
+  "version": "0.1.29",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vibe-kanban",
-      "version": "0.1.30-pthis.0",
+      "version": "0.1.29",
       "dependencies": {
         "adm-zip": "^0.5.16",
         "cac": "^7.0.0"

--- a/npx-cli/package.json
+++ b/npx-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vibe-kanban",
   "private": false,
-  "version": "0.1.30-pthis.0",
+  "version": "0.1.29",
   "main": "index.js",
   "bin": {
     "vibe-kanban": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-kanban",
-  "version": "0.1.30-pthis.0",
+  "version": "0.1.29",
   "private": true,
   "bin": {
     "vibe-kanban": "npx-cli/bin/cli.js"

--- a/packages/local-web/package.json
+++ b/packages/local-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vibe/local-web",
   "private": true,
-  "version": "0.1.30-pthis.0",
+  "version": "0.1.29",
   "type": "module",
   "scripts": {
     "dev": "VITE_OPEN=${VITE_OPEN:-false} vite",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Version-only changes across Rust and Node packages/lockfiles; no runtime logic changes, with main risk being packaging/publishing metadata mismatches.
> 
> **Overview**
> Standardizes version metadata across the Rust workspace crates and Node packages by changing `0.1.30-pthis.0` to `0.1.29` and updating the associated `Cargo.lock`/`package-lock.json` entries.
> 
> No functional code changes; this is purely a consistency/packaging version alignment.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d428f7e0cd33d598a282004f2d3fe99b780f4cc3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->