### PR TITLE
Fix pre-release version bump workflow path handling (Vibe Kanban)

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -115,14 +115,16 @@ jobs:
           fi
 
           # Update npx-cli package.json to match
-          cd npx-cli
-          npm version $new_version --no-git-tag-version --allow-same-version
-          cd ..
+          (
+            cd npx-cli
+            npm version $new_version --no-git-tag-version --allow-same-version
+          )
 
           # Update web app package.json to match
-          cd packages/local-web
-          npm version $new_version --no-git-tag-version --allow-same-version
-          cd ..
+          (
+            cd packages/local-web
+            npm version $new_version --no-git-tag-version --allow-same-version
+          )
 
           cargo set-version --workspace "$new_version"
 
@@ -153,7 +155,7 @@ jobs:
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
-          git add package.json pnpm-lock.yaml npx-cli/package.json packages/local-web/package.json crates/tauri-app/tauri.conf.json Cargo.lock
+          git add package.json pnpm-lock.yaml npx-cli/package.json npx-cli/package-lock.json packages/local-web/package.json crates/tauri-app/tauri.conf.json Cargo.lock
           git add $(find . -name Cargo.toml)
           [ -f crates/remote/Cargo.lock ] && git add crates/remote/Cargo.lock || true
           [ -f crates/relay-tunnel/Cargo.lock ] && git add crates/relay-tunnel/Cargo.lock || true


### PR DESCRIPTION
## What changed

- Wrapped the `npm version` updates for `npx-cli` and `packages/local-web` in subshells inside `.github/workflows/pre-release.yml`.
- Added `npx-cli/package-lock.json` to the files staged by the automated pre-release bump commit.

## Why

This branch was created to debug a failing pre-release GitHub Actions run on `main`.
The `Determine and update versions` step changed into `packages/local-web` and then used `cd ..`, which left the shell in `packages/` instead of the repository root. The next Node command tried to update `crates/tauri-app/tauri.conf.json` from the wrong working directory, causing the version bump job to fail before the release tag could be created.

## Implementation details

- The subshells keep the version updates scoped to each package directory without changing the working directory for the rest of the release step.
- Keeping the main shell at the repo root allows the later `cargo set-version` and Tauri config update commands to resolve paths correctly.
- Including `npx-cli/package-lock.json` ensures the automated release commit captures the lockfile change produced by `npm version`.
- The updated flow was replayed locally against the failing commit for both `patch` and `prerelease` version bumps.

This PR was written using [Vibe Kanban](https://vibekanban.com)
