### PR TITLE
fix: allow 'max' effort level for Claude.ai subscribers

### DIFF
--- a/crates/executors/src/executors/claude.rs
+++ b/crates/executors/src/executors/claude.rs
@@ -62,7 +62,7 @@ fn base_command(claude_code_router: bool) -> &'static str {
     if claude_code_router {
         "npx -y @musistudio/claude-code-router@1.0.66 code"
     } else {
-        "npx -y @anthropic-ai/claude-code@2.1.62"
+        "npx -y @anthropic-ai/claude-code@2.1.76"
     }
 }
 


### PR DESCRIPTION
## Summary
Fixes #3146

The pinned version of `@anthropic-ai/claude-code` (2.1.62) did not support the "max" effort level for Claude.ai subscribers, even though the CLI already supported it. This bump to 2.1.76 resolves the restriction.

## Changes
- Bump `@anthropic-ai/claude-code` from 2.1.62 to 2.1.76 in `crates/executors/src/executors/claude.rs`

## Test plan
- Verify "max" effort level no longer produces "Error: Effort level 'max' is not available for Claude.ai subscribers"
- Verify other effort levels (low, medium, high) still work correctly
- Verify Claude Code sessions start and function normally with the updated version

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Small code change, but it updates an externally executed CLI dependency, which can subtly affect runtime behavior and output parsing.
> 
> **Overview**
> Updates the Claude executor’s `npx` base command to use `@anthropic-ai/claude-code@2.1.76` instead of `2.1.62`, enabling the CLI’s support for the `max` effort level for Claude.ai subscribers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 66d11f47a7ad499900bda771fb0db7a24b104148. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->