### PR TITLE
fix: prevent analytics failure from affecting workspace creation response

### DIFF
--- a/crates/mcp/src/task_server/tools/task_attempts.rs
+++ b/crates/mcp/src/task_server/tools/task_attempts.rs
@@ -205,13 +205,19 @@ impl McpServer {
             Err(e) => return Ok(e),
         };
 
-        // Link workspace to remote issue if issue_id is provided
+        // Link workspace to remote issue if issue_id is provided.
+        // This is best-effort: the workspace was already created successfully,
+        // so we log and continue rather than failing the entire operation.
         if let Some(issue_id) = issue_id
-            && let Err(e) = self
+            && let Err(_e) = self
                 .link_workspace_to_issue(create_and_start_response.workspace.id, issue_id)
                 .await
         {
-            return Ok(e);
+            tracing::warn!(
+                workspace_id = %create_and_start_response.workspace.id,
+                issue_id = %issue_id,
+                "failed to link workspace to remote issue (workspace was created successfully)"
+            );
         }
 
         let response = StartWorkspaceResponse {

--- a/crates/remote/src/analytics.rs
+++ b/crates/remote/src/analytics.rs
@@ -1,6 +1,7 @@
 use std::time::Duration;
 
 use serde_json::{Value, json};
+use url::Url;
 use uuid::Uuid;
 
 #[derive(Debug, Clone)]
@@ -13,6 +14,19 @@ impl AnalyticsConfig {
     pub fn from_env() -> Option<Self> {
         let api_key = option_env!("POSTHOG_API_KEY")?.to_string();
         let api_endpoint = option_env!("POSTHOG_API_ENDPOINT")?.to_string();
+
+        if api_key.is_empty() || api_endpoint.is_empty() {
+            return None;
+        }
+
+        // Validate that the endpoint is an absolute URL to avoid RelativeUrlWithoutBase errors
+        if Url::parse(&api_endpoint).is_err() {
+            tracing::warn!(
+                "POSTHOG_API_ENDPOINT is not a valid absolute URL, analytics disabled"
+            );
+            return None;
+        }
+
         Some(Self {
             posthog_api_key: api_key,
             posthog_api_endpoint: api_endpoint,

--- a/crates/services/src/services/analytics.rs
+++ b/crates/services/src/services/analytics.rs
@@ -28,6 +28,18 @@ impl AnalyticsConfig {
             .map(|s| s.to_string())
             .or_else(|| std::env::var("POSTHOG_API_ENDPOINT").ok())?;
 
+        if api_key.is_empty() || api_endpoint.is_empty() {
+            return None;
+        }
+
+        // Validate that the endpoint is an absolute URL to avoid RelativeUrlWithoutBase errors
+        if url::Url::parse(&api_endpoint).is_err() {
+            tracing::warn!(
+                "POSTHOG_API_ENDPOINT is not a valid absolute URL, analytics disabled"
+            );
+            return None;
+        }
+
         Some(Self {
             posthog_api_key: api_key,
             posthog_api_endpoint: api_endpoint,


### PR DESCRIPTION
## Summary
Fixes #3143

`start_workspace` returns HTTP 400 even though the workspace is created successfully. The root cause is that the post-creation analytics call fails (e.g., when `ANALYTICS_URL` is not configured on self-hosted instances) and that error incorrectly propagates back to the HTTP response.

## Changes
- Validate `POSTHOG_API_ENDPOINT` is a valid absolute URL when constructing `AnalyticsConfig` in both `crates/remote/src/analytics.rs` and `crates/services/src/services/analytics.rs`. If the URL is empty or relative, analytics is gracefully disabled instead of failing with `RelativeUrlWithoutBase` at request time.
- Made workspace-to-issue linking best-effort in the MCP `start_workspace` tool (`crates/mcp/src/task_server/tools/task_attempts.rs`). Previously, if linking failed (e.g., remote client not configured), the entire tool returned an error even though the workspace was already created — causing clients to retry and create duplicates.

## Test plan
- Verify `start_workspace` returns success when analytics URL is not configured
- Verify analytics events still fire when properly configured
- Verify no duplicate workspaces from retries
- Existing analytics tests pass (`cargo test --package services -- analytics`)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes error propagation in workspace creation and can disable analytics based on URL validation; could mask misconfiguration or alter client retry behavior.
> 
> **Overview**
> Prevents `start_workspace` from failing after a workspace is successfully created: linking the new workspace to a remote issue is now **best-effort** and only logs a warning on failure.
> 
> Hardens analytics configuration by returning `None` (disabling analytics) when `POSTHOG_API_KEY`/`POSTHOG_API_ENDPOINT` are empty or when `POSTHOG_API_ENDPOINT` is not a valid absolute URL, avoiding runtime `RelativeUrlWithoutBase` failures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7cc334299eafb4b7e924dc669fca831d9056cbdc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->