### PR TITLE
fix(relay): make timestamp drift window configurable via env var

### DIFF
--- a/crates/relay-control/src/signing.rs
+++ b/crates/relay-control/src/signing.rs
@@ -41,6 +41,13 @@ impl RelaySignatureValidationError {
 }
 
 const RELAY_SIGNATURE_MAX_TIMESTAMP_DRIFT_SECS: i64 = 30;
+
+fn max_timestamp_drift_secs() -> i64 {
+    std::env::var("VK_RELAY_SIGNATURE_MAX_DRIFT_SECS")
+        .ok()
+        .and_then(|v| v.parse::<i64>().ok())
+        .unwrap_or(RELAY_SIGNATURE_MAX_TIMESTAMP_DRIFT_SECS)
+}
 const RELAY_SIGNING_SESSION_TTL: Duration = Duration::from_secs(60 * 60);
 const RELAY_SIGNING_SESSION_IDLE_TTL: Duration = Duration::from_secs(15 * 60);
 const RELAY_NONCE_TTL: Duration = Duration::from_secs(2 * 60);
@@ -204,7 +211,7 @@ fn validate_timestamp(timestamp: i64) -> Result<(), RelaySignatureValidationErro
     .map_err(|_| RelaySignatureValidationError::TimestampOutOfDrift)?;
 
     let drift_secs = now_secs.saturating_sub(timestamp).abs();
-    if drift_secs > RELAY_SIGNATURE_MAX_TIMESTAMP_DRIFT_SECS {
+    if drift_secs > max_timestamp_drift_secs() {
         return Err(RelaySignatureValidationError::TimestampOutOfDrift);
     }
     Ok(())


### PR DESCRIPTION
## Summary

Fixes #3151

- Add `VK_RELAY_SIGNATURE_MAX_DRIFT_SECS` env var to configure the relay signature timestamp drift tolerance
- Falls back to the existing 30-second default when unset
- Zero behavior change for users who don't set the env var

## Problem

The hardcoded 30s drift window in `validate_timestamp()` causes **all** relay requests to be rejected when the browser device clock differs from the server by >30 seconds. The browser then retries aggressively, triggering CDN-level 429 rate limiting and making relay mode completely unusable.

## Changes

**`crates/relay-control/src/signing.rs`**:
- Added `max_timestamp_drift_secs()` that reads `VK_RELAY_SIGNATURE_MAX_DRIFT_SECS` env var (with fallback to 30s default)
- Changed `validate_timestamp()` to use `max_timestamp_drift_secs()` instead of the hardcoded constant

## Testing

Deployed and verified on a live instance:
- Set `VK_RELAY_SIGNATURE_MAX_DRIFT_SECS=300` 
- Before fix: 1730+ `timestamp outside drift window` rejections
- After fix: zero drift rejections, relay requests passing through normally

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized change to timestamp validation that preserves the 30s default unless the new env var is set.
> 
> **Overview**
> **Relay signature timestamp validation is now configurable.** `validate_timestamp()` uses a new `max_timestamp_drift_secs()` helper to read `VK_RELAY_SIGNATURE_MAX_DRIFT_SECS`, falling back to the existing 30-second drift window when unset.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9bdd3542b54ccabf1c71955025cedc2ac4e38284. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->