### PR TITLE
fix: use ~/Library/Caches on macOS instead of temp dir for worktrees

### DIFF
--- a/crates/utils/src/path.rs
+++ b/crates/utils/src/path.rs
@@ -113,7 +113,12 @@ pub fn get_vibe_kanban_temp_dir() -> std::path::PathBuf {
     };
 
     if cfg!(target_os = "macos") {
-        // macOS already uses /var/folders/... which is persistent storage
+        // Use ~/Library/Caches/ instead of the temp dir (/var/folders/.../T/)
+        // because macOS periodically purges small files from the temp dir,
+        // which destroys the .git symlink files inside worktrees.
+        if let Some(cache_dir) = dirs::cache_dir() {
+            return cache_dir.join(dir_name);
+        }
         std::env::temp_dir().join(dir_name)
     } else if cfg!(target_os = "linux") {
         // Linux: use /var/tmp instead of /tmp to avoid RAM usage


### PR DESCRIPTION
## Summary

On macOS, `std::env::temp_dir()` returns `/var/folders/.../T/`, which is subject to periodic cleanup by the OS. macOS silently purges small files from this directory, which destroys the `.git` symlink files inside git worktrees (they're typically only ~70 bytes). This causes:

- Persistent ERROR log spam: `could not find repository at '...'`
- Diff streams failing and reconnecting in a loop
- Workspace code becoming inaccessible until the `.git` files are manually recreated

The previous comment claimed `/var/folders/...` was "persistent storage" — this is incorrect.

### Fix

Use `dirs::cache_dir()` (`~/Library/Caches/`) on macOS instead of the temp dir. This directory is not subject to automatic system cleanup. The `dirs` crate is already a project dependency, and the change falls back to the old behavior if `cache_dir()` returns `None`.

Existing worktrees are unaffected — their paths are stored in the database `container_ref` field and continue to work at their current locations. Only newly created workspaces use the new path.

## Test plan

- [x] On macOS, create a new workspace and verify the worktree is created under `~/Library/Caches/vibe-kanban/worktrees/` (or `vibe-kanban-dev` in debug builds)
- [x] Verify existing workspaces with worktrees in the old temp dir continue to function
- [x] `cargo test --workspace` passes
- [x] `pnpm run check` passes


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change limited to macOS path selection for newly created temp/worktree directories, with a fallback to the previous temp-dir behavior if the cache directory is unavailable.
> 
> **Overview**
> On macOS, `get_vibe_kanban_temp_dir()` now prefers `dirs::cache_dir()` (typically `~/Library/Caches`) instead of `std::env::temp_dir()` to avoid OS purges that can break git worktree `.git` symlinks.
> 
> Non-macOS behavior is unchanged, and macOS falls back to the prior temp-dir location if no cache directory is found.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 74e1dca91c8756f7d044ae34b3a987b19b839336. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->