### PR TITLE
ci: use blacksmith runners for all ubuntu jobs in pre-release workflow

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -31,7 +31,7 @@ env:
 
 jobs:
   bump-version:
-    runs-on: ubuntu-latest-m
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     outputs:
       new_tag: ${{ steps.version.outputs.new_tag }}
       new_version: ${{ steps.version.outputs.new_version }}
@@ -166,7 +166,7 @@ jobs:
 
   build-frontend:
     needs: bump-version
-    runs-on: ubuntu-latest-x64-l
+    runs-on: blacksmith-16vcpu-ubuntu-2404
     env:
       VITE_PUBLIC_REACT_VIRTUOSO_LICENSE_KEY: ${{ secrets.PUBLIC_REACT_VIRTUOSO_LICENSE_KEY }}
       VITE_VK_SHARED_API_BASE: ${{ secrets.VK_SHARED_API_BASE }}
@@ -222,13 +222,13 @@ jobs:
       matrix:
         include:
           - target: x86_64-unknown-linux-musl
-            os: ubuntu-latest-x64-l
+            os: blacksmith-16vcpu-ubuntu-2404
             name: linux-x64
           - target: aarch64-unknown-linux-musl
-            os: ubuntu-latest-arm64-l
+            os: blacksmith-16vcpu-ubuntu-2404-arm
             name: linux-arm64
           - target: x86_64-pc-windows-msvc
-            os: ubuntu-latest-x64-l
+            os: blacksmith-16vcpu-ubuntu-2404
             name: windows-x64
           - target: x86_64-apple-darwin
             os: macos-15-xlarge
@@ -237,7 +237,7 @@ jobs:
             os: macos-15-xlarge
             name: macos-arm64
           - target: aarch64-pc-windows-msvc
-            os: ubuntu-latest-x64-l
+            os: blacksmith-16vcpu-ubuntu-2404
             name: windows-arm64
     env:
       CARGO_INCREMENTAL: "0"
@@ -509,7 +509,7 @@ jobs:
 
   package-npx-cli:
     needs: [bump-version, build-frontend, build-backend]
-    runs-on: ubuntu-latest-m
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     strategy:
       # NOTE: This matrix must be kept in sync with build-backend job above
       # GitHub Actions doesn't support YAML anchors, so duplication is unavoidable
@@ -601,7 +601,7 @@ jobs:
 
   upload-to-r2:
     needs: [bump-version, package-npx-cli]
-    runs-on: ubuntu-latest-m
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v6
         with:
@@ -994,7 +994,7 @@ jobs:
 
   upload-tauri-update:
     needs: [bump-version, build-tauri]
-    runs-on: ubuntu-latest-m
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v6
         with:
@@ -1081,7 +1081,7 @@ jobs:
 
   create-prerelease:
     needs: [bump-version, build-frontend, upload-to-r2, upload-tauri-update]
-    runs-on: ubuntu-latest-m
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> CI-only change, but it alters the execution environment for the pre-release pipeline; misconfigured runner labels or environment differences could break builds, packaging, or uploads.
> 
> **Overview**
> **Pre-release CI now runs on Blacksmith Ubuntu runners.** The workflow updates `runs-on` for all Ubuntu-based jobs (including version bumping, frontend/backend builds, packaging, and R2/Tauri upload steps) to use `blacksmith-*-ubuntu-2404` (and `-arm` where applicable) instead of the prior `ubuntu-latest-*` runners.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 29467eb5013572749f8f87fe3fe4170d631611cf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->