### PR TITLE
Remove all #[ts(export)] attributes — they are no-ops (Vibe Kanban)

### DIFF
--- a/crates/api-types/src/attachment.rs
+++ b/crates/api-types/src/attachment.rs
@@ -5,7 +5,6 @@ use uuid::Uuid;
 
 /// An attachment links a blob to an issue or comment.
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
-#[ts(export)]
 pub struct Attachment {
     pub id: Uuid,
     pub blob_id: Uuid,
@@ -17,7 +16,6 @@ pub struct Attachment {
 
 /// An attachment with its associated blob data (for API responses).
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
-#[ts(export)]
 pub struct AttachmentWithBlob {
     pub id: Uuid,
     pub blob_id: Uuid,
@@ -52,7 +50,6 @@ pub struct ListAttachmentsResponse {
 
 /// Response containing a presigned URL for an attachment file or thumbnail.
 #[derive(Debug, Serialize, Deserialize, TS)]
-#[ts(export)]
 pub struct AttachmentUrlResponse {
     pub url: String,
 }

--- a/crates/api-types/src/blob.rs
+++ b/crates/api-types/src/blob.rs
@@ -4,7 +4,6 @@ use ts_rs::TS;
 use uuid::Uuid;
 
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
-#[ts(export)]
 pub struct Blob {
     pub id: Uuid,
     pub project_id: Uuid,

--- a/crates/executors/src/executor_discovery.rs
+++ b/crates/executors/src/executor_discovery.rs
@@ -9,7 +9,6 @@ use crate::{
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize, TS, Default)]
-#[ts(export)]
 pub struct ExecutorDiscoveredOptions {
     pub model_selector: ModelSelectorConfig,
     pub slash_commands: Vec<SlashCommandDescription>,

--- a/crates/executors/src/logs/mod.rs
+++ b/crates/executors/src/logs/mod.rs
@@ -100,7 +100,6 @@ pub enum NormalizedEntryType {
 
 /// A question–answer pair from a completed AskUserQuestion interaction.
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
-#[ts(export)]
 pub struct AnsweredQuestion {
     pub question: String,
     pub answer: Vec<String>,
@@ -243,7 +242,6 @@ pub enum ActionType {
 
 /// A single question in an AskUserQuestion tool call.
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
-#[ts(export)]
 pub struct AskUserQuestionItem {
     pub question: String,
     pub header: String,
@@ -254,7 +252,6 @@ pub struct AskUserQuestionItem {
 
 /// An option for an AskUserQuestion question.
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
-#[ts(export)]
 pub struct AskUserQuestionOption {
     pub label: String,
     pub description: String,

--- a/crates/remote/src/routes/attachments.rs
+++ b/crates/remote/src/routes/attachments.rs
@@ -55,7 +55,6 @@ pub fn router() -> Router<AppState> {
 }
 
 #[derive(Debug, Serialize, Deserialize, TS)]
-#[ts(export)]
 pub struct InitUploadRequest {
     pub project_id: Uuid,
     pub filename: String,
@@ -65,7 +64,6 @@ pub struct InitUploadRequest {
 }
 
 #[derive(Debug, Serialize, Deserialize, TS)]
-#[ts(export)]
 pub struct InitUploadResponse {
     pub upload_url: String,
     pub upload_id: Uuid,
@@ -75,7 +73,6 @@ pub struct InitUploadResponse {
 }
 
 #[derive(Debug, Serialize, Deserialize, TS)]
-#[ts(export)]
 pub struct ConfirmUploadRequest {
     pub project_id: Uuid,
     pub upload_id: Uuid,
@@ -92,13 +89,11 @@ pub struct ConfirmUploadRequest {
 }
 
 #[derive(Debug, Serialize, Deserialize, TS)]
-#[ts(export)]
 pub struct CommitAttachmentsRequest {
     pub attachment_ids: Vec<Uuid>,
 }
 
 #[derive(Debug, Serialize, Deserialize, TS)]
-#[ts(export)]
 pub struct CommitAttachmentsResponse {
     pub attachments: Vec<AttachmentWithBlob>,
 }


### PR DESCRIPTION
## Summary

Removes all 13 `#[ts(export)]` attributes across 5 files. These attributes are no-ops in the current `ts-rs` setup since type generation is driven explicitly by the `generate_types` and `remote-generate-types` binaries, not by the `#[ts(export)]` annotation.

## Changes

- **`crates/api-types/src/attachment.rs`** — removed from `Attachment`, `AttachmentWithBlob`, `AttachmentUrlResponse`
- **`crates/api-types/src/blob.rs`** — removed from `Blob`
- **`crates/executors/src/executor_discovery.rs`** — removed from `ExecutorDiscoveredOptions`
- **`crates/executors/src/logs/mod.rs`** — removed from `AnsweredQuestion`, `AskUserQuestionItem`, `AskUserQuestionOption`
- **`crates/remote/src/routes/attachments.rs`** — removed from `InitUploadRequest`, `InitUploadResponse`, `ConfirmUploadRequest`, `CommitAttachmentsRequest`, `CommitAttachmentsResponse`

## Verification

Both `pnpm run generate-types` and `pnpm run remote:generate-types` produce identical output before and after the change, confirming the attributes had no effect.

- [x] tested

---

This PR was written using [Vibe Kanban](https://vibekanban.com)