### PR TITLE
fix: ci builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9283,6 +9283,7 @@ dependencies = [
  "tauri-plugin-opener",
  "tauri-plugin-shell",
  "tauri-plugin-updater",
+ "tokio",
  "tokio-util",
  "tracing",
  "tracing-subscriber",

--- a/crates/tauri-app/Cargo.toml
+++ b/crates/tauri-app/Cargo.toml
@@ -21,6 +21,7 @@ server = { path = "../server" }
 services = { path = "../services" }
 utils = { path = "../utils" }
 async-trait = { workspace = true }
+tokio = { workspace = true }
 
 tokio-util = { version = "0.7", features = ["io"] }
 tracing = { workspace = true }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: this only adjusts Rust dependencies (adds `tokio` to `tauri-app`) with no functional code changes, but it can affect build resolution in CI.
> 
> **Overview**
> Fixes build/dependency resolution for the Tauri app by adding an explicit workspace `tokio` dependency to `crates/tauri-app` (and updating `Cargo.lock` accordingly). This ensures the crate compiles cleanly when `tokio` is required indirectly (e.g., alongside `tokio-util`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d970b616417af20faf819fa93582fc96173a86b5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->