### PR TITLE
Log API request context for server errors (Vibe Kanban)

### DIFF
--- a/crates/server/src/middleware/error_logging.rs
+++ b/crates/server/src/middleware/error_logging.rs
@@ -1,0 +1,32 @@
+use axum::{
+    extract::{MatchedPath, OriginalUri, Request},
+    middleware::Next,
+    response::Response,
+};
+
+pub async fn log_server_errors(request: Request, next: Next) -> Response {
+    let method = request.method().clone();
+    let uri = request
+        .extensions()
+        .get::<OriginalUri>()
+        .map(|original| original.0.clone())
+        .unwrap_or_else(|| request.uri().clone());
+    let matched_path = request
+        .extensions()
+        .get::<MatchedPath>()
+        .map(|matched| matched.as_str().to_owned());
+
+    let response = next.run(request).await;
+
+    if response.status().is_server_error() {
+        tracing::error!(
+            method = %method,
+            uri = %uri,
+            matched_path = matched_path.as_deref().unwrap_or("<unmatched>"),
+            status = %response.status(),
+            "API request returned server error"
+        );
+    }
+
+    response
+}

--- a/crates/server/src/middleware/mod.rs
+++ b/crates/server/src/middleware/mod.rs
@@ -1,7 +1,9 @@
+pub mod error_logging;
 pub mod model_loaders;
 pub mod origin;
 pub mod relay_request_signature;
 
+pub use error_logging::*;
 pub use model_loaders::*;
 pub use origin::*;
 pub use relay_request_signature::*;

--- a/crates/server/src/routes/mod.rs
+++ b/crates/server/src/routes/mod.rs
@@ -69,6 +69,7 @@ pub fn router(deployment: DeploymentImpl) -> IntoMakeService<Router> {
         .layer(ValidateRequestHeaderLayer::custom(
             middleware::validate_origin,
         ))
+        .layer(axum::middleware::from_fn(middleware::log_server_errors))
         .with_state(deployment);
 
     Router::new()


### PR DESCRIPTION
## Summary
This PR adds API-level server error logging so we can see which request is failing when the local server returns a 5xx.

## What changed
- added a new `log_server_errors` Axum middleware in `crates/server/src/middleware/error_logging.rs`
- captured the request method, original URI, matched route path, and response status before returning the response
- logged that context whenever an API response has a 5xx status
- applied the middleware to the `/api` router and exported it from the middleware module

## Why
We were debugging repeated `Database(RowNotFound)` errors that appear after periodic workspace cleanup. The existing `API request failed` log showed the error type and status, but not which endpoint triggered it. That made it hard to determine which stale client poll or workspace-related API call was still running after cleanup invalidated server-side state.

This change makes the next reproduction actionable by logging the failing request path alongside the 5xx, so we can identify the exact endpoint and then fix the underlying cleanup or polling behavior instead of guessing.

## Implementation details
- the middleware reads `OriginalUri` when available so the log reflects the incoming request URI rather than an internal rewritten one
- it also reads `MatchedPath` so the log includes the normalized route pattern, which is useful when IDs vary between requests
- logging happens after `next.run(request).await`, and only for server-error responses, so normal API traffic is unaffected
- the middleware is attached at the API router layer, so it covers API endpoints consistently without changing individual handlers

This PR was written using [Vibe Kanban](https://vibekanban.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a logging-only Axum middleware that triggers only on 5xx responses, with no changes to request handling or data flow beyond extra log output.
> 
> **Overview**
> Adds a new Axum middleware `log_server_errors` that logs request method, original URI, matched route pattern, and response status when an API response is a *server error (5xx)*.
> 
> Applies this middleware to the `/api` router (after origin validation) and exports it via `middleware::mod`, so all API endpoints consistently emit contextual error logs without touching individual handlers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 45d1967e93134a44fbb896517738eec379b06eec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->