### PR TITLE
fix(ci): pin aws-lc-sys to 0.37.0 to fix Windows cross-compilation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -439,19 +439,20 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.1"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
+checksum = "d9a7b350e3bb1767102698302bc37256cbd48422809984b98d292c40e2579aa9"
 dependencies = [
  "aws-lc-sys",
+ "untrusted 0.7.1",
  "zeroize",
 ]
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.38.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
+checksum = "5c34dda4df7017c8db52132f0f8a2e0f8161649d15723ed63fc00c82d0f2081a"
 dependencies = [
  "cc",
  "cmake",
@@ -6183,7 +6184,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
@@ -6424,7 +6425,7 @@ dependencies = [
  "aws-lc-rs",
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -7002,6 +7003,8 @@ version = "0.1.31"
 dependencies = [
  "anyhow",
  "api-types",
+ "aws-lc-rs",
+ "aws-lc-sys",
  "axum",
  "base64 0.22.1",
  "chrono",
@@ -9117,6 +9120,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,8 @@ ts-rs = { git = "https://github.com/xazukx/ts-rs.git", branch = "use-ts-enum", f
 schemars = { version = "1.0.4", features = ["derive", "chrono04", "uuid1", "preserve_order"] }
 serde_with = "3"
 async-trait = "0.1"
+aws-lc-sys = "=0.37.0"
+aws-lc-rs = "=1.16.0"
 
 [profile.release]
 debug = 1

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -39,6 +39,8 @@ schemars = { workspace = true }
 sentry = { version = "0.46.2", default-features = false, features = ["anyhow", "backtrace", "panic", "debug-images", "reqwest", "rustls"] }
 reqwest = { workspace = true }
 rustls = { workspace = true }
+aws-lc-sys = { workspace = true }
+aws-lc-rs = { workspace = true }
 strip-ansi-escapes = "0.2.1"
 thiserror = { workspace = true }
 os_info = "3.12.0"


### PR DESCRIPTION
aws-lc-sys >= 0.37.1 breaks cargo-xwin cross-compilation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Pins TLS/crypto backend crates (`aws-lc-sys`/`aws-lc-rs`) to specific versions to avoid a known Windows cross-compilation breakage; risk is moderate because it changes low-level cryptography dependencies used by Rustls/SQLx.
> 
> **Overview**
> Fixes Windows cross-compilation by **pinning the AWS-LC crypto backend** used by `rustls`/`sqlx`.
> 
> The workspace now locks `aws-lc-sys` to `=0.37.0` and `aws-lc-rs` to `=1.16.0`, and `server` explicitly depends on these workspace-pinned crates. `Cargo.lock` is updated accordingly (including introducing an additional `untrusted` version to satisfy dependency constraints).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a4e18bae15e75e3a0f5dc1711f92c6d014e21b72. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->