### PR TITLE
Clear assignee search after selection (Vibe Kanban)

### DIFF
--- a/packages/web-core/src/shared/dialogs/kanban/AssigneeSelectionDialog.tsx
+++ b/packages/web-core/src/shared/dialogs/kanban/AssigneeSelectionDialog.tsx
@@ -193,6 +193,8 @@ function AssigneeSelectionContent({
           }
         }
       }
+
+      setSearch('');
     },
     [
       isCreateMode,


### PR DESCRIPTION
## Summary
- clear the assignee search input after a user is selected or deselected in `AssigneeSelectionDialog`
- keep the existing behavior that resets search when the dialog opens

## Why
This change addresses the task context for the assignee picker: after selecting an assignee, the previous search term should not remain in the input. Clearing it makes repeated selections easier and avoids leaving the dialog filtered to a stale query.

## Implementation Details
- updated `handleToggle` in `packages/web-core/src/shared/dialogs/kanban/AssigneeSelectionDialog.tsx`
- after applying the create-mode or edit-mode assignee update, the dialog now resets the local search state to an empty string
- the change applies to both selecting and deselecting assignees, without altering the existing assignment logic

This PR was written using [Vibe Kanban](https://vibekanban.com)