### PR TITLE
perf: speed up local server Docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,11 +7,14 @@ ARG POSTHOG_API_ENDPOINT=""
 
 WORKDIR /app
 
+ENV PNPM_HOME=/pnpm
+ENV PATH=${PNPM_HOME}:${PATH}
 ENV VITE_PUBLIC_POSTHOG_KEY=${POSTHOG_API_KEY}
 ENV VITE_PUBLIC_POSTHOG_HOST=${POSTHOG_API_ENDPOINT}
 ENV NODE_OPTIONS=--max-old-space-size=4096
 
 RUN corepack enable
+RUN pnpm config set store-dir /pnpm/store
 
 COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
 COPY packages/local-web/package.json packages/local-web/package.json


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Reworks the Docker build pipeline and base images (Alpine→Debian/Rust slim) plus new cache mounts, which can affect build reproducibility, binary compatibility, and runtime dependencies despite no app-code changes.
> 
> **Overview**
> Refactors the `Dockerfile` into a dedicated Node `fe-builder` stage and a Rust `builder` stage, using BuildKit cache mounts for `pnpm` and Cargo to significantly reduce rebuild times.
> 
> Switches the Rust build and runtime images from Alpine to Debian (`rust:*-bookworm` and `debian:bookworm-slim`), adds required build/runtime packages (e.g., `libssl-dev`, `openssh-client`), and updates runtime wiring (new non-root user, `/health`-based healthcheck, and `tini` entrypoint to run the server binary directly).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e3c2927cf381568f570c19946a4e66314f6354b3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->