### PR TITLE
Move Tauri pre-release artifacts to R2 and publish installer links in notes (Vibe Kanban)

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -888,6 +888,9 @@ jobs:
 
       - name: Build Tauri app
         run: |
+          # Avoid stale cached bundle artifacts from previous versions.
+          rm -rf "target/${{ matrix.target }}/release/bundle"
+
           if [[ "${{ matrix.target }}" == "aarch64-pc-windows-msvc" ]]; then
             # ring requires clang on arm64 windows cross-compile
             chmod +x scripts/ring-cc-wrapper.sh scripts/clang
@@ -1124,10 +1127,14 @@ jobs:
           TAG="${{ needs.bump-version.outputs.new_tag }}"
           ENDPOINT="${{ secrets.R2_BINARIES_ENDPOINT }}"
           BUCKET="${{ secrets.R2_BINARIES_BUCKET }}"
-          aws s3 ls "s3://$BUCKET/binaries/$TAG/tauri/" \
-            --recursive \
+          aws s3api list-objects-v2 \
+            --bucket "$BUCKET" \
+            --prefix "binaries/$TAG/tauri/" \
             --endpoint-url "$ENDPOINT" \
-            | awk '{print $4}' \
+            --output json \
+            > tauri-objects.json
+
+          jq -r '.Contents[]?.Key // empty' tauri-objects.json \
             | grep -E '(\.dmg|\.AppImage|\.deb|\.msi|-setup\.exe)$' \
             > tauri-installer-paths.txt || true
 
@@ -1158,7 +1165,8 @@ jobs:
               while IFS= read -r key; do
                 [ -n "$key" ] || continue
                 file="$(basename "$key")"
-                echo "- [$file](${{ secrets.R2_BINARIES_PUBLIC_URL }}/binaries/$TAG/tauri/$platform/$file)" >> release-notes.md
+                encoded_file="${file// /%20}"
+                echo "- [$file](${{ secrets.R2_BINARIES_PUBLIC_URL }}/binaries/$TAG/tauri/$platform/$encoded_file)" >> release-notes.md
               done <<< "$matches"
             else
               echo "- Not available" >> release-notes.md

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -982,7 +982,7 @@ jobs:
               echo "Collected updater artifact: $(basename $artifact)"
             fi
           done
-          # Collect installer files for GitHub Release (DMG, AppImage, deb, msi, NSIS exe)
+          # Collect installer files for R2 distribution and release note links
           find target/${{ matrix.target }}/release/bundle \
             \( -name "*.dmg" -o -name "*.AppImage" -o -name "*.deb" -o -name "*.msi" -o -name "*-setup.exe" \) | while read f; do
             cp "$f" "tauri-artifacts/${{ matrix.platform }}/"
@@ -991,16 +991,28 @@ jobs:
           echo "All artifacts for ${{ matrix.platform }}:"
           ls -la tauri-artifacts/${{ matrix.platform }}/
 
+      - name: Configure AWS CLI for R2
+        run: |
+          aws configure set aws_access_key_id ${{ secrets.R2_BINARIES_ACCESS_KEY_ID }}
+          aws configure set aws_secret_access_key ${{ secrets.R2_BINARIES_SECRET_ACCESS_KEY }}
+          aws configure set default.region auto
+
+      - name: Upload Tauri artifacts to R2
+        run: |
+          TAG="${{ needs.bump-version.outputs.new_tag }}"
+          ENDPOINT="${{ secrets.R2_BINARIES_ENDPOINT }}"
+          BUCKET="${{ secrets.R2_BINARIES_BUCKET }}"
+
+          if [ -d "tauri-artifacts/${{ matrix.platform }}" ]; then
+            aws s3 cp "tauri-artifacts/${{ matrix.platform }}" \
+              "s3://$BUCKET/binaries/$TAG/tauri/${{ matrix.platform }}/" \
+              --recursive \
+              --endpoint-url "$ENDPOINT"
+          fi
+
       - name: Clean up signing keys
         if: always() && runner.os == 'macOS'
         run: rm -rf ~/.private_keys
-
-      - name: Upload Tauri artifacts
-        uses: actions/upload-artifact@v6
-        with:
-          name: tauri-artifacts-${{ matrix.platform }}
-          path: tauri-artifacts/
-          retention-days: 1
 
       - name: Sweep Cargo target cache
         if: always()
@@ -1019,12 +1031,26 @@ jobs:
       - name: Setup Node
         uses: ./.github/actions/setup-node
 
-      - name: Download all Tauri artifacts
-        uses: actions/download-artifact@v7
-        with:
-          pattern: tauri-artifacts-*
-          path: tauri-artifacts/
-          merge-multiple: true
+      - name: Configure AWS CLI for R2
+        run: |
+          aws configure set aws_access_key_id ${{ secrets.R2_BINARIES_ACCESS_KEY_ID }}
+          aws configure set aws_secret_access_key ${{ secrets.R2_BINARIES_SECRET_ACCESS_KEY }}
+          aws configure set default.region auto
+
+      - name: Download all Tauri artifacts from R2
+        run: |
+          TAG="${{ needs.bump-version.outputs.new_tag }}"
+          ENDPOINT="${{ secrets.R2_BINARIES_ENDPOINT }}"
+          BUCKET="${{ secrets.R2_BINARIES_BUCKET }}"
+
+          mkdir -p tauri-artifacts
+          for platform in darwin-aarch64 darwin-x86_64 linux-x86_64 linux-aarch64 windows-x86_64 windows-aarch64; do
+            aws s3 cp \
+              "s3://$BUCKET/binaries/$TAG/tauri/$platform/" \
+              "tauri-artifacts/$platform/" \
+              --recursive \
+              --endpoint-url "$ENDPOINT" || true
+          done
 
       - name: List Tauri artifacts
         run: find tauri-artifacts/
@@ -1049,33 +1075,11 @@ jobs:
           echo "Generated desktop-manifest.json:"
           cat desktop-manifest.json
 
-      - name: Configure AWS CLI for R2
-        run: |
-          aws configure set aws_access_key_id ${{ secrets.R2_BINARIES_ACCESS_KEY_ID }}
-          aws configure set aws_secret_access_key ${{ secrets.R2_BINARIES_SECRET_ACCESS_KEY }}
-          aws configure set default.region auto
-
       - name: Upload Tauri artifacts and update manifest to R2
         run: |
           TAG="${{ needs.bump-version.outputs.new_tag }}"
           ENDPOINT="${{ secrets.R2_BINARIES_ENDPOINT }}"
           BUCKET="${{ secrets.R2_BINARIES_BUCKET }}"
-
-          # Upload individual platform artifacts
-          for platform in darwin-aarch64 darwin-x86_64 linux-x86_64 linux-aarch64 windows-x86_64 windows-aarch64; do
-            if [ -d "tauri-artifacts/$platform" ]; then
-              for file in tauri-artifacts/$platform/*; do
-                [ -f "$file" ] || continue
-                # Skip .sig files from artifact upload (signatures are in latest.json)
-                [[ "$file" == *.sig ]] && continue
-                filename=$(basename "$file")
-                echo "Uploading $filename for $platform..."
-                aws s3 cp "$file" \
-                  "s3://$BUCKET/binaries/$TAG/tauri/$platform/$filename" \
-                  --endpoint-url "$ENDPOINT"
-              done
-            fi
-          done
 
           # Upload latest.json alongside the tag artifacts (NOT to the fixed
           # update endpoint). The fixed endpoint is only updated when a
@@ -1109,20 +1113,64 @@ jobs:
           name: frontend-dist
           path: packages/local-web/dist/
 
-      - name: Download Tauri artifacts for release
-        uses: actions/download-artifact@v7
-        with:
-          pattern: tauri-artifacts-*
-          path: tauri-release/
-          merge-multiple: true
-
-      - name: Collect Tauri installers for release
+      - name: Configure AWS CLI for R2
         run: |
-          mkdir -p tauri-installers
-          find tauri-release \( -name "*.dmg" -o -name "*.AppImage" -o -name "*.deb" -o -name "*.msi" -o -name "*-setup.exe" \) \
-            -exec cp {} tauri-installers/ \;
-          echo "Tauri installers for release:"
-          ls -la tauri-installers/ 2>/dev/null || echo "No installers found"
+          aws configure set aws_access_key_id ${{ secrets.R2_BINARIES_ACCESS_KEY_ID }}
+          aws configure set aws_secret_access_key ${{ secrets.R2_BINARIES_SECRET_ACCESS_KEY }}
+          aws configure set default.region auto
+
+      - name: Prepare release notes with Tauri installer links
+        run: |
+          TAG="${{ needs.bump-version.outputs.new_tag }}"
+          ENDPOINT="${{ secrets.R2_BINARIES_ENDPOINT }}"
+          BUCKET="${{ secrets.R2_BINARIES_BUCKET }}"
+          aws s3 ls "s3://$BUCKET/binaries/$TAG/tauri/" \
+            --recursive \
+            --endpoint-url "$ENDPOINT" \
+            | awk '{print $4}' \
+            | grep -E '(\.dmg|\.AppImage|\.deb|\.msi|-setup\.exe)$' \
+            > tauri-installer-paths.txt || true
+
+          cat > release-notes.md <<EOF
+          ## Desktop Installers (R2)
+          EOF
+
+          platforms=(
+            "darwin-aarch64|macOS (Apple Silicon)"
+            "darwin-x86_64|macOS (Intel)"
+            "linux-x86_64|Linux (x86_64)"
+            "linux-aarch64|Linux (ARM64)"
+            "windows-x86_64|Windows (x86_64)"
+            "windows-aarch64|Windows (ARM64)"
+          )
+
+          for item in "${platforms[@]}"; do
+            platform="${item%%|*}"
+            label="${item##*|}"
+            echo "" >> release-notes.md
+            echo "### $label" >> release-notes.md
+            if [ -s tauri-installer-paths.txt ]; then
+              matches=$(grep "/$platform/" tauri-installer-paths.txt || true)
+            else
+              matches=""
+            fi
+            if [ -n "$matches" ]; then
+              while IFS= read -r key; do
+                [ -n "$key" ] || continue
+                file="$(basename "$key")"
+                echo "- [$file](${{ secrets.R2_BINARIES_PUBLIC_URL }}/binaries/$TAG/tauri/$platform/$file)" >> release-notes.md
+              done <<< "$matches"
+            else
+              echo "- Not available" >> release-notes.md
+            fi
+          done
+
+          echo "" >> release-notes.md
+          echo "---" >> release-notes.md
+          echo "" >> release-notes.md
+
+          echo "Generated release notes preamble:"
+          cat release-notes.md
 
       - name: List downloaded artifacts
         run: |
@@ -1159,7 +1207,7 @@ jobs:
           name: Pre-release ${{ needs.bump-version.outputs.new_tag }}
           prerelease: true
           generate_release_notes: true
+          body_path: release-notes.md
           files: |
             vibe-kanban-${{ needs.bump-version.outputs.new_tag }}.zip
             npx-cli/vibe-kanban-*.tgz
-            tauri-installers/*

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -1122,7 +1122,7 @@ jobs:
           aws configure set aws_secret_access_key ${{ secrets.R2_BINARIES_SECRET_ACCESS_KEY }}
           aws configure set default.region auto
 
-      - name: Prepare release notes with Tauri installer links
+      - name: Prepare installer links for release notes
         run: |
           TAG="${{ needs.bump-version.outputs.new_tag }}"
           ENDPOINT="${{ secrets.R2_BINARIES_ENDPOINT }}"
@@ -1177,7 +1177,7 @@ jobs:
           echo "---" >> release-notes.md
           echo "" >> release-notes.md
 
-          echo "Generated release notes preamble:"
+          echo "Generated installer links section:"
           cat release-notes.md
 
       - name: List downloaded artifacts
@@ -1215,6 +1215,7 @@ jobs:
           name: Pre-release ${{ needs.bump-version.outputs.new_tag }}
           prerelease: true
           generate_release_notes: true
+          append_body: true
           body_path: release-notes.md
           files: |
             vibe-kanban-${{ needs.bump-version.outputs.new_tag }}.zip

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,7 +199,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "api-types"
-version = "0.1.33-artef.2"
+version = "0.1.33-artef.3"
 dependencies = [
  "chrono",
  "schemars 1.2.1",
@@ -1599,7 +1599,7 @@ checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "db"
-version = "0.1.33-artef.2"
+version = "0.1.33-artef.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1641,7 +1641,7 @@ dependencies = [
 
 [[package]]
 name = "deployment"
-version = "0.1.33-artef.2"
+version = "0.1.33-artef.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2268,7 +2268,7 @@ dependencies = [
 
 [[package]]
 name = "executors"
-version = "0.1.33-artef.2"
+version = "0.1.33-artef.3"
 dependencies = [
  "agent-client-protocol",
  "async-stream",
@@ -2889,7 +2889,7 @@ dependencies = [
 
 [[package]]
 name = "git"
-version = "0.1.33-artef.2"
+version = "0.1.33-artef.3"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -2904,7 +2904,7 @@ dependencies = [
 
 [[package]]
 name = "git-host"
-version = "0.1.33-artef.2"
+version = "0.1.33-artef.3"
 dependencies = [
  "async-trait",
  "backon",
@@ -4124,7 +4124,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "local-deployment"
-version = "0.1.33-artef.2"
+version = "0.1.33-artef.3"
 dependencies = [
  "anyhow",
  "api-types",
@@ -4312,7 +4312,7 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "mcp"
-version = "0.1.33-artef.2"
+version = "0.1.33-artef.3"
 dependencies = [
  "anyhow",
  "api-types",
@@ -6028,7 +6028,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "relay-control"
-version = "0.1.33-artef.2"
+version = "0.1.33-artef.3"
 dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",
@@ -6141,7 +6141,7 @@ dependencies = [
 
 [[package]]
 name = "review"
-version = "0.1.33-artef.2"
+version = "0.1.33-artef.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -6999,7 +6999,7 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.1.33-artef.2"
+version = "0.1.33-artef.3"
 dependencies = [
  "anyhow",
  "api-types",
@@ -7053,14 +7053,14 @@ dependencies = [
 
 [[package]]
 name = "server-info"
-version = "0.1.33-artef.2"
+version = "0.1.33-artef.3"
 dependencies = [
  "tokio",
 ]
 
 [[package]]
 name = "services"
-version = "0.1.33-artef.2"
+version = "0.1.33-artef.3"
 dependencies = [
  "anyhow",
  "api-types",
@@ -8874,7 +8874,7 @@ dependencies = [
 
 [[package]]
 name = "trusted-key-auth"
-version = "0.1.33-artef.2"
+version = "0.1.33-artef.3"
 dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",
@@ -9206,7 +9206,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "utils"
-version = "0.1.33-artef.2"
+version = "0.1.33-artef.3"
 dependencies = [
  "axum",
  "bytes",
@@ -9280,7 +9280,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vibe-kanban-tauri"
-version = "0.1.33-artef.2"
+version = "0.1.33-artef.3"
 dependencies = [
  "async-trait",
  "objc2-web-kit",
@@ -10289,7 +10289,7 @@ dependencies = [
 
 [[package]]
 name = "workspace-manager"
-version = "0.1.33-artef.2"
+version = "0.1.33-artef.3"
 dependencies = [
  "db",
  "git",
@@ -10304,7 +10304,7 @@ dependencies = [
 
 [[package]]
 name = "worktree-manager"
-version = "0.1.33-artef.2"
+version = "0.1.33-artef.3"
 dependencies = [
  "dunce",
  "git",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,7 +199,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "api-types"
-version = "0.1.33-artef.4"
+version = "0.1.33-artef.5"
 dependencies = [
  "chrono",
  "schemars 1.2.1",
@@ -1599,7 +1599,7 @@ checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "db"
-version = "0.1.33-artef.4"
+version = "0.1.33-artef.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1641,7 +1641,7 @@ dependencies = [
 
 [[package]]
 name = "deployment"
-version = "0.1.33-artef.4"
+version = "0.1.33-artef.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2268,7 +2268,7 @@ dependencies = [
 
 [[package]]
 name = "executors"
-version = "0.1.33-artef.4"
+version = "0.1.33-artef.5"
 dependencies = [
  "agent-client-protocol",
  "async-stream",
@@ -2889,7 +2889,7 @@ dependencies = [
 
 [[package]]
 name = "git"
-version = "0.1.33-artef.4"
+version = "0.1.33-artef.5"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -2904,7 +2904,7 @@ dependencies = [
 
 [[package]]
 name = "git-host"
-version = "0.1.33-artef.4"
+version = "0.1.33-artef.5"
 dependencies = [
  "async-trait",
  "backon",
@@ -4124,7 +4124,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "local-deployment"
-version = "0.1.33-artef.4"
+version = "0.1.33-artef.5"
 dependencies = [
  "anyhow",
  "api-types",
@@ -4312,7 +4312,7 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "mcp"
-version = "0.1.33-artef.4"
+version = "0.1.33-artef.5"
 dependencies = [
  "anyhow",
  "api-types",
@@ -6028,7 +6028,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "relay-control"
-version = "0.1.33-artef.4"
+version = "0.1.33-artef.5"
 dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",
@@ -6141,7 +6141,7 @@ dependencies = [
 
 [[package]]
 name = "review"
-version = "0.1.33-artef.4"
+version = "0.1.33-artef.5"
 dependencies = [
  "anyhow",
  "clap",
@@ -6999,7 +6999,7 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.1.33-artef.4"
+version = "0.1.33-artef.5"
 dependencies = [
  "anyhow",
  "api-types",
@@ -7053,14 +7053,14 @@ dependencies = [
 
 [[package]]
 name = "server-info"
-version = "0.1.33-artef.4"
+version = "0.1.33-artef.5"
 dependencies = [
  "tokio",
 ]
 
 [[package]]
 name = "services"
-version = "0.1.33-artef.4"
+version = "0.1.33-artef.5"
 dependencies = [
  "anyhow",
  "api-types",
@@ -8874,7 +8874,7 @@ dependencies = [
 
 [[package]]
 name = "trusted-key-auth"
-version = "0.1.33-artef.4"
+version = "0.1.33-artef.5"
 dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",
@@ -9206,7 +9206,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "utils"
-version = "0.1.33-artef.4"
+version = "0.1.33-artef.5"
 dependencies = [
  "axum",
  "bytes",
@@ -9280,7 +9280,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vibe-kanban-tauri"
-version = "0.1.33-artef.4"
+version = "0.1.33-artef.5"
 dependencies = [
  "async-trait",
  "objc2-web-kit",
@@ -10289,7 +10289,7 @@ dependencies = [
 
 [[package]]
 name = "workspace-manager"
-version = "0.1.33-artef.4"
+version = "0.1.33-artef.5"
 dependencies = [
  "db",
  "git",
@@ -10304,7 +10304,7 @@ dependencies = [
 
 [[package]]
 name = "worktree-manager"
-version = "0.1.33-artef.4"
+version = "0.1.33-artef.5"
 dependencies = [
  "dunce",
  "git",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,7 +199,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "api-types"
-version = "0.1.33-artef.0"
+version = "0.1.33-artef.1"
 dependencies = [
  "chrono",
  "schemars 1.2.1",
@@ -1599,7 +1599,7 @@ checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "db"
-version = "0.1.33-artef.0"
+version = "0.1.33-artef.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1641,7 +1641,7 @@ dependencies = [
 
 [[package]]
 name = "deployment"
-version = "0.1.33-artef.0"
+version = "0.1.33-artef.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2268,7 +2268,7 @@ dependencies = [
 
 [[package]]
 name = "executors"
-version = "0.1.33-artef.0"
+version = "0.1.33-artef.1"
 dependencies = [
  "agent-client-protocol",
  "async-stream",
@@ -2889,7 +2889,7 @@ dependencies = [
 
 [[package]]
 name = "git"
-version = "0.1.33-artef.0"
+version = "0.1.33-artef.1"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -2904,7 +2904,7 @@ dependencies = [
 
 [[package]]
 name = "git-host"
-version = "0.1.33-artef.0"
+version = "0.1.33-artef.1"
 dependencies = [
  "async-trait",
  "backon",
@@ -4124,7 +4124,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "local-deployment"
-version = "0.1.33-artef.0"
+version = "0.1.33-artef.1"
 dependencies = [
  "anyhow",
  "api-types",
@@ -4312,7 +4312,7 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "mcp"
-version = "0.1.33-artef.0"
+version = "0.1.33-artef.1"
 dependencies = [
  "anyhow",
  "api-types",
@@ -6028,7 +6028,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "relay-control"
-version = "0.1.33-artef.0"
+version = "0.1.33-artef.1"
 dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",
@@ -6141,7 +6141,7 @@ dependencies = [
 
 [[package]]
 name = "review"
-version = "0.1.33-artef.0"
+version = "0.1.33-artef.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -6999,7 +6999,7 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.1.33-artef.0"
+version = "0.1.33-artef.1"
 dependencies = [
  "anyhow",
  "api-types",
@@ -7053,14 +7053,14 @@ dependencies = [
 
 [[package]]
 name = "server-info"
-version = "0.1.33-artef.0"
+version = "0.1.33-artef.1"
 dependencies = [
  "tokio",
 ]
 
 [[package]]
 name = "services"
-version = "0.1.33-artef.0"
+version = "0.1.33-artef.1"
 dependencies = [
  "anyhow",
  "api-types",
@@ -8874,7 +8874,7 @@ dependencies = [
 
 [[package]]
 name = "trusted-key-auth"
-version = "0.1.33-artef.0"
+version = "0.1.33-artef.1"
 dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",
@@ -9206,7 +9206,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "utils"
-version = "0.1.33-artef.0"
+version = "0.1.33-artef.1"
 dependencies = [
  "axum",
  "bytes",
@@ -9280,7 +9280,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vibe-kanban-tauri"
-version = "0.1.33-artef.0"
+version = "0.1.33-artef.1"
 dependencies = [
  "async-trait",
  "objc2-web-kit",
@@ -10289,7 +10289,7 @@ dependencies = [
 
 [[package]]
 name = "workspace-manager"
-version = "0.1.33-artef.0"
+version = "0.1.33-artef.1"
 dependencies = [
  "db",
  "git",
@@ -10304,7 +10304,7 @@ dependencies = [
 
 [[package]]
 name = "worktree-manager"
-version = "0.1.33-artef.0"
+version = "0.1.33-artef.1"
 dependencies = [
  "dunce",
  "git",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,7 +199,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "api-types"
-version = "0.1.33-artef.3"
+version = "0.1.33-artef.4"
 dependencies = [
  "chrono",
  "schemars 1.2.1",
@@ -1599,7 +1599,7 @@ checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "db"
-version = "0.1.33-artef.3"
+version = "0.1.33-artef.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1641,7 +1641,7 @@ dependencies = [
 
 [[package]]
 name = "deployment"
-version = "0.1.33-artef.3"
+version = "0.1.33-artef.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2268,7 +2268,7 @@ dependencies = [
 
 [[package]]
 name = "executors"
-version = "0.1.33-artef.3"
+version = "0.1.33-artef.4"
 dependencies = [
  "agent-client-protocol",
  "async-stream",
@@ -2889,7 +2889,7 @@ dependencies = [
 
 [[package]]
 name = "git"
-version = "0.1.33-artef.3"
+version = "0.1.33-artef.4"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -2904,7 +2904,7 @@ dependencies = [
 
 [[package]]
 name = "git-host"
-version = "0.1.33-artef.3"
+version = "0.1.33-artef.4"
 dependencies = [
  "async-trait",
  "backon",
@@ -4124,7 +4124,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "local-deployment"
-version = "0.1.33-artef.3"
+version = "0.1.33-artef.4"
 dependencies = [
  "anyhow",
  "api-types",
@@ -4312,7 +4312,7 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "mcp"
-version = "0.1.33-artef.3"
+version = "0.1.33-artef.4"
 dependencies = [
  "anyhow",
  "api-types",
@@ -6028,7 +6028,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "relay-control"
-version = "0.1.33-artef.3"
+version = "0.1.33-artef.4"
 dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",
@@ -6141,7 +6141,7 @@ dependencies = [
 
 [[package]]
 name = "review"
-version = "0.1.33-artef.3"
+version = "0.1.33-artef.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -6999,7 +6999,7 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.1.33-artef.3"
+version = "0.1.33-artef.4"
 dependencies = [
  "anyhow",
  "api-types",
@@ -7053,14 +7053,14 @@ dependencies = [
 
 [[package]]
 name = "server-info"
-version = "0.1.33-artef.3"
+version = "0.1.33-artef.4"
 dependencies = [
  "tokio",
 ]
 
 [[package]]
 name = "services"
-version = "0.1.33-artef.3"
+version = "0.1.33-artef.4"
 dependencies = [
  "anyhow",
  "api-types",
@@ -8874,7 +8874,7 @@ dependencies = [
 
 [[package]]
 name = "trusted-key-auth"
-version = "0.1.33-artef.3"
+version = "0.1.33-artef.4"
 dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",
@@ -9206,7 +9206,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "utils"
-version = "0.1.33-artef.3"
+version = "0.1.33-artef.4"
 dependencies = [
  "axum",
  "bytes",
@@ -9280,7 +9280,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vibe-kanban-tauri"
-version = "0.1.33-artef.3"
+version = "0.1.33-artef.4"
 dependencies = [
  "async-trait",
  "objc2-web-kit",
@@ -10289,7 +10289,7 @@ dependencies = [
 
 [[package]]
 name = "workspace-manager"
-version = "0.1.33-artef.3"
+version = "0.1.33-artef.4"
 dependencies = [
  "db",
  "git",
@@ -10304,7 +10304,7 @@ dependencies = [
 
 [[package]]
 name = "worktree-manager"
-version = "0.1.33-artef.3"
+version = "0.1.33-artef.4"
 dependencies = [
  "dunce",
  "git",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,7 +199,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "api-types"
-version = "0.1.33-artef.1"
+version = "0.1.33-artef.2"
 dependencies = [
  "chrono",
  "schemars 1.2.1",
@@ -1599,7 +1599,7 @@ checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "db"
-version = "0.1.33-artef.1"
+version = "0.1.33-artef.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1641,7 +1641,7 @@ dependencies = [
 
 [[package]]
 name = "deployment"
-version = "0.1.33-artef.1"
+version = "0.1.33-artef.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2268,7 +2268,7 @@ dependencies = [
 
 [[package]]
 name = "executors"
-version = "0.1.33-artef.1"
+version = "0.1.33-artef.2"
 dependencies = [
  "agent-client-protocol",
  "async-stream",
@@ -2889,7 +2889,7 @@ dependencies = [
 
 [[package]]
 name = "git"
-version = "0.1.33-artef.1"
+version = "0.1.33-artef.2"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -2904,7 +2904,7 @@ dependencies = [
 
 [[package]]
 name = "git-host"
-version = "0.1.33-artef.1"
+version = "0.1.33-artef.2"
 dependencies = [
  "async-trait",
  "backon",
@@ -4124,7 +4124,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "local-deployment"
-version = "0.1.33-artef.1"
+version = "0.1.33-artef.2"
 dependencies = [
  "anyhow",
  "api-types",
@@ -4312,7 +4312,7 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "mcp"
-version = "0.1.33-artef.1"
+version = "0.1.33-artef.2"
 dependencies = [
  "anyhow",
  "api-types",
@@ -6028,7 +6028,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "relay-control"
-version = "0.1.33-artef.1"
+version = "0.1.33-artef.2"
 dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",
@@ -6141,7 +6141,7 @@ dependencies = [
 
 [[package]]
 name = "review"
-version = "0.1.33-artef.1"
+version = "0.1.33-artef.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -6999,7 +6999,7 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.1.33-artef.1"
+version = "0.1.33-artef.2"
 dependencies = [
  "anyhow",
  "api-types",
@@ -7053,14 +7053,14 @@ dependencies = [
 
 [[package]]
 name = "server-info"
-version = "0.1.33-artef.1"
+version = "0.1.33-artef.2"
 dependencies = [
  "tokio",
 ]
 
 [[package]]
 name = "services"
-version = "0.1.33-artef.1"
+version = "0.1.33-artef.2"
 dependencies = [
  "anyhow",
  "api-types",
@@ -8874,7 +8874,7 @@ dependencies = [
 
 [[package]]
 name = "trusted-key-auth"
-version = "0.1.33-artef.1"
+version = "0.1.33-artef.2"
 dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",
@@ -9206,7 +9206,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "utils"
-version = "0.1.33-artef.1"
+version = "0.1.33-artef.2"
 dependencies = [
  "axum",
  "bytes",
@@ -9280,7 +9280,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vibe-kanban-tauri"
-version = "0.1.33-artef.1"
+version = "0.1.33-artef.2"
 dependencies = [
  "async-trait",
  "objc2-web-kit",
@@ -10289,7 +10289,7 @@ dependencies = [
 
 [[package]]
 name = "workspace-manager"
-version = "0.1.33-artef.1"
+version = "0.1.33-artef.2"
 dependencies = [
  "db",
  "git",
@@ -10304,7 +10304,7 @@ dependencies = [
 
 [[package]]
 name = "worktree-manager"
-version = "0.1.33-artef.1"
+version = "0.1.33-artef.2"
 dependencies = [
  "dunce",
  "git",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,7 +199,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "api-types"
-version = "0.1.33-artef.5"
+version = "0.1.33-artef.6"
 dependencies = [
  "chrono",
  "schemars 1.2.1",
@@ -1599,7 +1599,7 @@ checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "db"
-version = "0.1.33-artef.5"
+version = "0.1.33-artef.6"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1641,7 +1641,7 @@ dependencies = [
 
 [[package]]
 name = "deployment"
-version = "0.1.33-artef.5"
+version = "0.1.33-artef.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2268,7 +2268,7 @@ dependencies = [
 
 [[package]]
 name = "executors"
-version = "0.1.33-artef.5"
+version = "0.1.33-artef.6"
 dependencies = [
  "agent-client-protocol",
  "async-stream",
@@ -2889,7 +2889,7 @@ dependencies = [
 
 [[package]]
 name = "git"
-version = "0.1.33-artef.5"
+version = "0.1.33-artef.6"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -2904,7 +2904,7 @@ dependencies = [
 
 [[package]]
 name = "git-host"
-version = "0.1.33-artef.5"
+version = "0.1.33-artef.6"
 dependencies = [
  "async-trait",
  "backon",
@@ -4124,7 +4124,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "local-deployment"
-version = "0.1.33-artef.5"
+version = "0.1.33-artef.6"
 dependencies = [
  "anyhow",
  "api-types",
@@ -4312,7 +4312,7 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "mcp"
-version = "0.1.33-artef.5"
+version = "0.1.33-artef.6"
 dependencies = [
  "anyhow",
  "api-types",
@@ -6028,7 +6028,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "relay-control"
-version = "0.1.33-artef.5"
+version = "0.1.33-artef.6"
 dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",
@@ -6141,7 +6141,7 @@ dependencies = [
 
 [[package]]
 name = "review"
-version = "0.1.33-artef.5"
+version = "0.1.33-artef.6"
 dependencies = [
  "anyhow",
  "clap",
@@ -6999,7 +6999,7 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.1.33-artef.5"
+version = "0.1.33-artef.6"
 dependencies = [
  "anyhow",
  "api-types",
@@ -7053,14 +7053,14 @@ dependencies = [
 
 [[package]]
 name = "server-info"
-version = "0.1.33-artef.5"
+version = "0.1.33-artef.6"
 dependencies = [
  "tokio",
 ]
 
 [[package]]
 name = "services"
-version = "0.1.33-artef.5"
+version = "0.1.33-artef.6"
 dependencies = [
  "anyhow",
  "api-types",
@@ -8874,7 +8874,7 @@ dependencies = [
 
 [[package]]
 name = "trusted-key-auth"
-version = "0.1.33-artef.5"
+version = "0.1.33-artef.6"
 dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",
@@ -9206,7 +9206,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "utils"
-version = "0.1.33-artef.5"
+version = "0.1.33-artef.6"
 dependencies = [
  "axum",
  "bytes",
@@ -9280,7 +9280,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vibe-kanban-tauri"
-version = "0.1.33-artef.5"
+version = "0.1.33-artef.6"
 dependencies = [
  "async-trait",
  "objc2-web-kit",
@@ -10289,7 +10289,7 @@ dependencies = [
 
 [[package]]
 name = "workspace-manager"
-version = "0.1.33-artef.5"
+version = "0.1.33-artef.6"
 dependencies = [
  "db",
  "git",
@@ -10304,7 +10304,7 @@ dependencies = [
 
 [[package]]
 name = "worktree-manager"
-version = "0.1.33-artef.5"
+version = "0.1.33-artef.6"
 dependencies = [
  "dunce",
  "git",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,41 +28,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "aead"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
-dependencies = [
- "crypto-common 0.1.6",
- "generic-array",
-]
-
-[[package]]
-name = "aes"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
-dependencies = [
- "cfg-if",
- "cipher",
- "cpufeatures",
-]
-
-[[package]]
-name = "aes-gcm"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
-dependencies = [
- "aead",
- "aes",
- "cipher",
- "ctr",
- "ghash",
- "subtle",
-]
-
-[[package]]
 name = "agent-client-protocol"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -99,7 +64,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
- "const-random",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -235,7 +199,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "api-types"
-version = "0.1.37"
+version = "0.1.33-artef.0"
 dependencies = [
  "chrono",
  "schemars 1.2.1",
@@ -256,80 +220,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "arboard"
-version = "3.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
-dependencies = [
- "clipboard-win",
- "image",
- "log",
- "objc2",
- "objc2-app-kit",
- "objc2-core-foundation",
- "objc2-core-graphics",
- "objc2-foundation",
- "parking_lot",
- "percent-encoding",
- "windows-sys 0.60.2",
- "x11rb",
-]
-
-[[package]]
-name = "arc-swap"
-version = "1.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9f3647c145568cec02c42054e07bdf9a5a698e15b466fb2341bfc393cd24aa5"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "ascii-canvas"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6"
 dependencies = [
  "term",
-]
-
-[[package]]
-name = "asn1-rs"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
-dependencies = [
- "asn1-rs-derive",
- "asn1-rs-impl",
- "displaydoc",
- "nom",
- "num-traits",
- "rusticata-macros",
- "thiserror 1.0.69",
- "time",
-]
-
-[[package]]
-name = "asn1-rs-derive"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "synstructure",
-]
-
-[[package]]
-name = "asn1-rs-impl"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -683,30 +579,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
-name = "bcrypt-pbkdf"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aeac2e1fe888769f34f05ac343bbef98b14d1ffb292ab69d4608b3abc86f2a2"
-dependencies = [
- "blowfish",
- "pbkdf2",
- "sha2 0.10.9",
-]
-
-[[package]]
 name = "beef"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
-
-[[package]]
-name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "bindgen"
@@ -792,15 +668,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "block-padding"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
 name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -823,16 +690,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "blowfish"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e412e2cd0f2b2d93e02543ceae7917b3c70331573df19ee046bcbc35e45e87d7"
-dependencies = [
- "byteorder",
- "cipher",
-]
-
-[[package]]
 name = "bon"
 version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -848,7 +705,7 @@ version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -989,15 +846,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cbc"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
-dependencies = [
- "cipher",
-]
-
-[[package]]
 name = "cc"
 version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1007,18 +855,6 @@ dependencies = [
  "jobserver",
  "libc",
  "shlex",
-]
-
-[[package]]
-name = "ccm"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae3c82e4355234767756212c570e29833699ab63e6ffd161887314cc5b43847"
-dependencies = [
- "aead",
- "cipher",
- "ctr",
- "subtle",
 ]
 
 [[package]]
@@ -1076,17 +912,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
-name = "chacha20"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
-dependencies = [
- "cfg-if",
- "cipher",
- "cpufeatures",
-]
-
-[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1098,16 +923,6 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link 0.2.1",
-]
-
-[[package]]
-name = "cipher"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
-dependencies = [
- "crypto-common 0.1.6",
- "inout",
 ]
 
 [[package]]
@@ -1162,10 +977,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
-name = "client-info"
-version = "0.1.37"
-
-[[package]]
 name = "clipboard-win"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1197,8 +1008,8 @@ checksum = "e9b18233253483ce2f65329a24072ec414db782531bdbb7d0bbc4bd2ce6b7e21"
 
 [[package]]
 name = "codex-app-server-protocol"
-version = "0.116.0"
-source = "git+https://github.com/openai/codex.git?tag=rust-v0.116.0#38771c9082535aa16b4c4d0395d3532f32f656ff"
+version = "0.114.0"
+source = "git+https://github.com/openai/codex.git?tag=rust-v0.114.0#b9904c0ae4ecb773549efd6ea3fb05229402fdb9"
 dependencies = [
  "anyhow",
  "clap",
@@ -1221,8 +1032,8 @@ dependencies = [
 
 [[package]]
 name = "codex-execpolicy"
-version = "0.116.0"
-source = "git+https://github.com/openai/codex.git?tag=rust-v0.116.0#38771c9082535aa16b4c4d0395d3532f32f656ff"
+version = "0.114.0"
+source = "git+https://github.com/openai/codex.git?tag=rust-v0.114.0#b9904c0ae4ecb773549efd6ea3fb05229402fdb9"
 dependencies = [
  "anyhow",
  "clap",
@@ -1237,8 +1048,8 @@ dependencies = [
 
 [[package]]
 name = "codex-experimental-api-macros"
-version = "0.116.0"
-source = "git+https://github.com/openai/codex.git?tag=rust-v0.116.0#38771c9082535aa16b4c4d0395d3532f32f656ff"
+version = "0.114.0"
+source = "git+https://github.com/openai/codex.git?tag=rust-v0.114.0#b9904c0ae4ecb773549efd6ea3fb05229402fdb9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1247,8 +1058,8 @@ dependencies = [
 
 [[package]]
 name = "codex-git"
-version = "0.116.0"
-source = "git+https://github.com/openai/codex.git?tag=rust-v0.116.0#38771c9082535aa16b4c4d0395d3532f32f656ff"
+version = "0.114.0"
+source = "git+https://github.com/openai/codex.git?tag=rust-v0.114.0#b9904c0ae4ecb773549efd6ea3fb05229402fdb9"
 dependencies = [
  "once_cell",
  "regex",
@@ -1262,8 +1073,8 @@ dependencies = [
 
 [[package]]
 name = "codex-protocol"
-version = "0.116.0"
-source = "git+https://github.com/openai/codex.git?tag=rust-v0.116.0#38771c9082535aa16b4c4d0395d3532f32f656ff"
+version = "0.114.0"
+source = "git+https://github.com/openai/codex.git?tag=rust-v0.114.0#b9904c0ae4ecb773549efd6ea3fb05229402fdb9"
 dependencies = [
  "codex-execpolicy",
  "codex-git",
@@ -1287,8 +1098,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-absolute-path"
-version = "0.116.0"
-source = "git+https://github.com/openai/codex.git?tag=rust-v0.116.0#38771c9082535aa16b4c4d0395d3532f32f656ff"
+version = "0.114.0"
+source = "git+https://github.com/openai/codex.git?tag=rust-v0.114.0#b9904c0ae4ecb773549efd6ea3fb05229402fdb9"
 dependencies = [
  "dirs 6.0.0",
  "path-absolutize",
@@ -1299,8 +1110,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-cache"
-version = "0.116.0"
-source = "git+https://github.com/openai/codex.git?tag=rust-v0.116.0#38771c9082535aa16b4c4d0395d3532f32f656ff"
+version = "0.114.0"
+source = "git+https://github.com/openai/codex.git?tag=rust-v0.114.0#b9904c0ae4ecb773549efd6ea3fb05229402fdb9"
 dependencies = [
  "lru 0.16.3",
  "sha1",
@@ -1309,8 +1120,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-image"
-version = "0.116.0"
-source = "git+https://github.com/openai/codex.git?tag=rust-v0.116.0#38771c9082535aa16b4c4d0395d3532f32f656ff"
+version = "0.114.0"
+source = "git+https://github.com/openai/codex.git?tag=rust-v0.114.0#b9904c0ae4ecb773549efd6ea3fb05229402fdb9"
 dependencies = [
  "base64 0.22.1",
  "codex-utils-cache",
@@ -1398,26 +1209,6 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
-
-[[package]]
-name = "const-random"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
-dependencies = [
- "const-random-macro",
-]
-
-[[package]]
-name = "const-random-macro"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
-dependencies = [
- "getrandom 0.2.17",
- "once_cell",
- "tiny-keccak",
-]
 
 [[package]]
 name = "convert_case"
@@ -1594,7 +1385,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -1668,15 +1458,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ctr"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
-dependencies = [
- "cipher",
-]
-
-[[package]]
 name = "ctutils"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1729,12 +1510,36 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+dependencies = [
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
+]
+
+[[package]]
+name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.11.1",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1752,11 +1557,22 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+dependencies = [
+ "darling_core 0.21.3",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core",
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.117",
 ]
@@ -1783,7 +1599,7 @@ checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "db"
-version = "0.1.37"
+version = "0.1.33-artef.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1824,38 +1640,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "delegate"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "780eb241654bf097afb00fc5f054a09b687dad862e485fdcf8399bb056565370"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "deployment"
-version = "0.1.37"
+version = "0.1.33-artef.0"
 dependencies = [
  "anyhow",
  "async-trait",
  "axum",
- "client-info",
  "db",
  "executors",
  "futures",
  "git",
- "preview-proxy",
+ "git2",
  "relay-control",
- "relay-hosts",
- "remote-info",
  "serde_json",
+ "server-info",
  "services",
  "sqlx",
  "thiserror 2.0.18",
  "tokio",
- "tokio-util",
  "trusted-key-auth",
  "utils",
  "worktree-manager",
@@ -1870,20 +1672,6 @@ dependencies = [
  "const-oid",
  "pem-rfc7468",
  "zeroize",
-]
-
-[[package]]
-name = "der-parser"
-version = "9.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
-dependencies = [
- "asn1-rs",
- "displaydoc",
- "nom",
- "num-bigint",
- "num-traits",
- "rusticata-macros",
 ]
 
 [[package]]
@@ -1974,29 +1762,6 @@ dependencies = [
  "rustc_version",
  "syn 2.0.117",
  "unicode-xid",
-]
-
-[[package]]
-name = "des"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffdd80ce8ce993de27e9f063a444a4d53ce8e8db4c1f00cc03af5ad5a9867a1e"
-dependencies = [
- "cipher",
-]
-
-[[package]]
-name = "desktop-bridge"
-version = "0.1.37"
-dependencies = [
- "base64 0.22.1",
- "dirs 5.0.1",
- "relay-control",
- "serde",
- "sha2 0.10.9",
- "ssh-key",
- "thiserror 2.0.18",
- "ts-rs 11.0.1",
 ]
 
 [[package]]
@@ -2348,22 +2113,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
 
 [[package]]
-name = "embedded-ssh"
-version = "0.1.37"
-dependencies = [
- "anyhow",
- "async-trait",
- "ed25519-dalek",
- "relay-control",
- "russh",
- "russh-keys",
- "russh-sftp",
- "ssh-key",
- "tokio",
- "tracing",
-]
-
-[[package]]
 name = "ena"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2519,7 +2268,7 @@ dependencies = [
 
 [[package]]
 name = "executors"
-version = "0.1.37"
+version = "0.1.33-artef.0"
 dependencies = [
  "agent-client-protocol",
  "async-stream",
@@ -2573,26 +2322,6 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
-
-[[package]]
-name = "fax"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f05de7d48f37cd6730705cbca900770cab77a89f413d23e100ad7fad7795a0ab"
-dependencies = [
- "fax_derive",
-]
-
-[[package]]
-name = "fax_derive"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0aca10fb742cb43f9e7bb8467c91aa9bcb8e3ffbc6a6f7389bb93ffc920577d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
 
 [[package]]
 name = "fd-lock"
@@ -2740,18 +2469,6 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "spin",
-]
-
-[[package]]
-name = "flurry"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf5efcf77a4da27927d3ab0509dec5b0954bb3bc59da5a1de9e52642ebd4cdf9"
-dependencies = [
- "ahash",
- "num_cpus",
- "parking_lot",
- "seize",
 ]
 
 [[package]]
@@ -3071,16 +2788,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gethostname"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
-dependencies = [
- "rustix",
- "windows-link 0.2.1",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3133,16 +2840,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ghash"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
-dependencies = [
- "opaque-debug",
- "polyval",
-]
-
-[[package]]
 name = "gif"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3192,7 +2889,7 @@ dependencies = [
 
 [[package]]
 name = "git"
-version = "0.1.37"
+version = "0.1.33-artef.0"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -3207,7 +2904,7 @@ dependencies = [
 
 [[package]]
 name = "git-host"
-version = "0.1.37"
+version = "0.1.33-artef.0"
 dependencies = [
  "async-trait",
  "backon",
@@ -3402,17 +3099,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "half"
-version = "2.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
-dependencies = [
- "cfg-if",
- "crunchy",
- "zerocopy",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3482,12 +3168,6 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "hex-literal"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
 name = "hkdf"
@@ -3672,7 +3352,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -3901,7 +3581,6 @@ dependencies = [
  "moxcms",
  "num-traits",
  "png 0.18.1",
- "tiff",
  "zune-core",
  "zune-jpeg",
 ]
@@ -3985,36 +3664,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "inout"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
-dependencies = [
- "block-padding",
- "generic-array",
-]
-
-[[package]]
-name = "interceptor"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ab04c530fd82e414e40394cabe5f0ebfe30d119f10fe29d6e3561926af412e"
-dependencies = [
- "async-trait",
- "bytes",
- "log",
- "portable-atomic",
- "rand 0.8.5",
- "rtcp",
- "rtp",
- "thiserror 1.0.69",
- "tokio",
- "waitgroup",
- "webrtc-srtp",
- "webrtc-util",
 ]
 
 [[package]]
@@ -4475,33 +4124,23 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "local-deployment"
-version = "0.1.37"
+version = "0.1.33-artef.0"
 dependencies = [
  "anyhow",
  "api-types",
  "async-trait",
- "base64 0.22.1",
- "client-info",
  "command-group",
  "db",
  "deployment",
  "dotenv",
- "ed25519-dalek",
- "embedded-ssh",
  "executors",
  "futures",
  "git",
  "globwalk",
  "portable-pty",
- "preview-proxy",
  "relay-control",
- "relay-hosts",
- "relay-types",
- "relay-webrtc",
- "remote-info",
- "russh",
- "serde",
  "serde_json",
+ "server-info",
  "services",
  "tempfile",
  "thiserror 2.0.18",
@@ -4673,7 +4312,7 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "mcp"
-version = "0.1.37"
+version = "0.1.33-artef.0"
 dependencies = [
  "anyhow",
  "api-types",
@@ -4681,13 +4320,12 @@ dependencies = [
  "executors",
  "regex",
  "reqwest 0.13.2",
- "rmcp 1.2.0",
+ "rmcp 0.5.0",
  "rustls",
  "schemars 1.2.1",
  "sentry",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -4706,12 +4344,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "md5"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
-
-[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4722,15 +4354,6 @@ name = "memoffset"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
-name = "memoffset"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
 dependencies = [
  "autocfg",
 ]
@@ -4932,19 +4555,6 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
-dependencies = [
- "bitflags 1.3.2",
- "cfg-if",
- "libc",
- "memoffset 0.7.1",
- "pin-utils",
-]
-
-[[package]]
-name = "nix"
 version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
@@ -5083,7 +4693,6 @@ checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
- "rand 0.8.5",
 ]
 
 [[package]]
@@ -5139,16 +4748,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_cpus"
-version = "1.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
-dependencies = [
- "hermit-abi",
- "libc",
-]
-
-[[package]]
 name = "num_enum"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5196,7 +4795,6 @@ dependencies = [
  "block2",
  "objc2",
  "objc2-core-foundation",
- "objc2-core-graphics",
  "objc2-foundation",
 ]
 
@@ -5418,15 +5016,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "oid-registry"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9"
-dependencies = [
- "asn1-rs",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5437,12 +5026,6 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
-
-[[package]]
-name = "opaque-debug"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "open"
@@ -5543,35 +5126,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "p521"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fc9e2161f1f215afdfce23677034ae137bbd45016a880c2eb3ba8eb95f085b2"
-dependencies = [
- "base16ct",
- "ecdsa",
- "elliptic-curve",
- "primeorder",
- "rand_core 0.6.4",
- "sha2 0.10.9",
-]
-
-[[package]]
-name = "pageant"
-version = "0.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "032d6201d2fb765158455ae0d5a510c016bb6da7232e5040e39e9c8db12b0afc"
-dependencies = [
- "bytes",
- "delegate",
- "futures",
- "rand 0.8.5",
- "thiserror 1.0.69",
- "tokio",
- "windows 0.58.0",
-]
-
-[[package]]
 name = "pango"
 version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5660,16 +5214,6 @@ name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
-
-[[package]]
-name = "pbkdf2"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
-dependencies = [
- "digest 0.10.7",
- "hmac 0.12.1",
-]
 
 [[package]]
 name = "pem"
@@ -5928,29 +5472,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "pkcs5"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e847e2c91a18bfa887dd028ec33f2fe6f25db77db3619024764914affe8b69a6"
-dependencies = [
- "aes",
- "cbc",
- "der",
- "pbkdf2",
- "scrypt",
- "sha2 0.10.9",
- "spki",
-]
-
-[[package]]
 name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
  "der",
- "pkcs5",
- "rand_core 0.6.4",
  "spki",
 ]
 
@@ -6020,29 +5547,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "poly1305"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
-dependencies = [
- "cpufeatures",
- "opaque-debug",
- "universal-hash",
-]
-
-[[package]]
-name = "polyval"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "opaque-debug",
- "universal-hash",
-]
-
-[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6109,21 +5613,6 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "preview-proxy"
-version = "0.1.37"
-dependencies = [
- "axum",
- "http",
- "reqwest 0.13.2",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
- "utils",
- "uuid",
- "ws-bridge",
 ]
 
 [[package]]
@@ -6246,7 +5735,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls",
- "socket2 0.6.3",
+ "socket2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6284,7 +5773,7 @@ dependencies = [
  "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -6443,20 +5932,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
-name = "rcgen"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
-dependencies = [
- "pem",
- "ring",
- "rustls-pki-types",
- "time",
- "x509-parser",
- "yasna",
-]
-
-[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6552,168 +6027,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
-name = "relay-client"
-version = "0.1.37"
-dependencies = [
- "anyhow",
- "base64 0.22.1",
- "ed25519-dalek",
- "http",
- "os_info",
- "relay-control",
- "relay-types",
- "relay-ws",
- "reqwest 0.13.2",
- "serde",
- "spake2",
- "thiserror 2.0.18",
- "tokio",
- "tokio-tungstenite 0.26.2",
- "trusted-key-auth",
- "utils",
- "uuid",
-]
-
-[[package]]
 name = "relay-control"
-version = "0.1.37"
+version = "0.1.33-artef.0"
 dependencies = [
- "anyhow",
  "base64 0.22.1",
  "ed25519-dalek",
  "rand 0.8.5",
- "sha2 0.10.9",
  "tokio",
  "tokio-util",
  "uuid",
 ]
 
 [[package]]
-name = "relay-hosts"
-version = "0.1.37"
+name = "relay-tunnel"
+version = "0.1.5"
 dependencies = [
+ "anyhow",
  "axum",
- "base64 0.22.1",
  "bytes",
- "chrono",
- "ed25519-dalek",
- "futures-util",
- "http",
- "relay-client",
- "relay-control",
- "relay-types",
- "relay-webrtc",
- "relay-ws",
- "remote-info",
- "reqwest 0.13.2",
- "serde",
- "serde_json",
- "services",
- "thiserror 2.0.18",
- "tokio",
- "tokio-tungstenite 0.26.2",
- "tokio-util",
- "tracing",
- "trusted-key-auth",
- "url",
- "utils",
- "uuid",
- "ws-bridge",
-]
-
-[[package]]
-name = "relay-protocol"
-version = "0.1.37"
-dependencies = [
- "anyhow",
- "axum",
- "serde",
- "tokio-tungstenite 0.26.2",
- "ts-rs 11.0.1",
-]
-
-[[package]]
-name = "relay-tunnel-core"
-version = "0.1.37"
-dependencies = [
- "anyhow",
- "axum",
+ "futures",
  "futures-util",
  "http",
  "hyper",
  "hyper-util",
  "rustls",
  "tokio",
- "tokio-tungstenite 0.26.2",
+ "tokio-tungstenite 0.24.0",
  "tokio-util",
  "tokio-yamux",
  "tracing",
- "ws-bridge",
 ]
-
-[[package]]
-name = "relay-types"
-version = "0.1.37"
-dependencies = [
- "chrono",
- "serde",
- "sqlx",
- "ts-rs 11.0.1",
- "uuid",
-]
-
-[[package]]
-name = "relay-webrtc"
-version = "0.1.37"
-dependencies = [
- "anyhow",
- "base64 0.22.1",
- "bytes",
- "futures-util",
- "http",
- "rand 0.8.5",
- "relay-protocol",
- "reqwest 0.13.2",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "tokio",
- "tokio-tungstenite 0.26.2",
- "tokio-util",
- "tracing",
- "ts-rs 11.0.1",
- "uuid",
- "webrtc",
- "webrtc-ice",
- "ws-bridge",
-]
-
-[[package]]
-name = "relay-ws"
-version = "0.1.37"
-dependencies = [
- "anyhow",
- "axum",
- "base64 0.22.1",
- "ed25519-dalek",
- "futures-channel",
- "futures-util",
- "http",
- "rand 0.8.5",
- "relay-control",
- "relay-protocol",
- "serde",
- "serde_json",
- "sha2 0.10.9",
- "thiserror 2.0.18",
- "tokio",
- "tokio-tungstenite 0.26.2",
- "uuid",
-]
-
-[[package]]
-name = "remote-info"
-version = "0.1.37"
 
 [[package]]
 name = "reqwest"
@@ -6798,7 +6141,7 @@ dependencies = [
 
 [[package]]
 name = "review"
-version = "0.1.37"
+version = "0.1.33-artef.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -6847,6 +6190,27 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2faf35b7d3c4b7f8c21c45bb014011b32a0ce6444bf6094da04daab01a8c3c34"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "futures",
+ "paste",
+ "pin-project-lite",
+ "rmcp-macros 0.5.0",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "rmcp"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bef41ebc9ebed2c1b1d90203e9d1756091e8a00bbc3107676151f39868ca0ee"
@@ -6868,34 +6232,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "rmcp"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba6b9d2f0efe2258b23767f1f9e0054cfbcac9c2d6f81a031214143096d7864f"
-dependencies = [
- "async-trait",
- "base64 0.22.1",
- "chrono",
- "futures",
- "pastey",
- "pin-project-lite",
- "rmcp-macros 1.2.0",
- "schemars 1.2.1",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
 name = "rmcp-macros"
-version = "0.15.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e88ad84b8b6237a934534a62b379a5be6388915663c0cc598ceb9b3292bbbfe"
+checksum = "ad9720d9d2a943779f1dc3d47fa9072c7eeffaff4e1a82f67eb9f7ea52696091"
 dependencies = [
- "darling",
+ "darling 0.21.3",
  "proc-macro2",
  "quote",
  "serde_json",
@@ -6904,11 +6246,11 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.2.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab9d95d7ed26ad8306352b0d5f05b593222b272790564589790d210aa15caa9e"
+checksum = "0e88ad84b8b6237a934534a62b379a5be6388915663c0cc598ceb9b3292bbbfe"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "serde_json",
@@ -6929,182 +6271,10 @@ dependencies = [
  "pkcs1",
  "pkcs8",
  "rand_core 0.6.4",
- "sha2 0.10.9",
  "signature",
  "spki",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rtcp"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8306430fb118b7834bbee50e744dc34826eca1da2158657a3d6cbc70e24c2096"
-dependencies = [
- "bytes",
- "thiserror 1.0.69",
- "webrtc-util",
-]
-
-[[package]]
-name = "rtp"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e68baca5b6cb4980678713f0d06ef3a432aa642baefcbfd0f4dd2ef9eb5ab550"
-dependencies = [
- "bytes",
- "memchr",
- "portable-atomic",
- "rand 0.8.5",
- "serde",
- "thiserror 1.0.69",
- "webrtc-util",
-]
-
-[[package]]
-name = "russh"
-version = "0.48.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c086efe0c429fa0b4e448c67147366d0319ed1c9a051d91b8f38e93fef25cc7"
-dependencies = [
- "aes",
- "aes-gcm",
- "async-trait",
- "bitflags 2.11.0",
- "byteorder",
- "bytes",
- "cbc",
- "chacha20",
- "ctr",
- "curve25519-dalek 4.1.3",
- "delegate",
- "des",
- "digest 0.10.7",
- "elliptic-curve",
- "flate2",
- "futures",
- "generic-array",
- "hex-literal",
- "hmac 0.12.1",
- "log",
- "num-bigint",
- "once_cell",
- "p256",
- "p384",
- "p521",
- "poly1305",
- "rand 0.8.5",
- "rand_core 0.6.4",
- "rsa",
- "russh-cryptovec",
- "russh-keys",
- "russh-sftp",
- "russh-util",
- "sha1",
- "sha2 0.10.9",
- "signature",
- "ssh-encoding",
- "ssh-key",
- "subtle",
- "thiserror 1.0.69",
- "tokio",
-]
-
-[[package]]
-name = "russh-cryptovec"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d8e7e854e1a87e4be00fa287c98cad23faa064d0464434beaa9f014ec3baa98"
-dependencies = [
- "libc",
- "ssh-encoding",
- "winapi",
-]
-
-[[package]]
-name = "russh-keys"
-version = "0.48.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed9bf3da16ad2892a44b840e40483010295bfc8fda8134650c381654cb1ef36"
-dependencies = [
- "aes",
- "async-trait",
- "bcrypt-pbkdf",
- "block-padding",
- "byteorder",
- "bytes",
- "cbc",
- "ctr",
- "data-encoding",
- "der",
- "digest 0.10.7",
- "ecdsa",
- "ed25519-dalek",
- "elliptic-curve",
- "futures",
- "getrandom 0.2.17",
- "hmac 0.12.1",
- "home",
- "inout",
- "log",
- "md5",
- "num-integer",
- "p256",
- "p384",
- "p521",
- "pageant",
- "pbkdf2",
- "pkcs1",
- "pkcs5",
- "pkcs8",
- "rand 0.8.5",
- "rand_core 0.6.4",
- "rsa",
- "russh-cryptovec",
- "russh-util",
- "sec1",
- "serde",
- "sha1",
- "sha2 0.10.9",
- "signature",
- "spki",
- "ssh-encoding",
- "ssh-key",
- "thiserror 1.0.69",
- "tokio",
- "tokio-stream",
- "typenum",
- "zeroize",
-]
-
-[[package]]
-name = "russh-sftp"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bb94393cafad0530145b8f626d8687f1ee1dedb93d7ba7740d6ae81868b13b5"
-dependencies = [
- "bitflags 2.11.0",
- "bytes",
- "chrono",
- "flurry",
- "log",
- "serde",
- "thiserror 2.0.18",
- "tokio",
- "tokio-util",
-]
-
-[[package]]
-name = "russh-util"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92c7dd577958c0cefbc8f8a2c05c48c88c42e2fdb760dbe9b96ae31d4de97a1f"
-dependencies = [
- "chrono",
- "tokio",
- "wasm-bindgen",
- "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -7166,15 +6336,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
-]
-
-[[package]]
-name = "rusticata-macros"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
-dependencies = [
- "nom",
 ]
 
 [[package]]
@@ -7300,15 +6461,6 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
-
-[[package]]
-name = "salsa20"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
-dependencies = [
- "cipher",
-]
 
 [[package]]
 name = "same-file"
@@ -7443,29 +6595,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "scrypt"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
-dependencies = [
- "pbkdf2",
- "salsa20",
- "sha2 0.10.9",
-]
-
-[[package]]
-name = "sdp"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02a526161f474ae94b966ba622379d939a8fe46c930eebbadb73e339622599d5"
-dependencies = [
- "rand 0.8.5",
- "substring",
- "thiserror 1.0.69",
- "url",
-]
-
-[[package]]
 name = "sec1"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7501,12 +6630,6 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
-
-[[package]]
-name = "seize"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "689224d06523904ebcc9b482c6a3f4f7fb396096645c4cd10c0d2ff7371a34d3"
 
 [[package]]
 name = "selectors"
@@ -7804,7 +6927,7 @@ version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -7876,7 +6999,7 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.1.37"
+version = "0.1.33-artef.0"
 dependencies = [
  "anyhow",
  "api-types",
@@ -7887,28 +7010,18 @@ dependencies = [
  "chrono",
  "db",
  "deployment",
- "desktop-bridge",
  "dotenv",
- "ed25519-dalek",
- "embedded-ssh",
  "executors",
  "futures-util",
  "git",
  "git-host",
+ "git2",
  "http",
  "local-deployment",
  "mime_guess",
  "os_info",
- "preview-proxy",
  "rand 0.8.5",
- "relay-client",
- "relay-control",
- "relay-hosts",
- "relay-protocol",
- "relay-tunnel-core",
- "relay-types",
- "relay-webrtc",
- "relay-ws",
+ "relay-tunnel",
  "reqwest 0.13.2",
  "rust-embed",
  "rustls",
@@ -7919,7 +7032,6 @@ dependencies = [
  "services",
  "sha2 0.10.9",
  "shlex",
- "spake2",
  "sqlx",
  "strip-ansi-escapes",
  "tempfile",
@@ -7937,12 +7049,18 @@ dependencies = [
  "uuid",
  "workspace-manager",
  "worktree-manager",
- "ws-bridge",
+]
+
+[[package]]
+name = "server-info"
+version = "0.1.33-artef.0"
+dependencies = [
+ "tokio",
 ]
 
 [[package]]
 name = "services"
-version = "0.1.37"
+version = "0.1.33-artef.0"
 dependencies = [
  "anyhow",
  "api-types",
@@ -7958,6 +7076,7 @@ dependencies = [
  "futures",
  "git",
  "git-host",
+ "git2",
  "ignore",
  "indicatif",
  "json-patch 2.0.0",
@@ -7968,7 +7087,6 @@ dependencies = [
  "notify-rust",
  "once_cell",
  "os_info",
- "relay-types",
  "reqwest 0.13.2",
  "rust-embed",
  "serde",
@@ -8183,25 +7301,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "smol_str"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd538fb6910ac1099850255cf94a94df6551fbdd602454387d0adb2d1ca6dead"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8493,58 +7592,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ssh-cipher"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caac132742f0d33c3af65bfcde7f6aa8f62f0e991d80db99149eb9d44708784f"
-dependencies = [
- "aes",
- "aes-gcm",
- "cbc",
- "chacha20",
- "cipher",
- "ctr",
- "poly1305",
- "ssh-encoding",
- "subtle",
-]
-
-[[package]]
-name = "ssh-encoding"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb9242b9ef4108a78e8cd1a2c98e193ef372437f8c22be363075233321dd4a15"
-dependencies = [
- "base64ct",
- "bytes",
- "pem-rfc7468",
- "sha2 0.10.9",
-]
-
-[[package]]
-name = "ssh-key"
-version = "0.6.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b86f5297f0f04d08cabaa0f6bff7cb6aec4d9c3b49d87990d63da9d9156a8c3"
-dependencies = [
- "bcrypt-pbkdf",
- "ed25519-dalek",
- "num-bigint-dig",
- "p256",
- "p384",
- "p521",
- "rand_core 0.6.4",
- "rsa",
- "sec1",
- "sha2 0.10.9",
- "signature",
- "ssh-cipher",
- "ssh-encoding",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8758,34 +7805,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "stun"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea256fb46a13f9204e9dee9982997b2c3097db175a9fddaa8350310d03c4d5a3"
-dependencies = [
- "base64 0.22.1",
- "crc",
- "lazy_static",
- "md-5",
- "rand 0.8.5",
- "ring",
- "subtle",
- "thiserror 1.0.69",
- "tokio",
- "url",
- "webrtc-util",
-]
-
-[[package]]
-name = "substring"
-version = "1.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ee6433ecef213b2e72f587ef64a2f5943e7cd16fbd82dbe8bc07486c534c86"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8904,7 +7923,7 @@ dependencies = [
  "tao-macros",
  "unicode-segmentation",
  "url",
- "windows 0.61.3",
+ "windows",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
@@ -8986,7 +8005,7 @@ dependencies = [
  "webkit2gtk",
  "webview2-com",
  "window-vibrancy",
- "windows 0.61.3",
+ "windows",
 ]
 
 [[package]]
@@ -9070,19 +8089,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tauri-plugin-macos-fps"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11177f7c97f1322fbcb5d966ebb0378e411145d65f3f2a2f897d8389ebdba583"
-dependencies = [
- "log",
- "objc2",
- "objc2-foundation",
- "serde",
- "tauri",
-]
-
-[[package]]
 name = "tauri-plugin-notification"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9119,7 +8125,7 @@ dependencies = [
  "tauri-plugin",
  "thiserror 2.0.18",
  "url",
- "windows 0.61.3",
+ "windows",
  "zbus",
 ]
 
@@ -9199,7 +8205,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows 0.61.3",
+ "windows",
 ]
 
 [[package]]
@@ -9224,7 +8230,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows 0.61.3",
+ "windows",
  "wry",
 ]
 
@@ -9285,7 +8291,7 @@ checksum = "0b1e66e07de489fe43a46678dd0b8df65e0c973909df1b60ba33874e297ba9b9"
 dependencies = [
  "quick-xml 0.37.5",
  "thiserror 2.0.18",
- "windows 0.61.3",
+ "windows",
  "windows-version",
 ]
 
@@ -9401,20 +8407,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tiff"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
-dependencies = [
- "fax",
- "flate2",
- "half",
- "quick-error",
- "weezl",
- "zune-jpeg",
-]
-
-[[package]]
 name = "time"
 version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9492,7 +8484,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.3",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -9532,6 +8524,22 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tungstenite 0.24.0",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "tokio-tungstenite"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
@@ -9544,7 +8552,6 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tungstenite 0.26.2",
- "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -9867,7 +8874,7 @@ dependencies = [
 
 [[package]]
 name = "trusted-key-auth"
-version = "0.1.37"
+version = "0.1.33-artef.0"
 dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",
@@ -9939,6 +8946,26 @@ dependencies = [
 
 [[package]]
 name = "tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "rustls",
+ "rustls-pki-types",
+ "sha1",
+ "thiserror 1.0.69",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
@@ -9971,27 +8998,6 @@ dependencies = [
  "sha1",
  "thiserror 2.0.18",
  "utf-8",
-]
-
-[[package]]
-name = "turn"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0044fdae001dd8a1e247ea6289abf12f4fcea1331a2364da512f9cd680bbd8cb"
-dependencies = [
- "async-trait",
- "base64 0.22.1",
- "futures",
- "log",
- "md-5",
- "portable-atomic",
- "rand 0.8.5",
- "ring",
- "stun",
- "thiserror 1.0.69",
- "tokio",
- "tokio-util",
- "webrtc-util",
 ]
 
 [[package]]
@@ -10116,16 +9122,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
-name = "universal-hash"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
-dependencies = [
- "crypto-common 0.1.6",
- "subtle",
-]
-
-[[package]]
 name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10210,7 +9206,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "utils"
-version = "0.1.37"
+version = "0.1.33-artef.0"
 dependencies = [
  "axum",
  "bytes",
@@ -10219,6 +9215,7 @@ dependencies = [
  "directories",
  "dirs 5.0.1",
  "futures",
+ "git2",
  "json-patch 2.0.0",
  "jsonwebtoken",
  "nix 0.29.0",
@@ -10283,12 +9280,9 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vibe-kanban-tauri"
-version = "0.1.37"
+version = "0.1.33-artef.0"
 dependencies = [
- "arboard",
  "async-trait",
- "objc2",
- "objc2-foundation",
  "objc2-web-kit",
  "rustls",
  "serde_json",
@@ -10296,7 +9290,6 @@ dependencies = [
  "services",
  "tauri",
  "tauri-build",
- "tauri-plugin-macos-fps",
  "tauri-plugin-notification",
  "tauri-plugin-opener",
  "tauri-plugin-shell",
@@ -10336,15 +9329,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "231fdcd7ef3037e8330d8e17e61011a2c244126acc0a982f4040ac3f9f0bc077"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "waitgroup"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1f50000a783467e6c0200f9d10642f4bc424e39efc1b770203e88b488f79292"
-dependencies = [
- "atomic-waker",
 ]
 
 [[package]]
@@ -10612,215 +9596,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "webrtc"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30367074d9f18231d28a74fab0120856b2b665da108d71a12beab7185a36f97b"
-dependencies = [
- "arc-swap",
- "async-trait",
- "bytes",
- "cfg-if",
- "hex",
- "interceptor",
- "lazy_static",
- "log",
- "portable-atomic",
- "rand 0.8.5",
- "rcgen",
- "regex",
- "ring",
- "rtcp",
- "rtp",
- "rustls",
- "sdp",
- "serde",
- "serde_json",
- "sha2 0.10.9",
- "smol_str",
- "stun",
- "thiserror 1.0.69",
- "time",
- "tokio",
- "turn",
- "url",
- "waitgroup",
- "webrtc-data",
- "webrtc-dtls",
- "webrtc-ice",
- "webrtc-mdns",
- "webrtc-media",
- "webrtc-sctp",
- "webrtc-srtp",
- "webrtc-util",
-]
-
-[[package]]
-name = "webrtc-data"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec93b991efcd01b73c5b3503fa8adba159d069abe5785c988ebe14fcf8f05d1"
-dependencies = [
- "bytes",
- "log",
- "portable-atomic",
- "thiserror 1.0.69",
- "tokio",
- "webrtc-sctp",
- "webrtc-util",
-]
-
-[[package]]
-name = "webrtc-dtls"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c9b89fc909f9da0499283b1112cd98f72fec28e55a54a9e352525ca65cd95c"
-dependencies = [
- "aes",
- "aes-gcm",
- "async-trait",
- "bincode",
- "byteorder",
- "cbc",
- "ccm",
- "der-parser",
- "hkdf 0.12.4",
- "hmac 0.12.1",
- "log",
- "p256",
- "p384",
- "portable-atomic",
- "rand 0.8.5",
- "rand_core 0.6.4",
- "rcgen",
- "ring",
- "rustls",
- "sec1",
- "serde",
- "sha1",
- "sha2 0.10.9",
- "subtle",
- "thiserror 1.0.69",
- "tokio",
- "webrtc-util",
- "x25519-dalek",
- "x509-parser",
-]
-
-[[package]]
-name = "webrtc-ice"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0348b28b593f7709ac98d872beb58c0009523df652c78e01b950ab9c537ff17d"
-dependencies = [
- "arc-swap",
- "async-trait",
- "crc",
- "log",
- "portable-atomic",
- "rand 0.8.5",
- "serde",
- "serde_json",
- "stun",
- "thiserror 1.0.69",
- "tokio",
- "turn",
- "url",
- "uuid",
- "waitgroup",
- "webrtc-mdns",
- "webrtc-util",
-]
-
-[[package]]
-name = "webrtc-mdns"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6dfe9686c6c9c51428da4de415cb6ca2dc0591ce2b63212e23fd9cccf0e316b"
-dependencies = [
- "log",
- "socket2 0.5.10",
- "thiserror 1.0.69",
- "tokio",
- "webrtc-util",
-]
-
-[[package]]
-name = "webrtc-media"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e153be16b8650021ad3e9e49ab6e5fa9fb7f6d1c23c213fd8bbd1a1135a4c704"
-dependencies = [
- "byteorder",
- "bytes",
- "rand 0.8.5",
- "rtp",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "webrtc-sctp"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5faf3846ec4b7e64b56338d62cbafe084aa79806b0379dff5cc74a8b7a2b3063"
-dependencies = [
- "arc-swap",
- "async-trait",
- "bytes",
- "crc",
- "log",
- "portable-atomic",
- "rand 0.8.5",
- "thiserror 1.0.69",
- "tokio",
- "webrtc-util",
-]
-
-[[package]]
-name = "webrtc-srtp"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "771db9993712a8fb3886d5be4613ebf27250ef422bd4071988bf55f1ed1a64fa"
-dependencies = [
- "aead",
- "aes",
- "aes-gcm",
- "byteorder",
- "bytes",
- "ctr",
- "hmac 0.12.1",
- "log",
- "rtcp",
- "rtp",
- "sha1",
- "subtle",
- "thiserror 1.0.69",
- "tokio",
- "webrtc-util",
-]
-
-[[package]]
-name = "webrtc-util"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1438a8fd0d69c5775afb4a71470af92242dbd04059c61895163aa3c1ef933375"
-dependencies = [
- "async-trait",
- "bitflags 1.3.2",
- "bytes",
- "ipnet",
- "lazy_static",
- "libc",
- "log",
- "nix 0.26.4",
- "portable-atomic",
- "rand 0.8.5",
- "thiserror 1.0.69",
- "tokio",
- "winapi",
-]
-
-[[package]]
 name = "webview2-com"
 version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10828,10 +9603,10 @@ checksum = "7130243a7a5b33c54a444e54842e6a9e133de08b5ad7b5861cd8ed9a6a5bc96a"
 dependencies = [
  "webview2-com-macros",
  "webview2-com-sys",
- "windows 0.61.3",
+ "windows",
  "windows-core 0.61.2",
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
+ "windows-implement",
+ "windows-interface",
 ]
 
 [[package]]
@@ -10852,7 +9627,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c"
 dependencies = [
  "thiserror 2.0.18",
- "windows 0.61.3",
+ "windows",
  "windows-core 0.61.2",
 ]
 
@@ -10929,16 +9704,6 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
-dependencies = [
- "windows-core 0.58.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows"
 version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
@@ -10961,25 +9726,12 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
-dependencies = [
- "windows-implement 0.58.0",
- "windows-interface 0.58.0",
- "windows-result 0.2.0",
- "windows-strings 0.1.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-core"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
+ "windows-implement",
+ "windows-interface",
  "windows-link 0.1.3",
  "windows-result 0.3.4",
  "windows-strings 0.4.2",
@@ -10991,8 +9743,8 @@ version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
+ "windows-implement",
+ "windows-interface",
  "windows-link 0.2.1",
  "windows-result 0.4.1",
  "windows-strings 0.5.1",
@@ -11011,31 +9763,9 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11077,15 +9807,6 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-result"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
@@ -11100,16 +9821,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
  "windows-link 0.2.1",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
-dependencies = [
- "windows-result 0.2.0",
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -11578,7 +10289,7 @@ dependencies = [
 
 [[package]]
 name = "workspace-manager"
-version = "0.1.37"
+version = "0.1.33-artef.0"
 dependencies = [
  "db",
  "git",
@@ -11593,10 +10304,11 @@ dependencies = [
 
 [[package]]
 name = "worktree-manager"
-version = "0.1.37"
+version = "0.1.33-artef.0"
 dependencies = [
  "dunce",
  "git",
+ "git2",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -11648,24 +10360,10 @@ dependencies = [
  "webkit2gtk",
  "webkit2gtk-sys",
  "webview2-com",
- "windows 0.61.3",
+ "windows",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
-]
-
-[[package]]
-name = "ws-bridge"
-version = "0.1.37"
-dependencies = [
- "axum",
- "bytes",
- "futures",
- "futures-util",
- "http",
- "thiserror 2.0.18",
- "tokio",
- "tokio-tungstenite 0.26.2",
 ]
 
 [[package]]
@@ -11690,53 +10388,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "x11rb"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
-dependencies = [
- "gethostname",
- "rustix",
- "x11rb-protocol",
-]
-
-[[package]]
-name = "x11rb-protocol"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
-
-[[package]]
-name = "x25519-dalek"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
-dependencies = [
- "curve25519-dalek 4.1.3",
- "rand_core 0.6.4",
- "serde",
- "zeroize",
-]
-
-[[package]]
-name = "x509-parser"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
-dependencies = [
- "asn1-rs",
- "data-encoding",
- "der-parser",
- "lazy_static",
- "nom",
- "oid-registry",
- "ring",
- "rusticata-macros",
- "thiserror 1.0.69",
- "time",
-]
-
-[[package]]
 name = "xattr"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11751,15 +10402,6 @@ name = "xdg"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fb433233f2df9344722454bc7e96465c9d03bff9d77c248f9e7523fe79585b5"
-
-[[package]]
-name = "yasna"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
-dependencies = [
- "time",
-]
 
 [[package]]
 name = "yoke"
@@ -11891,20 +10533,6 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
-dependencies = [
- "zeroize_derive",
-]
-
-[[package]]
-name = "zeroize_derive"
-version = "1.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
 
 [[package]]
 name = "zerotrie"

--- a/crates/api-types/Cargo.toml
+++ b/crates/api-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "api-types"
-version = "0.1.33-artef.5"
+version = "0.1.33-artef.6"
 edition = "2024"
 
 [dependencies]

--- a/crates/api-types/Cargo.toml
+++ b/crates/api-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "api-types"
-version = "0.1.37"
+version = "0.1.33-artef.0"
 edition = "2024"
 
 [dependencies]

--- a/crates/api-types/Cargo.toml
+++ b/crates/api-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "api-types"
-version = "0.1.33-artef.0"
+version = "0.1.33-artef.1"
 edition = "2024"
 
 [dependencies]

--- a/crates/api-types/Cargo.toml
+++ b/crates/api-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "api-types"
-version = "0.1.33-artef.1"
+version = "0.1.33-artef.2"
 edition = "2024"
 
 [dependencies]

--- a/crates/api-types/Cargo.toml
+++ b/crates/api-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "api-types"
-version = "0.1.33-artef.4"
+version = "0.1.33-artef.5"
 edition = "2024"
 
 [dependencies]

--- a/crates/api-types/Cargo.toml
+++ b/crates/api-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "api-types"
-version = "0.1.33-artef.3"
+version = "0.1.33-artef.4"
 edition = "2024"
 
 [dependencies]

--- a/crates/api-types/Cargo.toml
+++ b/crates/api-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "api-types"
-version = "0.1.33-artef.2"
+version = "0.1.33-artef.3"
 edition = "2024"
 
 [dependencies]

--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "db"
-version = "0.1.33-artef.1"
+version = "0.1.33-artef.2"
 edition = "2024"
 
 [dependencies]

--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "db"
-version = "0.1.33-artef.0"
+version = "0.1.33-artef.1"
 edition = "2024"
 
 [dependencies]

--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "db"
-version = "0.1.33-artef.3"
+version = "0.1.33-artef.4"
 edition = "2024"
 
 [dependencies]

--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "db"
-version = "0.1.37"
+version = "0.1.33-artef.0"
 edition = "2024"
 
 [dependencies]

--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "db"
-version = "0.1.33-artef.2"
+version = "0.1.33-artef.3"
 edition = "2024"
 
 [dependencies]

--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "db"
-version = "0.1.33-artef.5"
+version = "0.1.33-artef.6"
 edition = "2024"
 
 [dependencies]

--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "db"
-version = "0.1.33-artef.4"
+version = "0.1.33-artef.5"
 edition = "2024"
 
 [dependencies]

--- a/crates/deployment/Cargo.toml
+++ b/crates/deployment/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deployment"
-version = "0.1.37"
+version = "0.1.33-artef.0"
 edition = "2024"
 
 [dependencies]
@@ -14,14 +14,11 @@ async-trait = { workspace = true }
 thiserror = { workspace = true } 
 anyhow = { workspace = true }
 relay-control = { path = "../relay-control" }
-relay-hosts = { path = "../relay-hosts" }
 trusted-key-auth = { path = "../trusted-key-auth" }
-client-info = { path = "../client-info" }
-remote-info = { path = "../remote-info" }
-preview-proxy = { path = "../preview-proxy" }
+server-info = { path = "../server-info" }
 tokio = { workspace = true }
 sqlx = "0.8.6"
 serde_json = { workspace = true }
+git2 = { workspace = true }
 futures = "0.3.31"
 axum = { workspace = true }
-tokio-util = { version = "0.7" }

--- a/crates/deployment/Cargo.toml
+++ b/crates/deployment/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deployment"
-version = "0.1.33-artef.2"
+version = "0.1.33-artef.3"
 edition = "2024"
 
 [dependencies]

--- a/crates/deployment/Cargo.toml
+++ b/crates/deployment/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deployment"
-version = "0.1.33-artef.3"
+version = "0.1.33-artef.4"
 edition = "2024"
 
 [dependencies]

--- a/crates/deployment/Cargo.toml
+++ b/crates/deployment/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deployment"
-version = "0.1.33-artef.5"
+version = "0.1.33-artef.6"
 edition = "2024"
 
 [dependencies]

--- a/crates/deployment/Cargo.toml
+++ b/crates/deployment/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deployment"
-version = "0.1.33-artef.1"
+version = "0.1.33-artef.2"
 edition = "2024"
 
 [dependencies]

--- a/crates/deployment/Cargo.toml
+++ b/crates/deployment/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deployment"
-version = "0.1.33-artef.4"
+version = "0.1.33-artef.5"
 edition = "2024"
 
 [dependencies]

--- a/crates/deployment/Cargo.toml
+++ b/crates/deployment/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deployment"
-version = "0.1.33-artef.0"
+version = "0.1.33-artef.1"
 edition = "2024"
 
 [dependencies]

--- a/crates/executors/Cargo.toml
+++ b/crates/executors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "executors"
-version = "0.1.33-artef.5"
+version = "0.1.33-artef.6"
 edition = "2024"
 
 [dependencies]

--- a/crates/executors/Cargo.toml
+++ b/crates/executors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "executors"
-version = "0.1.33-artef.1"
+version = "0.1.33-artef.2"
 edition = "2024"
 
 [dependencies]

--- a/crates/executors/Cargo.toml
+++ b/crates/executors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "executors"
-version = "0.1.33-artef.4"
+version = "0.1.33-artef.5"
 edition = "2024"
 
 [dependencies]

--- a/crates/executors/Cargo.toml
+++ b/crates/executors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "executors"
-version = "0.1.33-artef.2"
+version = "0.1.33-artef.3"
 edition = "2024"
 
 [dependencies]

--- a/crates/executors/Cargo.toml
+++ b/crates/executors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "executors"
-version = "0.1.33-artef.0"
+version = "0.1.33-artef.1"
 edition = "2024"
 
 [dependencies]

--- a/crates/executors/Cargo.toml
+++ b/crates/executors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "executors"
-version = "0.1.37"
+version = "0.1.33-artef.0"
 edition = "2024"
 
 [dependencies]
@@ -36,8 +36,8 @@ convert_case = "0.6"
 sqlx = "0.8.6"
 shlex = "1.3.0"
 agent-client-protocol = { version = "0.8", features = ["unstable"] }
-codex-protocol = { git = "https://github.com/openai/codex.git", package = "codex-protocol", tag = "rust-v0.116.0" }
-codex-app-server-protocol = { git = "https://github.com/openai/codex.git", package = "codex-app-server-protocol", tag = "rust-v0.116.0" }
+codex-protocol = { git = "https://github.com/openai/codex.git", package = "codex-protocol", tag = "rust-v0.114.0" }
+codex-app-server-protocol = { git = "https://github.com/openai/codex.git", package = "codex-app-server-protocol", tag = "rust-v0.114.0" }
 sha2 = "0.10"
 derivative = "2.2.0"
 reqwest = { workspace = true }

--- a/crates/executors/Cargo.toml
+++ b/crates/executors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "executors"
-version = "0.1.33-artef.3"
+version = "0.1.33-artef.4"
 edition = "2024"
 
 [dependencies]

--- a/crates/git-host/Cargo.toml
+++ b/crates/git-host/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-host"
-version = "0.1.33-artef.1"
+version = "0.1.33-artef.2"
 edition = "2024"
 
 [dependencies]

--- a/crates/git-host/Cargo.toml
+++ b/crates/git-host/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-host"
-version = "0.1.33-artef.5"
+version = "0.1.33-artef.6"
 edition = "2024"
 
 [dependencies]

--- a/crates/git-host/Cargo.toml
+++ b/crates/git-host/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-host"
-version = "0.1.33-artef.4"
+version = "0.1.33-artef.5"
 edition = "2024"
 
 [dependencies]

--- a/crates/git-host/Cargo.toml
+++ b/crates/git-host/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-host"
-version = "0.1.33-artef.0"
+version = "0.1.33-artef.1"
 edition = "2024"
 
 [dependencies]

--- a/crates/git-host/Cargo.toml
+++ b/crates/git-host/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-host"
-version = "0.1.37"
+version = "0.1.33-artef.0"
 edition = "2024"
 
 [dependencies]

--- a/crates/git-host/Cargo.toml
+++ b/crates/git-host/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-host"
-version = "0.1.33-artef.3"
+version = "0.1.33-artef.4"
 edition = "2024"
 
 [dependencies]

--- a/crates/git-host/Cargo.toml
+++ b/crates/git-host/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-host"
-version = "0.1.33-artef.2"
+version = "0.1.33-artef.3"
 edition = "2024"
 
 [dependencies]

--- a/crates/git/Cargo.toml
+++ b/crates/git/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git"
-version = "0.1.33-artef.0"
+version = "0.1.33-artef.1"
 edition = "2024"
 
 [features]

--- a/crates/git/Cargo.toml
+++ b/crates/git/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git"
-version = "0.1.37"
+version = "0.1.33-artef.0"
 edition = "2024"
 
 [features]

--- a/crates/git/Cargo.toml
+++ b/crates/git/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git"
-version = "0.1.33-artef.1"
+version = "0.1.33-artef.2"
 edition = "2024"
 
 [features]

--- a/crates/git/Cargo.toml
+++ b/crates/git/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git"
-version = "0.1.33-artef.4"
+version = "0.1.33-artef.5"
 edition = "2024"
 
 [features]

--- a/crates/git/Cargo.toml
+++ b/crates/git/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git"
-version = "0.1.33-artef.2"
+version = "0.1.33-artef.3"
 edition = "2024"
 
 [features]

--- a/crates/git/Cargo.toml
+++ b/crates/git/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git"
-version = "0.1.33-artef.3"
+version = "0.1.33-artef.4"
 edition = "2024"
 
 [features]

--- a/crates/git/Cargo.toml
+++ b/crates/git/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git"
-version = "0.1.33-artef.5"
+version = "0.1.33-artef.6"
 edition = "2024"
 
 [features]

--- a/crates/local-deployment/Cargo.toml
+++ b/crates/local-deployment/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "local-deployment"
-version = "0.1.33-artef.2"
+version = "0.1.33-artef.3"
 edition = "2024"
 
 [dependencies]

--- a/crates/local-deployment/Cargo.toml
+++ b/crates/local-deployment/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "local-deployment"
-version = "0.1.37"
+version = "0.1.33-artef.0"
 edition = "2024"
 
 [dependencies]
@@ -8,15 +8,8 @@ api-types = { path = "../api-types" }
 db = { path = "../db" }
 executors = { path="../executors" }
 deployment = { path = "../deployment" }
-embedded-ssh = { path = "../embedded-ssh" }
 relay-control = { path = "../relay-control" }
-relay-hosts = { path = "../relay-hosts" }
-relay-webrtc = { path = "../relay-webrtc" }
-relay-types = { path = "../relay-types" }
-russh = "0.48"
-client-info = { path = "../client-info" }
-remote-info = { path = "../remote-info" }
-preview-proxy = { path = "../preview-proxy" }
+server-info = { path = "../server-info" }
 services = { path = "../services" }
 worktree-manager = { path = "../worktree-manager" }
 workspace-manager = { path = "../workspace-manager" }
@@ -25,9 +18,6 @@ git = { path = "../git" }
 trusted-key-auth = { path = "../trusted-key-auth" }
 tokio-util = { version = "0.7", features = ["io"] }
 serde_json = { workspace = true }
-serde = { workspace = true }
-base64 = "0.22"
-ed25519-dalek = "2.2.0"
 anyhow = { workspace = true }
 tracing = { workspace = true }
 uuid = { version = "1.0", features = ["v4", "serde"] }

--- a/crates/local-deployment/Cargo.toml
+++ b/crates/local-deployment/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "local-deployment"
-version = "0.1.33-artef.5"
+version = "0.1.33-artef.6"
 edition = "2024"
 
 [dependencies]

--- a/crates/local-deployment/Cargo.toml
+++ b/crates/local-deployment/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "local-deployment"
-version = "0.1.33-artef.4"
+version = "0.1.33-artef.5"
 edition = "2024"
 
 [dependencies]

--- a/crates/local-deployment/Cargo.toml
+++ b/crates/local-deployment/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "local-deployment"
-version = "0.1.33-artef.3"
+version = "0.1.33-artef.4"
 edition = "2024"
 
 [dependencies]

--- a/crates/local-deployment/Cargo.toml
+++ b/crates/local-deployment/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "local-deployment"
-version = "0.1.33-artef.0"
+version = "0.1.33-artef.1"
 edition = "2024"
 
 [dependencies]

--- a/crates/local-deployment/Cargo.toml
+++ b/crates/local-deployment/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "local-deployment"
-version = "0.1.33-artef.1"
+version = "0.1.33-artef.2"
 edition = "2024"
 
 [dependencies]

--- a/crates/mcp/Cargo.toml
+++ b/crates/mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp"
-version = "0.1.33-artef.4"
+version = "0.1.33-artef.5"
 edition = "2024"
 autobins = false
 

--- a/crates/mcp/Cargo.toml
+++ b/crates/mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp"
-version = "0.1.33-artef.5"
+version = "0.1.33-artef.6"
 edition = "2024"
 autobins = false
 

--- a/crates/mcp/Cargo.toml
+++ b/crates/mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp"
-version = "0.1.33-artef.3"
+version = "0.1.33-artef.4"
 edition = "2024"
 autobins = false
 

--- a/crates/mcp/Cargo.toml
+++ b/crates/mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp"
-version = "0.1.37"
+version = "0.1.33-artef.0"
 edition = "2024"
 autobins = false
 
@@ -23,10 +23,9 @@ anyhow = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 uuid = { version = "1.0", features = ["v4", "serde"] }
-rmcp = { version = "1.2.0", features = ["server", "transport-io"] }
+rmcp = { version = "0.5.0", features = ["server", "transport-io"] }
 schemars = { workspace = true }
 sentry = { version = "0.46.2", default-features = false, features = ["anyhow", "backtrace", "panic", "debug-images", "reqwest", "rustls"] }
 reqwest = { workspace = true }
 rustls = { workspace = true }
 regex = "1"
-thiserror = { workspace = true }

--- a/crates/mcp/Cargo.toml
+++ b/crates/mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp"
-version = "0.1.33-artef.1"
+version = "0.1.33-artef.2"
 edition = "2024"
 autobins = false
 

--- a/crates/mcp/Cargo.toml
+++ b/crates/mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp"
-version = "0.1.33-artef.2"
+version = "0.1.33-artef.3"
 edition = "2024"
 autobins = false
 

--- a/crates/mcp/Cargo.toml
+++ b/crates/mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp"
-version = "0.1.33-artef.0"
+version = "0.1.33-artef.1"
 edition = "2024"
 autobins = false
 

--- a/crates/relay-control/Cargo.toml
+++ b/crates/relay-control/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "relay-control"
-version = "0.1.33-artef.5"
+version = "0.1.33-artef.6"
 edition = "2024"
 
 [dependencies]

--- a/crates/relay-control/Cargo.toml
+++ b/crates/relay-control/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "relay-control"
-version = "0.1.33-artef.4"
+version = "0.1.33-artef.5"
 edition = "2024"
 
 [dependencies]

--- a/crates/relay-control/Cargo.toml
+++ b/crates/relay-control/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "relay-control"
-version = "0.1.33-artef.0"
+version = "0.1.33-artef.1"
 edition = "2024"
 
 [dependencies]

--- a/crates/relay-control/Cargo.toml
+++ b/crates/relay-control/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "relay-control"
-version = "0.1.33-artef.3"
+version = "0.1.33-artef.4"
 edition = "2024"
 
 [dependencies]

--- a/crates/relay-control/Cargo.toml
+++ b/crates/relay-control/Cargo.toml
@@ -1,14 +1,12 @@
 [package]
 name = "relay-control"
-version = "0.1.37"
+version = "0.1.33-artef.0"
 edition = "2024"
 
 [dependencies]
-anyhow = "1.0"
 tokio = { workspace = true }
 tokio-util = { version = "0.7", features = ["io"] }
 base64 = "0.22"
 ed25519-dalek = { version = "2.2.0", features = ["rand_core"] }
 rand = "0.8"
-sha2 = "0.10"
 uuid = { version = "1.0", features = ["v4"] }

--- a/crates/relay-control/Cargo.toml
+++ b/crates/relay-control/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "relay-control"
-version = "0.1.33-artef.2"
+version = "0.1.33-artef.3"
 edition = "2024"
 
 [dependencies]

--- a/crates/relay-control/Cargo.toml
+++ b/crates/relay-control/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "relay-control"
-version = "0.1.33-artef.1"
+version = "0.1.33-artef.2"
 edition = "2024"
 
 [dependencies]

--- a/crates/relay-tunnel/Cargo.lock
+++ b/crates/relay-tunnel/Cargo.lock
@@ -34,7 +34,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "api-types"
-version = "0.1.37"
+version = "0.1.33-artef.0"
 dependencies = [
  "chrono",
  "schemars",
@@ -482,7 +482,6 @@ checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand_core 0.6.4",
  "serde",
  "sha2",
  "subtle",
@@ -1686,33 +1685,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
-name = "relay-control"
-version = "0.1.37"
-dependencies = [
- "anyhow",
- "base64",
- "ed25519-dalek",
- "rand 0.8.5",
- "sha2",
- "tokio",
- "tokio-util",
- "uuid",
-]
-
-[[package]]
-name = "relay-protocol"
-version = "0.1.37"
-dependencies = [
- "anyhow",
- "axum",
- "serde",
- "tokio-tungstenite 0.26.2",
- "ts-rs",
-]
-
-[[package]]
 name = "relay-tunnel"
-version = "0.1.7"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "api-types",
@@ -1727,73 +1701,19 @@ dependencies = [
  "hyper",
  "hyper-util",
  "jsonwebtoken",
- "relay-tunnel-core",
- "relay-types",
- "relay-ws",
  "rustls",
  "secrecy",
  "serde",
  "sha2",
  "sqlx",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
- "tokio-tungstenite 0.26.2",
+ "tokio-tungstenite 0.24.0",
  "tokio-util",
  "tokio-yamux",
  "tower-http",
  "tracing",
  "tracing-subscriber",
- "uuid",
-]
-
-[[package]]
-name = "relay-tunnel-core"
-version = "0.1.37"
-dependencies = [
- "anyhow",
- "axum",
- "futures-util",
- "http",
- "hyper",
- "hyper-util",
- "rustls",
- "tokio",
- "tokio-tungstenite 0.26.2",
- "tokio-util",
- "tokio-yamux",
- "tracing",
- "ws-bridge",
-]
-
-[[package]]
-name = "relay-types"
-version = "0.1.37"
-dependencies = [
- "chrono",
- "serde",
- "sqlx",
- "ts-rs",
- "uuid",
-]
-
-[[package]]
-name = "relay-ws"
-version = "0.1.37"
-dependencies = [
- "anyhow",
- "axum",
- "base64",
- "ed25519-dalek",
- "futures-util",
- "http",
- "relay-control",
- "relay-protocol",
- "serde",
- "serde_json",
- "sha2",
- "thiserror",
- "tokio",
- "tokio-tungstenite 0.26.2",
  "uuid",
 ]
 
@@ -2102,7 +2022,7 @@ checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
 dependencies = [
  "num-bigint",
  "num-traits",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
 ]
 
@@ -2192,7 +2112,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "smallvec",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -2277,7 +2197,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
  "uuid",
  "whoami",
@@ -2316,7 +2236,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
  "uuid",
  "whoami",
@@ -2342,7 +2262,7 @@ dependencies = [
  "serde",
  "serde_urlencoded",
  "sqlx-core",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
  "url",
  "uuid",
@@ -2410,11 +2330,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2544,9 +2484,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.26.2"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
+checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
 dependencies = [
  "futures-util",
  "log",
@@ -2554,7 +2494,7 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
- "tungstenite 0.26.2",
+ "tungstenite 0.24.0",
  "webpki-roots 0.26.11",
 ]
 
@@ -2579,7 +2519,6 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
- "futures-util",
  "pin-project-lite",
  "tokio",
 ]
@@ -2709,9 +2648,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.23"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -2741,7 +2680,7 @@ source = "git+https://github.com/xazukx/ts-rs.git?branch=use-ts-enum#b5c8277ac9f
 dependencies = [
  "chrono",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "ts-rs-macros",
  "uuid",
 ]
@@ -2759,20 +2698,21 @@ dependencies = [
 
 [[package]]
 name = "tungstenite"
-version = "0.26.2"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
 dependencies = [
+ "byteorder",
  "bytes",
  "data-encoding",
  "http",
  "httparse",
  "log",
- "rand 0.9.2",
+ "rand 0.8.5",
  "rustls",
  "rustls-pki-types",
  "sha1",
- "thiserror",
+ "thiserror 1.0.69",
  "utf-8",
 ]
 
@@ -2789,7 +2729,7 @@ dependencies = [
  "log",
  "rand 0.9.2",
  "sha1",
- "thiserror",
+ "thiserror 2.0.18",
  "utf-8",
 ]
 
@@ -3363,20 +3303,6 @@ name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
-
-[[package]]
-name = "ws-bridge"
-version = "0.1.37"
-dependencies = [
- "axum",
- "bytes",
- "futures",
- "futures-util",
- "http",
- "thiserror",
- "tokio",
- "tokio-tungstenite 0.26.2",
-]
 
 [[package]]
 name = "yoke"

--- a/crates/relay-tunnel/Cargo.lock
+++ b/crates/relay-tunnel/Cargo.lock
@@ -34,7 +34,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "api-types"
-version = "0.1.33-artef.5"
+version = "0.1.33-artef.6"
 dependencies = [
  "chrono",
  "schemars",

--- a/crates/relay-tunnel/Cargo.lock
+++ b/crates/relay-tunnel/Cargo.lock
@@ -34,7 +34,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "api-types"
-version = "0.1.33-artef.2"
+version = "0.1.33-artef.3"
 dependencies = [
  "chrono",
  "schemars",

--- a/crates/relay-tunnel/Cargo.lock
+++ b/crates/relay-tunnel/Cargo.lock
@@ -34,7 +34,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "api-types"
-version = "0.1.33-artef.3"
+version = "0.1.33-artef.4"
 dependencies = [
  "chrono",
  "schemars",

--- a/crates/relay-tunnel/Cargo.lock
+++ b/crates/relay-tunnel/Cargo.lock
@@ -34,7 +34,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "api-types"
-version = "0.1.33-artef.1"
+version = "0.1.33-artef.2"
 dependencies = [
  "chrono",
  "schemars",

--- a/crates/relay-tunnel/Cargo.lock
+++ b/crates/relay-tunnel/Cargo.lock
@@ -34,7 +34,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "api-types"
-version = "0.1.33-artef.4"
+version = "0.1.33-artef.5"
 dependencies = [
  "chrono",
  "schemars",

--- a/crates/relay-tunnel/Cargo.lock
+++ b/crates/relay-tunnel/Cargo.lock
@@ -34,7 +34,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "api-types"
-version = "0.1.33-artef.0"
+version = "0.1.33-artef.1"
 dependencies = [
  "chrono",
  "schemars",

--- a/crates/remote/Cargo.lock
+++ b/crates/remote/Cargo.lock
@@ -3184,7 +3184,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "remote"
-version = "0.1.23"
+version = "0.1.24"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/crates/remote/Cargo.lock
+++ b/crates/remote/Cargo.lock
@@ -99,7 +99,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "api-types"
-version = "0.1.33-artef.5"
+version = "0.1.33-artef.6"
 dependencies = [
  "chrono",
  "schemars",
@@ -4835,7 +4835,7 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utils"
-version = "0.1.33-artef.5"
+version = "0.1.33-artef.6"
 dependencies = [
  "axum",
  "bytes",

--- a/crates/remote/Cargo.lock
+++ b/crates/remote/Cargo.lock
@@ -99,7 +99,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "api-types"
-version = "0.1.33-artef.0"
+version = "0.1.33-artef.1"
 dependencies = [
  "chrono",
  "schemars",
@@ -4835,7 +4835,7 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utils"
-version = "0.1.33-artef.0"
+version = "0.1.33-artef.1"
 dependencies = [
  "axum",
  "bytes",

--- a/crates/remote/Cargo.lock
+++ b/crates/remote/Cargo.lock
@@ -99,7 +99,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "api-types"
-version = "0.1.33-artef.3"
+version = "0.1.33-artef.4"
 dependencies = [
  "chrono",
  "schemars",
@@ -4835,7 +4835,7 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utils"
-version = "0.1.33-artef.3"
+version = "0.1.33-artef.4"
 dependencies = [
  "axum",
  "bytes",

--- a/crates/remote/Cargo.lock
+++ b/crates/remote/Cargo.lock
@@ -99,7 +99,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "api-types"
-version = "0.1.33-artef.1"
+version = "0.1.33-artef.2"
 dependencies = [
  "chrono",
  "schemars",
@@ -4835,7 +4835,7 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utils"
-version = "0.1.33-artef.1"
+version = "0.1.33-artef.2"
 dependencies = [
  "axum",
  "bytes",

--- a/crates/remote/Cargo.lock
+++ b/crates/remote/Cargo.lock
@@ -99,7 +99,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "api-types"
-version = "0.1.33-artef.4"
+version = "0.1.33-artef.5"
 dependencies = [
  "chrono",
  "schemars",
@@ -4835,7 +4835,7 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utils"
-version = "0.1.33-artef.4"
+version = "0.1.33-artef.5"
 dependencies = [
  "axum",
  "bytes",

--- a/crates/remote/Cargo.lock
+++ b/crates/remote/Cargo.lock
@@ -99,7 +99,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "api-types"
-version = "0.1.33-artef.2"
+version = "0.1.33-artef.3"
 dependencies = [
  "chrono",
  "schemars",
@@ -4835,7 +4835,7 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utils"
-version = "0.1.33-artef.2"
+version = "0.1.33-artef.3"
 dependencies = [
  "axum",
  "bytes",

--- a/crates/remote/Cargo.lock
+++ b/crates/remote/Cargo.lock
@@ -99,7 +99,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "api-types"
-version = "0.1.37"
+version = "0.1.33-artef.0"
 dependencies = [
  "chrono",
  "schemars",
@@ -1627,6 +1627,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
+name = "git2"
+version = "0.20.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
+dependencies = [
+ "bitflags 2.11.0",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "url",
+]
+
+[[package]]
 name = "gloo-timers"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2230,6 +2243,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
+name = "libgit2-sys"
+version = "0.18.3+1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9b3acc4b91781bb0b3386669d325163746af5f6e4f73e6d2d630e09a35f3487"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2253,6 +2278,18 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52f4c29e2a68ac30c9087e1b772dc9f44a2b66ed44edf2266cf2be9b03dafc1"
+dependencies = [
+ "cc",
+ "libc",
  "pkg-config",
  "vcpkg",
 ]
@@ -3146,19 +3183,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
-name = "relay-types"
-version = "0.1.37"
-dependencies = [
- "chrono",
- "serde",
- "sqlx",
- "ts-rs",
- "uuid",
-]
-
-[[package]]
 name = "remote"
-version = "0.1.26"
+version = "0.1.23"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -3187,7 +3213,6 @@ dependencies = [
  "opentelemetry-http",
  "opentelemetry_sdk",
  "rand 0.9.2",
- "relay-types",
  "reqwest 0.12.28",
  "reqwest 0.13.2",
  "rustls",
@@ -4810,7 +4835,7 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utils"
-version = "0.1.37"
+version = "0.1.33-artef.0"
 dependencies = [
  "axum",
  "bytes",
@@ -4819,6 +4844,7 @@ dependencies = [
  "directories",
  "dirs 5.0.1",
  "futures",
+ "git2",
  "json-patch",
  "jsonwebtoken",
  "nix 0.29.0",

--- a/crates/review/Cargo.toml
+++ b/crates/review/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "review"
-version = "0.1.33-artef.2"
+version = "0.1.33-artef.3"
 edition = "2024"
 publish = false
 

--- a/crates/review/Cargo.toml
+++ b/crates/review/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "review"
-version = "0.1.33-artef.0"
+version = "0.1.33-artef.1"
 edition = "2024"
 publish = false
 

--- a/crates/review/Cargo.toml
+++ b/crates/review/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "review"
-version = "0.1.33-artef.3"
+version = "0.1.33-artef.4"
 edition = "2024"
 publish = false
 

--- a/crates/review/Cargo.toml
+++ b/crates/review/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "review"
-version = "0.1.37"
+version = "0.1.33-artef.0"
 edition = "2024"
 publish = false
 

--- a/crates/review/Cargo.toml
+++ b/crates/review/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "review"
-version = "0.1.33-artef.5"
+version = "0.1.33-artef.6"
 edition = "2024"
 publish = false
 

--- a/crates/review/Cargo.toml
+++ b/crates/review/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "review"
-version = "0.1.33-artef.1"
+version = "0.1.33-artef.2"
 edition = "2024"
 publish = false
 

--- a/crates/review/Cargo.toml
+++ b/crates/review/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "review"
-version = "0.1.33-artef.4"
+version = "0.1.33-artef.5"
 edition = "2024"
 publish = false
 

--- a/crates/server-info/Cargo.toml
+++ b/crates/server-info/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "server-info"
-version = "0.1.33-artef.1"
+version = "0.1.33-artef.2"
 edition = "2024"
 
 [dependencies]

--- a/crates/server-info/Cargo.toml
+++ b/crates/server-info/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "server-info"
-version = "0.1.33-artef.3"
+version = "0.1.33-artef.4"
 edition = "2024"
 
 [dependencies]

--- a/crates/server-info/Cargo.toml
+++ b/crates/server-info/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "server-info"
-version = "0.1.33-artef.2"
+version = "0.1.33-artef.3"
 edition = "2024"
 
 [dependencies]

--- a/crates/server-info/Cargo.toml
+++ b/crates/server-info/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "server-info"
-version = "0.1.33-artef.0"
+version = "0.1.33-artef.1"
 edition = "2024"
 
 [dependencies]

--- a/crates/server-info/Cargo.toml
+++ b/crates/server-info/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "server-info"
-version = "0.1.33-artef.4"
+version = "0.1.33-artef.5"
 edition = "2024"
 
 [dependencies]

--- a/crates/server-info/Cargo.toml
+++ b/crates/server-info/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "server-info"
-version = "0.1.33-artef.5"
+version = "0.1.33-artef.6"
 edition = "2024"
 
 [dependencies]

--- a/crates/server-info/Cargo.toml
+++ b/crates/server-info/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "server-info"
-version = "0.1.33"
+version = "0.1.33-artef.0"
 edition = "2024"
 
 [dependencies]

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "server"
-version = "0.1.37"
+version = "0.1.33-artef.0"
 edition = "2024"
 default-run = "server"
 
@@ -19,18 +19,7 @@ db = { path = "../db" }
 services = { path = "../services" }
 worktree-manager = { path = "../worktree-manager" }
 workspace-manager = { path = "../workspace-manager" }
-embedded-ssh = { path = "../embedded-ssh" }
-relay-control = { path = "../relay-control" }
-relay-protocol = { path = "../relay-protocol" }
-relay-ws = { path = "../relay-ws" }
-relay-client = { path = "../relay-client" }
-relay-hosts = { path = "../relay-hosts" }
-relay-types = { path = "../relay-types" }
-relay-tunnel-core = { path = "../relay-tunnel-core" }
-relay-webrtc = { path = "../relay-webrtc" }
-ws-bridge = { path = "../ws-bridge" }
-desktop-bridge = { path = "../desktop-bridge" }
-preview-proxy = { path = "../preview-proxy" }
+relay-tunnel = { path = "../relay-tunnel" }
 trusted-key-auth = { path = "../trusted-key-auth" }
 tokio = { workspace = true }
 shlex = "1.3.0"
@@ -58,13 +47,12 @@ os_info = "3.12.0"
 futures-util = "0.3"
 http = "1"
 base64 = "0.22"
+git2 = { workspace = true }
 mime_guess = "2.0"
 rust-embed = "8.2"
 url = "2.5"
 rand = { version = "0.8", features = ["std"] }
-spake2 = { version = "0.5.0-pre.0", features = ["getrandom"] }
 sha2 = "0.10"
-ed25519-dalek = "2.2.0"
 tokio-tungstenite = { version = "0.26", features = ["rustls-tls-native-roots"] }
 
 [build-dependencies]

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "server"
-version = "0.1.33-artef.2"
+version = "0.1.33-artef.3"
 edition = "2024"
 default-run = "server"
 

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "server"
-version = "0.1.33-artef.5"
+version = "0.1.33-artef.6"
 edition = "2024"
 default-run = "server"
 

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "server"
-version = "0.1.33-artef.3"
+version = "0.1.33-artef.4"
 edition = "2024"
 default-run = "server"
 

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "server"
-version = "0.1.33-artef.4"
+version = "0.1.33-artef.5"
 edition = "2024"
 default-run = "server"
 

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "server"
-version = "0.1.33-artef.0"
+version = "0.1.33-artef.1"
 edition = "2024"
 default-run = "server"
 

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "server"
-version = "0.1.33-artef.1"
+version = "0.1.33-artef.2"
 edition = "2024"
 default-run = "server"
 

--- a/crates/services/Cargo.toml
+++ b/crates/services/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "services"
-version = "0.1.33-artef.5"
+version = "0.1.33-artef.6"
 edition = "2024"
 
 [features]

--- a/crates/services/Cargo.toml
+++ b/crates/services/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "services"
-version = "0.1.33-artef.1"
+version = "0.1.33-artef.2"
 edition = "2024"
 
 [features]

--- a/crates/services/Cargo.toml
+++ b/crates/services/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "services"
-version = "0.1.33-artef.0"
+version = "0.1.33-artef.1"
 edition = "2024"
 
 [features]

--- a/crates/services/Cargo.toml
+++ b/crates/services/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "services"
-version = "0.1.33-artef.2"
+version = "0.1.33-artef.3"
 edition = "2024"
 
 [features]

--- a/crates/services/Cargo.toml
+++ b/crates/services/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "services"
-version = "0.1.33-artef.4"
+version = "0.1.33-artef.5"
 edition = "2024"
 
 [features]

--- a/crates/services/Cargo.toml
+++ b/crates/services/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "services"
-version = "0.1.33-artef.3"
+version = "0.1.33-artef.4"
 edition = "2024"
 
 [features]

--- a/crates/services/Cargo.toml
+++ b/crates/services/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "services"
-version = "0.1.37"
+version = "0.1.33-artef.0"
 edition = "2024"
 
 [features]
@@ -11,7 +11,6 @@ qa-mode = ["executors/qa-mode"]
 [dependencies]
 indicatif = "0.17"
 api-types = { path = "../api-types" }
-relay-types = { path = "../relay-types" }
 utils = { path = "../utils" }
 git = { path = "../git" }
 git-host = { path = "../git-host" }
@@ -30,6 +29,7 @@ chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1.0", features = ["v4", "serde"] }
 ts-rs = { workspace = true }
 dirs = "5.0"
+git2 = { workspace = true }
 async-trait = { workspace = true }
 rust-embed = "8.2"
 ignore = "0.4"

--- a/crates/tauri-app/Cargo.toml
+++ b/crates/tauri-app/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vibe-kanban-tauri"
-version = "0.1.33-artef.3"
+version = "0.1.33-artef.4"
 edition = "2024"
 
 [[bin]]

--- a/crates/tauri-app/Cargo.toml
+++ b/crates/tauri-app/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vibe-kanban-tauri"
-version = "0.1.37"
+version = "0.1.33-artef.0"
 edition = "2024"
 
 [[bin]]
@@ -29,10 +29,6 @@ tracing-subscriber = { workspace = true, features = ["registry"] }
 serde_json = { workspace = true }
 uuid = { version = "1.0", features = ["v4", "serde"] }
 rustls = { workspace = true }
-arboard = "3.6.1"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-objc2 = "0.6"
-objc2-foundation = { version = "0.3", features = ["NSString"] }
 objc2-web-kit = { version = "0.3", features = ["WKWebView"] }
-tauri-plugin-macos-fps = "0.1"

--- a/crates/tauri-app/Cargo.toml
+++ b/crates/tauri-app/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vibe-kanban-tauri"
-version = "0.1.33-artef.0"
+version = "0.1.33-artef.1"
 edition = "2024"
 
 [[bin]]

--- a/crates/tauri-app/Cargo.toml
+++ b/crates/tauri-app/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vibe-kanban-tauri"
-version = "0.1.33-artef.1"
+version = "0.1.33-artef.2"
 edition = "2024"
 
 [[bin]]

--- a/crates/tauri-app/Cargo.toml
+++ b/crates/tauri-app/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vibe-kanban-tauri"
-version = "0.1.33-artef.2"
+version = "0.1.33-artef.3"
 edition = "2024"
 
 [[bin]]

--- a/crates/tauri-app/Cargo.toml
+++ b/crates/tauri-app/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vibe-kanban-tauri"
-version = "0.1.33-artef.5"
+version = "0.1.33-artef.6"
 edition = "2024"
 
 [[bin]]

--- a/crates/tauri-app/Cargo.toml
+++ b/crates/tauri-app/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vibe-kanban-tauri"
-version = "0.1.33-artef.4"
+version = "0.1.33-artef.5"
 edition = "2024"
 
 [[bin]]

--- a/crates/tauri-app/tauri.conf.json
+++ b/crates/tauri-app/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "Vibe Kanban",
-  "version": "0.1.33-artef.1",
+  "version": "0.1.33-artef.2",
   "identifier": "ai.bloop.vibe-kanban",
   "build": {
     "beforeDevCommand": {

--- a/crates/tauri-app/tauri.conf.json
+++ b/crates/tauri-app/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "Vibe Kanban",
-  "version": "0.1.33-artef.5",
+  "version": "0.1.33-artef.6",
   "identifier": "ai.bloop.vibe-kanban",
   "build": {
     "beforeDevCommand": {

--- a/crates/tauri-app/tauri.conf.json
+++ b/crates/tauri-app/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "Vibe Kanban",
-  "version": "0.1.33-artef.4",
+  "version": "0.1.33-artef.5",
   "identifier": "ai.bloop.vibe-kanban",
   "build": {
     "beforeDevCommand": {

--- a/crates/tauri-app/tauri.conf.json
+++ b/crates/tauri-app/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "Vibe Kanban",
-  "version": "0.1.33-artef.2",
+  "version": "0.1.33-artef.3",
   "identifier": "ai.bloop.vibe-kanban",
   "build": {
     "beforeDevCommand": {

--- a/crates/tauri-app/tauri.conf.json
+++ b/crates/tauri-app/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "Vibe Kanban",
-  "version": "0.1.33-artef.3",
+  "version": "0.1.33-artef.4",
   "identifier": "ai.bloop.vibe-kanban",
   "build": {
     "beforeDevCommand": {

--- a/crates/tauri-app/tauri.conf.json
+++ b/crates/tauri-app/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "Vibe Kanban",
-  "version": "0.1.37",
+  "version": "0.1.33-artef.0",
   "identifier": "ai.bloop.vibe-kanban",
   "build": {
     "beforeDevCommand": {
@@ -20,9 +20,6 @@
   "bundle": {
     "active": true,
     "targets": "all",
-    "macOS": {
-      "bundleName": "Vibe Kanban"
-    },
     "windows": {},
     "icon": [
       "icons/32x32.png",
@@ -37,7 +34,6 @@
     "createUpdaterArtifacts": true
   },
   "plugins": {
-    "macos-fps": {},
     "updater": {
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDMyN0ZCNDVCMDhFMDdEQjAKUldTd2ZlQUlXN1IvTWt1Z0ZmaWpsUUVGOHl3QUExRVVWL0crWkROSjViRUZSTXdUODN4WkFlQ1AK",
       "endpoints": [

--- a/crates/tauri-app/tauri.conf.json
+++ b/crates/tauri-app/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "Vibe Kanban",
-  "version": "0.1.33-artef.0",
+  "version": "0.1.33-artef.1",
   "identifier": "ai.bloop.vibe-kanban",
   "build": {
     "beforeDevCommand": {

--- a/crates/trusted-key-auth/Cargo.toml
+++ b/crates/trusted-key-auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusted-key-auth"
-version = "0.1.33-artef.5"
+version = "0.1.33-artef.6"
 edition = "2024"
 
 [dependencies]

--- a/crates/trusted-key-auth/Cargo.toml
+++ b/crates/trusted-key-auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusted-key-auth"
-version = "0.1.37"
+version = "0.1.33-artef.0"
 edition = "2024"
 
 [dependencies]

--- a/crates/trusted-key-auth/Cargo.toml
+++ b/crates/trusted-key-auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusted-key-auth"
-version = "0.1.33-artef.1"
+version = "0.1.33-artef.2"
 edition = "2024"
 
 [dependencies]

--- a/crates/trusted-key-auth/Cargo.toml
+++ b/crates/trusted-key-auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusted-key-auth"
-version = "0.1.33-artef.3"
+version = "0.1.33-artef.4"
 edition = "2024"
 
 [dependencies]

--- a/crates/trusted-key-auth/Cargo.toml
+++ b/crates/trusted-key-auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusted-key-auth"
-version = "0.1.33-artef.2"
+version = "0.1.33-artef.3"
 edition = "2024"
 
 [dependencies]

--- a/crates/trusted-key-auth/Cargo.toml
+++ b/crates/trusted-key-auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusted-key-auth"
-version = "0.1.33-artef.0"
+version = "0.1.33-artef.1"
 edition = "2024"
 
 [dependencies]

--- a/crates/trusted-key-auth/Cargo.toml
+++ b/crates/trusted-key-auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusted-key-auth"
-version = "0.1.33-artef.4"
+version = "0.1.33-artef.5"
 edition = "2024"
 
 [dependencies]

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "utils"
-version = "0.1.33-artef.2"
+version = "0.1.33-artef.3"
 edition = "2024"
 
 [dependencies]

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "utils"
-version = "0.1.33-artef.0"
+version = "0.1.33-artef.1"
 edition = "2024"
 
 [dependencies]

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "utils"
-version = "0.1.33-artef.3"
+version = "0.1.33-artef.4"
 edition = "2024"
 
 [dependencies]

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "utils"
-version = "0.1.37"
+version = "0.1.33-artef.0"
 edition = "2024"
 
 [dependencies]
@@ -29,6 +29,7 @@ tokio-stream = { version = "0.1.17", features = ["sync"] }
 shellexpand = "3.1.1"
 which = "8.0.0"
 similar = "2"
+git2 = { workspace = true }
 dirs = "5.0"
 thiserror = { workspace = true }
 command-group = { version = "5.0", features = ["with-tokio"] }

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "utils"
-version = "0.1.33-artef.1"
+version = "0.1.33-artef.2"
 edition = "2024"
 
 [dependencies]

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "utils"
-version = "0.1.33-artef.4"
+version = "0.1.33-artef.5"
 edition = "2024"
 
 [dependencies]

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "utils"
-version = "0.1.33-artef.5"
+version = "0.1.33-artef.6"
 edition = "2024"
 
 [dependencies]

--- a/crates/workspace-manager/Cargo.toml
+++ b/crates/workspace-manager/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workspace-manager"
-version = "0.1.37"
+version = "0.1.33-artef.0"
 edition = "2024"
 
 [dependencies]

--- a/crates/workspace-manager/Cargo.toml
+++ b/crates/workspace-manager/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workspace-manager"
-version = "0.1.33-artef.0"
+version = "0.1.33-artef.1"
 edition = "2024"
 
 [dependencies]

--- a/crates/workspace-manager/Cargo.toml
+++ b/crates/workspace-manager/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workspace-manager"
-version = "0.1.33-artef.4"
+version = "0.1.33-artef.5"
 edition = "2024"
 
 [dependencies]

--- a/crates/workspace-manager/Cargo.toml
+++ b/crates/workspace-manager/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workspace-manager"
-version = "0.1.33-artef.3"
+version = "0.1.33-artef.4"
 edition = "2024"
 
 [dependencies]

--- a/crates/workspace-manager/Cargo.toml
+++ b/crates/workspace-manager/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workspace-manager"
-version = "0.1.33-artef.2"
+version = "0.1.33-artef.3"
 edition = "2024"
 
 [dependencies]

--- a/crates/workspace-manager/Cargo.toml
+++ b/crates/workspace-manager/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workspace-manager"
-version = "0.1.33-artef.5"
+version = "0.1.33-artef.6"
 edition = "2024"
 
 [dependencies]

--- a/crates/workspace-manager/Cargo.toml
+++ b/crates/workspace-manager/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workspace-manager"
-version = "0.1.33-artef.1"
+version = "0.1.33-artef.2"
 edition = "2024"
 
 [dependencies]

--- a/crates/worktree-manager/Cargo.toml
+++ b/crates/worktree-manager/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "worktree-manager"
-version = "0.1.33-artef.5"
+version = "0.1.33-artef.6"
 edition = "2024"
 
 [dependencies]

--- a/crates/worktree-manager/Cargo.toml
+++ b/crates/worktree-manager/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "worktree-manager"
-version = "0.1.33-artef.4"
+version = "0.1.33-artef.5"
 edition = "2024"
 
 [dependencies]

--- a/crates/worktree-manager/Cargo.toml
+++ b/crates/worktree-manager/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "worktree-manager"
-version = "0.1.33-artef.1"
+version = "0.1.33-artef.2"
 edition = "2024"
 
 [dependencies]

--- a/crates/worktree-manager/Cargo.toml
+++ b/crates/worktree-manager/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "worktree-manager"
-version = "0.1.33-artef.3"
+version = "0.1.33-artef.4"
 edition = "2024"
 
 [dependencies]

--- a/crates/worktree-manager/Cargo.toml
+++ b/crates/worktree-manager/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "worktree-manager"
-version = "0.1.37"
+version = "0.1.33-artef.0"
 edition = "2024"
 
 [dependencies]
@@ -9,6 +9,7 @@ utils = { path = "../utils" }
 tokio = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
+git2 = { workspace = true }
 dunce = "1.0"
 
 [dev-dependencies]

--- a/crates/worktree-manager/Cargo.toml
+++ b/crates/worktree-manager/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "worktree-manager"
-version = "0.1.33-artef.0"
+version = "0.1.33-artef.1"
 edition = "2024"
 
 [dependencies]

--- a/crates/worktree-manager/Cargo.toml
+++ b/crates/worktree-manager/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "worktree-manager"
-version = "0.1.33-artef.2"
+version = "0.1.33-artef.3"
 edition = "2024"
 
 [dependencies]

--- a/npx-cli/package-lock.json
+++ b/npx-cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vibe-kanban",
-  "version": "0.1.33-artef.1",
+  "version": "0.1.33-artef.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vibe-kanban",
-      "version": "0.1.33-artef.1",
+      "version": "0.1.33-artef.2",
       "dependencies": {
         "adm-zip": "^0.5.16",
         "cac": "^7.0.0"

--- a/npx-cli/package-lock.json
+++ b/npx-cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vibe-kanban",
-  "version": "0.1.33-artef.5",
+  "version": "0.1.33-artef.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vibe-kanban",
-      "version": "0.1.33-artef.5",
+      "version": "0.1.33-artef.6",
       "dependencies": {
         "adm-zip": "^0.5.16",
         "cac": "^7.0.0"

--- a/npx-cli/package-lock.json
+++ b/npx-cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vibe-kanban",
-  "version": "0.1.33-artef.4",
+  "version": "0.1.33-artef.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vibe-kanban",
-      "version": "0.1.33-artef.4",
+      "version": "0.1.33-artef.5",
       "dependencies": {
         "adm-zip": "^0.5.16",
         "cac": "^7.0.0"

--- a/npx-cli/package-lock.json
+++ b/npx-cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vibe-kanban",
-  "version": "0.1.37",
+  "version": "0.1.33-artef.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vibe-kanban",
-      "version": "0.1.37",
+      "version": "0.1.33-artef.0",
       "dependencies": {
         "adm-zip": "^0.5.16",
         "cac": "^7.0.0"

--- a/npx-cli/package-lock.json
+++ b/npx-cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vibe-kanban",
-  "version": "0.1.33-artef.3",
+  "version": "0.1.33-artef.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vibe-kanban",
-      "version": "0.1.33-artef.3",
+      "version": "0.1.33-artef.4",
       "dependencies": {
         "adm-zip": "^0.5.16",
         "cac": "^7.0.0"

--- a/npx-cli/package-lock.json
+++ b/npx-cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vibe-kanban",
-  "version": "0.1.33-artef.0",
+  "version": "0.1.33-artef.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vibe-kanban",
-      "version": "0.1.33-artef.0",
+      "version": "0.1.33-artef.1",
       "dependencies": {
         "adm-zip": "^0.5.16",
         "cac": "^7.0.0"

--- a/npx-cli/package-lock.json
+++ b/npx-cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vibe-kanban",
-  "version": "0.1.33-artef.2",
+  "version": "0.1.33-artef.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vibe-kanban",
-      "version": "0.1.33-artef.2",
+      "version": "0.1.33-artef.3",
       "dependencies": {
         "adm-zip": "^0.5.16",
         "cac": "^7.0.0"

--- a/npx-cli/package.json
+++ b/npx-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vibe-kanban",
   "private": false,
-  "version": "0.1.37",
+  "version": "0.1.33-artef.0",
   "main": "index.js",
   "bin": {
     "vibe-kanban": "bin/cli.js"

--- a/npx-cli/package.json
+++ b/npx-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vibe-kanban",
   "private": false,
-  "version": "0.1.33-artef.0",
+  "version": "0.1.33-artef.1",
   "main": "index.js",
   "bin": {
     "vibe-kanban": "bin/cli.js"

--- a/npx-cli/package.json
+++ b/npx-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vibe-kanban",
   "private": false,
-  "version": "0.1.33-artef.2",
+  "version": "0.1.33-artef.3",
   "main": "index.js",
   "bin": {
     "vibe-kanban": "bin/cli.js"

--- a/npx-cli/package.json
+++ b/npx-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vibe-kanban",
   "private": false,
-  "version": "0.1.33-artef.1",
+  "version": "0.1.33-artef.2",
   "main": "index.js",
   "bin": {
     "vibe-kanban": "bin/cli.js"

--- a/npx-cli/package.json
+++ b/npx-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vibe-kanban",
   "private": false,
-  "version": "0.1.33-artef.3",
+  "version": "0.1.33-artef.4",
   "main": "index.js",
   "bin": {
     "vibe-kanban": "bin/cli.js"

--- a/npx-cli/package.json
+++ b/npx-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vibe-kanban",
   "private": false,
-  "version": "0.1.33-artef.5",
+  "version": "0.1.33-artef.6",
   "main": "index.js",
   "bin": {
     "vibe-kanban": "bin/cli.js"

--- a/npx-cli/package.json
+++ b/npx-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vibe-kanban",
   "private": false,
-  "version": "0.1.33-artef.4",
+  "version": "0.1.33-artef.5",
   "main": "index.js",
   "bin": {
     "vibe-kanban": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-kanban",
-  "version": "0.1.33-artef.1",
+  "version": "0.1.33-artef.2",
   "private": true,
   "bin": {
     "vibe-kanban": "npx-cli/bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-kanban",
-  "version": "0.1.33-artef.5",
+  "version": "0.1.33-artef.6",
   "private": true,
   "bin": {
     "vibe-kanban": "npx-cli/bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-kanban",
-  "version": "0.1.33-artef.2",
+  "version": "0.1.33-artef.3",
   "private": true,
   "bin": {
     "vibe-kanban": "npx-cli/bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-kanban",
-  "version": "0.1.33-artef.0",
+  "version": "0.1.33-artef.1",
   "private": true,
   "bin": {
     "vibe-kanban": "npx-cli/bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-kanban",
-  "version": "0.1.33-artef.4",
+  "version": "0.1.33-artef.5",
   "private": true,
   "bin": {
     "vibe-kanban": "npx-cli/bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-kanban",
-  "version": "0.1.37",
+  "version": "0.1.33-artef.0",
   "private": true,
   "bin": {
     "vibe-kanban": "npx-cli/bin/cli.js"
@@ -40,15 +40,14 @@
     "prepare-db:check": "node scripts/prepare-db.js --check",
     "build:bippy-bundle": "node scripts/build-bippy-bundle.mjs",
     "build:npx": "bash ./local-build.sh",
-    "build:npx-cli": "cd npx-cli && npm ci && npm run build",
+    "build:npx-cli": "esbuild npx-cli/src/cli.ts --bundle --platform=node --target=node20 --format=cjs --outfile=npx-cli/bin/cli.js --external:adm-zip --banner:js=\"#!/usr/bin/env node\"",
     "check:npx-cli": "tsc --noEmit -p npx-cli/tsconfig.json",
     "prepack": "pnpm run build:npx && pnpm run build:npx-cli",
     "remote:dev": "cd crates/remote && docker compose --env-file .env.remote up --build ; docker compose --env-file .env.remote down -v",
-    "remote:dev:full": "cd crates/remote && docker compose --env-file .env.remote --profile relay --profile attachments up --build ; docker compose --env-file .env.remote down -v",
-    "remote:dev:clean": "cd crates/remote && docker compose --env-file .env.remote --profile relay --profile attachments down -v --remove-orphans",
+    "remote:dev:clean": "cd crates/remote && docker compose --env-file .env.remote down -v",
     "remote:prepare-db": "cd crates/remote && bash scripts/prepare-db.sh",
     "remote:prepare-db:check": "cd crates/remote && bash scripts/prepare-db.sh --check",
-    "tauri:dev": "set -a && [ -f .env ] && . ./.env && set +a && export FRONTEND_PORT=$(node scripts/setup-dev-environment.js frontend) && export BACKEND_PORT=$(node scripts/setup-dev-environment.js backend) && export VK_ALLOWED_ORIGINS=\"http://localhost:${FRONTEND_PORT}\" && export DISABLE_WORKTREE_CLEANUP=1 && export RUST_LOG=debug && export VITE_VK_SHARED_API_BASE=${VK_SHARED_API_BASE:-} && cd crates/tauri-app && cargo tauri dev --config '{\"build\":{\"devUrl\":\"http://localhost:'\"${FRONTEND_PORT}\"'\"}}'",
+    "tauri:dev": "set -a && [ -f .env ] && . ./.env && set +a && export FRONTEND_PORT=$(node scripts/setup-dev-environment.js frontend) && export BACKEND_PORT=$(node scripts/setup-dev-environment.js backend) && export VK_ALLOWED_ORIGINS=\"http://localhost:${FRONTEND_PORT}\" && export DISABLE_WORKTREE_CLEANUP=1 && export RUST_LOG=debug && export VITE_VK_SHARED_API_BASE=${VK_SHARED_API_BASE:-} && cd crates/tauri-app && cargo tauri dev",
     "tauri:build": "cd crates/tauri-app && cargo tauri build"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-kanban",
-  "version": "0.1.33-artef.3",
+  "version": "0.1.33-artef.4",
   "private": true,
   "bin": {
     "vibe-kanban": "npx-cli/bin/cli.js"

--- a/packages/local-web/package.json
+++ b/packages/local-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vibe/local-web",
   "private": true,
-  "version": "0.1.33-artef.2",
+  "version": "0.1.33-artef.3",
   "type": "module",
   "scripts": {
     "dev": "VITE_OPEN=${VITE_OPEN:-false} vite",

--- a/packages/local-web/package.json
+++ b/packages/local-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vibe/local-web",
   "private": true,
-  "version": "0.1.33-artef.3",
+  "version": "0.1.33-artef.4",
   "type": "module",
   "scripts": {
     "dev": "VITE_OPEN=${VITE_OPEN:-false} vite",

--- a/packages/local-web/package.json
+++ b/packages/local-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vibe/local-web",
   "private": true,
-  "version": "0.1.33-artef.4",
+  "version": "0.1.33-artef.5",
   "type": "module",
   "scripts": {
     "dev": "VITE_OPEN=${VITE_OPEN:-false} vite",

--- a/packages/local-web/package.json
+++ b/packages/local-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vibe/local-web",
   "private": true,
-  "version": "0.1.33-artef.1",
+  "version": "0.1.33-artef.2",
   "type": "module",
   "scripts": {
     "dev": "VITE_OPEN=${VITE_OPEN:-false} vite",

--- a/packages/local-web/package.json
+++ b/packages/local-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vibe/local-web",
   "private": true,
-  "version": "0.1.33-artef.0",
+  "version": "0.1.33-artef.1",
   "type": "module",
   "scripts": {
     "dev": "VITE_OPEN=${VITE_OPEN:-false} vite",

--- a/packages/local-web/package.json
+++ b/packages/local-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vibe/local-web",
   "private": true,
-  "version": "0.1.33-artef.5",
+  "version": "0.1.33-artef.6",
   "type": "module",
   "scripts": {
     "dev": "VITE_OPEN=${VITE_OPEN:-false} vite",

--- a/packages/local-web/package.json
+++ b/packages/local-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vibe/local-web",
   "private": true,
-  "version": "0.1.37",
+  "version": "0.1.33-artef.0",
   "type": "module",
   "scripts": {
     "dev": "VITE_OPEN=${VITE_OPEN:-false} vite",
@@ -34,7 +34,7 @@
     "@lexical/rich-text": "^0.36.2",
     "@lexical/table": "^0.36.2",
     "@phosphor-icons/react": "^2.1.10",
-    "@pierre/diffs": "1.1.4",
+    "@pierre/diffs": "^1.0.8",
     "@radix-ui/react-accordion": "^1.2.1",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.15",


### PR DESCRIPTION
## Summary
This PR updates the pre-release pipeline to stop storing Tauri build artifacts in GitHub Actions and keep them in R2, while still exposing installer downloads in release notes.

## What Changed
- Updated `.github/workflows/pre-release.yml` to remove GitHub Actions artifact upload/download for Tauri bundles.
- In `build-tauri`, added direct upload of per-platform Tauri artifacts to R2 under `binaries/$TAG/tauri/<platform>/`.
- In `upload-tauri-update`, switched artifact input from GitHub artifacts to R2 download, then continued generating and uploading:
  - `latest.json` (Tauri updater manifest)
  - `desktop-manifest.json` (desktop manifest for NPX CLI)
- In `create-prerelease`, removed Tauri installer attachments from GitHub release assets and generated a release notes preamble with installer links for all supported platforms using R2 public URLs.

## Why
GitHub Actions artifact storage is limited, and Tauri bundles are large. Moving Tauri artifacts to R2 avoids consuming GitHub artifact quota while preserving distribution through stable public links in release notes.

## Important Implementation Details
- Platform artifacts are uploaded during each matrix build job, so no cross-job GitHub artifact transfer is required for Tauri files.
- The updater and desktop manifests are generated from artifacts fetched back from R2, keeping release metadata aligned with uploaded binaries.
- Release notes now include explicit installer links grouped by platform (`darwin-aarch64`, `darwin-x86_64`, `linux-x86_64`, `linux-aarch64`, `windows-x86_64`, `windows-aarch64`) and mark unavailable installers when missing.
- GitHub pre-release assets now include only the web ZIP and NPX package; Tauri installers are distributed via R2 links in notes.

This PR was written using [Vibe Kanban](https://vibekanban.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it rewires the pre-release distribution pipeline (artifact storage/download paths, release notes generation) and includes broad dependency/lockfile churn that could affect build reproducibility.
> 
> **Overview**
> Pre-release workflow now **publishes Tauri desktop build outputs via R2 instead of GitHub Actions artifacts**: each `build-tauri` matrix job uploads its bundles/signatures to `binaries/$TAG/tauri/<platform>/`, and `upload-tauri-update` downloads from R2 to generate and upload `latest.json` and `desktop-manifest.json`.
> 
> GitHub pre-releases no longer attach desktop installers; instead `create-prerelease` generates a `release-notes.md` section with per-platform installer links pointing at the public R2 URL and appends it to the release body. The workflow also clears `target/.../bundle` before building to avoid stale cached bundles.
> 
> Separately, this bumps workspace/package versions to `0.1.33-artef.6`, adjusts local scripts (notably `build:npx-cli` and `tauri:dev`), and updates Rust lockfiles/dependencies (including switching `rmcp` to `0.5.0` in `mcp` and pinning Codex crates to `rust-v0.114.0`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3d670524130672e0fe36cf56bfbe32cd179c2775. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->