### PR TITLE
feat: make accordion sections dynamic

### DIFF
--- a/packages/ui/src/components/WorkspacesSidebar.tsx
+++ b/packages/ui/src/components/WorkspacesSidebar.tsx
@@ -301,56 +301,48 @@ export function WorkspacesSidebar({
           /* Accordion layout view */
           <div className="flex flex-col gap-base">
             {/* Needs Attention section */}
-            <CollapsibleSectionHeader
-              title={t('common:workspaces.needsAttention')}
-              persistKey={persistKeys.raisedHand}
-              defaultExpanded={true}
-            >
-              <div className="flex flex-col gap-base py-half">
-                {draftTitle && (
-                  <WorkspaceSummary
-                    name={draftTitle}
-                    isActive={isCreateMode}
-                    isDraft={true}
-                    onClick={onSelectCreate}
-                  />
-                )}
-                {raisedHandWorkspaces.length === 0 && !draftTitle ? (
-                  <span className="text-sm text-low opacity-60 pl-base">
-                    {t('common:workspaces.noWorkspaces')}
-                  </span>
-                ) : (
+            {(raisedHandWorkspaces.length > 0 || draftTitle) && (
+              <CollapsibleSectionHeader
+                title={t('common:workspaces.needsAttention')}
+                persistKey={persistKeys.raisedHand}
+                defaultExpanded={true}
+              >
+                <div className="flex flex-col gap-base py-half">
+                  {draftTitle && (
+                    <WorkspaceSummary
+                      name={draftTitle}
+                      isActive={isCreateMode}
+                      isDraft={true}
+                      onClick={onSelectCreate}
+                    />
+                  )}
                   <WorkspaceList
                     workspaces={raisedHandWorkspaces}
                     selectedWorkspaceId={selectedWorkspaceId}
                     onSelectWorkspace={onSelectWorkspace}
                     onOpenWorkspaceActions={handleOpenWorkspaceActions}
                   />
-                )}
-              </div>
-            </CollapsibleSectionHeader>
+                </div>
+              </CollapsibleSectionHeader>
+            )}
 
             {/* Running section */}
-            <CollapsibleSectionHeader
-              title={t('common:workspaces.running')}
-              persistKey={persistKeys.running}
-              defaultExpanded={true}
-            >
-              <div className="flex flex-col gap-base py-half">
-                {runningWorkspaces.length === 0 ? (
-                  <span className="text-sm text-low opacity-60 pl-base">
-                    {t('common:workspaces.noWorkspaces')}
-                  </span>
-                ) : (
+            {runningWorkspaces.length > 0 && (
+              <CollapsibleSectionHeader
+                title={t('common:workspaces.running')}
+                persistKey={persistKeys.running}
+                defaultExpanded={true}
+              >
+                <div className="flex flex-col gap-base py-half">
                   <WorkspaceList
                     workspaces={runningWorkspaces}
                     selectedWorkspaceId={selectedWorkspaceId}
                     onSelectWorkspace={onSelectWorkspace}
                     onOpenWorkspaceActions={handleOpenWorkspaceActions}
                   />
-                )}
-              </div>
-            </CollapsibleSectionHeader>
+                </div>
+              </CollapsibleSectionHeader>
+            )}
 
             {/* Idle section */}
             <CollapsibleSectionHeader


### PR DESCRIPTION
- only display when relevant (e.g. only show `running` header when something is actually running)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that tweaks rendering conditions for accordion sections; main risk is minor UX regressions (missing headers/empty-state messaging) in edge cases.
> 
> **Overview**
> Makes the `WorkspacesSidebar` accordion view **dynamic** by only rendering the `Needs Attention` and `Running` collapsible sections when they contain content (or when a draft workspace title exists for `Needs Attention`).
> 
> This removes the previous empty-state `noWorkspaces` placeholders for those sections, while leaving the `Idle` section behavior unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 28ad4801c722ed082b05c15ac4582aa66e2aef93. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->