### PR TITLE
Auto-detect PRs created by coding agents on workspace branches

### DIFF
--- a/crates/db/.sqlx/query-042944307765b8ddab6a86ec12b26b1fcfd3f541af40cb3c8176a02abd91c48c.json
+++ b/crates/db/.sqlx/query-042944307765b8ddab6a86ec12b26b1fcfd3f541af40cb3c8176a02abd91c48c.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "SQLite",
+  "query": "SELECT pr_number AS \"pr_number!: i64\"\n               FROM pull_requests\n               WHERE workspace_id = $1\n                 AND repo_id = $2",
+  "describe": {
+    "columns": [
+      {
+        "name": "pr_number!: i64",
+        "ordinal": 0,
+        "type_info": "Integer"
+      }
+    ],
+    "parameters": {
+      "Right": 2
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "042944307765b8ddab6a86ec12b26b1fcfd3f541af40cb3c8176a02abd91c48c"
+}

--- a/crates/db/.sqlx/query-272d26fb51181544b24be309956fc0b52192818972aebaf13dae6a959674b9f3.json
+++ b/crates/db/.sqlx/query-272d26fb51181544b24be309956fc0b52192818972aebaf13dae6a959674b9f3.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "SQLite",
+  "query": "SELECT COUNT(*) as \"count!: i64\"\n               FROM execution_processes ep\n               JOIN sessions s ON ep.session_id = s.id\n               WHERE s.workspace_id = $1\n                 AND ep.run_reason IN ('setupscript','cleanupscript','codingagent')",
+  "describe": {
+    "columns": [
+      {
+        "name": "count!: i64",
+        "ordinal": 0,
+        "type_info": "Integer"
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "272d26fb51181544b24be309956fc0b52192818972aebaf13dae6a959674b9f3"
+}

--- a/crates/db/.sqlx/query-920b3143f5ecafdf0fb8170a2ef6de550b2cf66298de9dd9a2cf2240ce5c7c75.json
+++ b/crates/db/.sqlx/query-920b3143f5ecafdf0fb8170a2ef6de550b2cf66298de9dd9a2cf2240ce5c7c75.json
@@ -1,6 +1,6 @@
 {
   "db_name": "SQLite",
-  "query": "SELECT\n                wr.workspace_id AS \"workspace_id!: Uuid\",\n                wr.repo_id AS \"repo_id!: Uuid\",\n                w.branch AS \"workspace_branch!\",\n                wr.target_branch AS \"target_branch!\"\n            FROM workspace_repos wr\n            JOIN workspaces w ON w.id = wr.workspace_id\n            WHERE w.archived = FALSE\n            ORDER BY w.updated_at DESC",
+  "query": "SELECT\n                wr.workspace_id AS \"workspace_id!: Uuid\",\n                wr.repo_id AS \"repo_id!: Uuid\",\n                w.branch AS \"workspace_branch!\",\n                wr.target_branch AS \"target_branch!\"\n            FROM workspace_repos wr\n            JOIN workspaces w ON w.id = wr.workspace_id\n            WHERE w.archived = FALSE\n              AND (? IS NULL OR w.updated_at >= ?)\n            ORDER BY w.updated_at DESC",
   "describe": {
     "columns": [
       {
@@ -25,7 +25,7 @@
       }
     ],
     "parameters": {
-      "Right": 0
+      "Right": 2
     },
     "nullable": [
       false,
@@ -34,5 +34,5 @@
       false
     ]
   },
-  "hash": "bf8f9ad2c50e53472bbbbe372f76c364c05a2b77181d19c2b60368e1174365ec"
+  "hash": "920b3143f5ecafdf0fb8170a2ef6de550b2cf66298de9dd9a2cf2240ce5c7c75"
 }

--- a/crates/db/.sqlx/query-bf8f9ad2c50e53472bbbbe372f76c364c05a2b77181d19c2b60368e1174365ec.json
+++ b/crates/db/.sqlx/query-bf8f9ad2c50e53472bbbbe372f76c364c05a2b77181d19c2b60368e1174365ec.json
@@ -1,0 +1,38 @@
+{
+  "db_name": "SQLite",
+  "query": "SELECT\n                wr.workspace_id AS \"workspace_id!: Uuid\",\n                wr.repo_id AS \"repo_id!: Uuid\",\n                w.branch AS \"workspace_branch!\",\n                wr.target_branch AS \"target_branch!\"\n            FROM workspace_repos wr\n            JOIN workspaces w ON w.id = wr.workspace_id\n            WHERE w.archived = FALSE\n            ORDER BY w.updated_at DESC",
+  "describe": {
+    "columns": [
+      {
+        "name": "workspace_id!: Uuid",
+        "ordinal": 0,
+        "type_info": "Blob"
+      },
+      {
+        "name": "repo_id!: Uuid",
+        "ordinal": 1,
+        "type_info": "Blob"
+      },
+      {
+        "name": "workspace_branch!",
+        "ordinal": 2,
+        "type_info": "Text"
+      },
+      {
+        "name": "target_branch!",
+        "ordinal": 3,
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Right": 0
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "bf8f9ad2c50e53472bbbbe372f76c364c05a2b77181d19c2b60368e1174365ec"
+}

--- a/crates/db/src/models/merge.rs
+++ b/crates/db/src/models/merge.rs
@@ -123,8 +123,11 @@ impl Merge {
 
     /// Find all active (non-archived) workspace-repo pairs.
     /// Used by the PR monitor to discover PRs created outside of VK.
+    /// When `updated_since` is provided, only returns workspaces that have been
+    /// updated since that time, reducing unnecessary GitHub API calls.
     pub async fn get_active_workspace_repos(
         pool: &SqlitePool,
+        updated_since: Option<DateTime<Utc>>,
     ) -> Result<Vec<ActiveWorkspaceRepo>, sqlx::Error> {
         sqlx::query_as!(
             ActiveWorkspaceRepo,
@@ -136,7 +139,10 @@ impl Merge {
             FROM workspace_repos wr
             JOIN workspaces w ON w.id = wr.workspace_id
             WHERE w.archived = FALSE
+              AND (? IS NULL OR w.updated_at >= ?)
             ORDER BY w.updated_at DESC"#,
+            updated_since,
+            updated_since,
         )
         .fetch_all(pool)
         .await

--- a/crates/db/src/models/merge.rs
+++ b/crates/db/src/models/merge.rs
@@ -1,6 +1,6 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use sqlx::{SqlitePool, Type};
+use sqlx::{FromRow, SqlitePool, Type};
 use ts_rs::TS;
 use uuid::Uuid;
 
@@ -53,6 +53,22 @@ pub struct PullRequestInfo {
     pub merge_commit_sha: Option<String>,
 }
 
+/// Active workspace-repo pair used for auto-detecting PRs created outside of VK.
+#[derive(Debug, Clone, FromRow)]
+pub struct ActiveWorkspaceRepo {
+    pub workspace_id: Uuid,
+    pub repo_id: Uuid,
+    pub workspace_branch: String,
+    pub target_branch: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+#[sqlx(type_name = "TEXT", rename_all = "snake_case")]
+pub enum MergeType {
+    Direct,
+    Pr,
+}
+
 /// Row type for direct merges only (PR data now lives in pull_requests).
 struct DirectMergeRow {
     id: Uuid,
@@ -103,6 +119,27 @@ impl Merge {
             target_branch_name: target_branch_name.to_string(),
             created_at: now,
         })
+    }
+
+    /// Find all active (non-archived) workspace-repo pairs.
+    /// Used by the PR monitor to discover PRs created outside of VK.
+    pub async fn get_active_workspace_repos(
+        pool: &SqlitePool,
+    ) -> Result<Vec<ActiveWorkspaceRepo>, sqlx::Error> {
+        sqlx::query_as!(
+            ActiveWorkspaceRepo,
+            r#"SELECT
+                wr.workspace_id AS "workspace_id!: Uuid",
+                wr.repo_id AS "repo_id!: Uuid",
+                w.branch AS "workspace_branch!",
+                wr.target_branch AS "target_branch!"
+            FROM workspace_repos wr
+            JOIN workspaces w ON w.id = wr.workspace_id
+            WHERE w.archived = FALSE
+            ORDER BY w.updated_at DESC"#,
+        )
+        .fetch_all(pool)
+        .await
     }
 
     /// Find all merges for a workspace (returns both direct merges and PRs).

--- a/crates/db/src/models/pull_request.rs
+++ b/crates/db/src/models/pull_request.rs
@@ -211,6 +211,24 @@ impl PullRequest {
         .await
     }
 
+    /// Get the set of PR numbers already linked to a workspace-repo pair.
+    pub async fn get_known_pr_numbers(
+        pool: &SqlitePool,
+        workspace_id: Uuid,
+        repo_id: Uuid,
+    ) -> Result<Vec<i64>, sqlx::Error> {
+        sqlx::query_scalar!(
+            r#"SELECT pr_number AS "pr_number!: i64"
+               FROM pull_requests
+               WHERE workspace_id = $1
+                 AND repo_id = $2"#,
+            workspace_id,
+            repo_id
+        )
+        .fetch_all(pool)
+        .await
+    }
+
     pub async fn count_open_for_workspace(
         pool: &SqlitePool,
         workspace_id: Uuid,

--- a/crates/services/src/services/pr_monitor.rs
+++ b/crates/services/src/services/pr_monitor.rs
@@ -210,8 +210,8 @@ impl<C: ContainerService + Send + Sync + 'static> PrMonitorService<C> {
             }
 
             info!(
-                "Auto-discovered PR #{} for workspace {} repo {}",
-                pr_info.number, candidate.workspace_id, candidate.repo_id
+                "Auto-discovered PR #{} ({:?}) for workspace {} repo {}",
+                pr_info.number, pr_info.status, candidate.workspace_id, candidate.repo_id
             );
 
             PullRequest::create_for_workspace(
@@ -223,6 +223,19 @@ impl<C: ContainerService + Send + Sync + 'static> PrMonitorService<C> {
                 &pr_info.url,
             )
             .await?;
+
+            // create_for_workspace inserts as 'open'; correct the status immediately so
+            // check_all_open_prs doesn't falsely trigger the merged/closed lifecycle.
+            if !matches!(pr_info.status, MergeStatus::Open) {
+                PullRequest::update_status(
+                    &self.db.pool,
+                    &pr_info.url,
+                    &pr_info.status,
+                    pr_info.merged_at,
+                    pr_info.merge_commit_sha.clone(),
+                )
+                .await?;
+            }
         }
 
         Ok(())

--- a/crates/services/src/services/pr_monitor.rs
+++ b/crates/services/src/services/pr_monitor.rs
@@ -1,7 +1,7 @@
-use std::{sync::Arc, time::Duration};
+use std::{sync::Arc, sync::Mutex, time::Duration};
 
 use api_types::{PullRequestStatus, UpdatePullRequestApiRequest, UpsertPullRequestRequest};
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use db::{
     DBService,
     models::{
@@ -57,6 +57,10 @@ pub struct PrMonitorService<C: ContainerService> {
     container: C,
     remote_client: Option<RemoteClient>,
     sync_notify: Arc<Notify>,
+    /// Tracks when we last ran PR discovery so we only poll workspaces
+    /// that have been updated since then, avoiding unnecessary GitHub API calls
+    /// that could exhaust rate limits for users with many active workspaces.
+    last_discovery_at: Mutex<Option<DateTime<Utc>>>,
 }
 
 impl<C: ContainerService + Send + Sync + 'static> PrMonitorService<C> {
@@ -74,6 +78,7 @@ impl<C: ContainerService + Send + Sync + 'static> PrMonitorService<C> {
             container,
             remote_client,
             sync_notify,
+            last_discovery_at: Mutex::new(None),
         };
         tokio::spawn(async move {
             service.start().await;
@@ -139,16 +144,22 @@ impl<C: ContainerService + Send + Sync + 'static> PrMonitorService<C> {
     /// and links any not already known. Runs before check_all_open_prs so
     /// newly discovered PRs get their status checked in the same cycle.
     async fn discover_new_prs(&self) -> Result<(), PrMonitorError> {
-        let candidates = Merge::get_active_workspace_repos(&self.db.pool).await?;
+        let updated_since = *self.last_discovery_at.lock().unwrap();
+        let candidates = Merge::get_active_workspace_repos(&self.db.pool, updated_since).await?;
+
+        // Record the time before we start checking so we don't miss concurrent updates.
+        let discovery_started_at = Utc::now();
 
         if candidates.is_empty() {
             debug!("No active workspace repos to check for PRs");
+            *self.last_discovery_at.lock().unwrap() = Some(discovery_started_at);
             return Ok(());
         }
 
         debug!(
-            "Checking {} workspace-repo pairs for new PRs",
-            candidates.len()
+            "Checking {} workspace-repo pairs for new PRs (since {:?})",
+            candidates.len(),
+            updated_since,
         );
 
         for candidate in &candidates {
@@ -166,6 +177,8 @@ impl<C: ContainerService + Send + Sync + 'static> PrMonitorService<C> {
                 }
             }
         }
+
+        *self.last_discovery_at.lock().unwrap() = Some(discovery_started_at);
         Ok(())
     }
 

--- a/crates/services/src/services/pr_monitor.rs
+++ b/crates/services/src/services/pr_monitor.rs
@@ -5,11 +5,13 @@ use chrono::Utc;
 use db::{
     DBService,
     models::{
-        merge::MergeStatus,
+        merge::{ActiveWorkspaceRepo, Merge, MergeStatus},
         pull_request::PullRequest,
+        repo::Repo,
         workspace::{Workspace, WorkspaceError},
     },
 };
+use git::GitServiceError;
 use git_host::{GitHostError, GitHostProvider, GitHostService};
 use serde_json::json;
 use sqlx::error::Error as SqlxError;
@@ -29,6 +31,8 @@ enum PrMonitorError {
     #[error(transparent)]
     GitHostError(#[from] GitHostError),
     #[error(transparent)]
+    GitServiceError(#[from] GitServiceError),
+    #[error(transparent)]
     WorkspaceError(#[from] WorkspaceError),
     #[error(transparent)]
     Sqlx(#[from] SqlxError),
@@ -40,7 +44,7 @@ impl PrMonitorError {
             self,
             PrMonitorError::GitHostError(
                 GitHostError::CliNotInstalled { .. } | GitHostError::NotAGitRepository(_)
-            )
+            ) | PrMonitorError::GitServiceError(_)
         )
     }
 }
@@ -87,6 +91,11 @@ impl<C: ContainerService + Send + Sync + 'static> PrMonitorService<C> {
         loop {
             tokio::select! {
                 _ = interval.tick() => {
+                    // Discover new PRs first so check_all_open_prs can handle
+                    // their status updates in the same cycle.
+                    if let Err(e) = self.discover_new_prs().await {
+                        error!("Error discovering new PRs: {}", e);
+                    }
                     if let Err(e) = self.check_all_open_prs().await {
                         error!("Error checking open PRs: {}", e);
                     }
@@ -120,6 +129,100 @@ impl<C: ContainerService + Send + Sync + 'static> PrMonitorService<C> {
                     error!("Error checking PR #{}: {}", pr.pr_number, e);
                 }
             }
+        }
+
+        Ok(())
+    }
+
+    /// Discover PRs created outside of VK on workspace branches.
+    /// Scans all active workspaces, queries GitHub for PRs on their branch,
+    /// and links any not already known. Runs before check_all_open_prs so
+    /// newly discovered PRs get their status checked in the same cycle.
+    async fn discover_new_prs(&self) -> Result<(), PrMonitorError> {
+        let candidates = Merge::get_active_workspace_repos(&self.db.pool).await?;
+
+        if candidates.is_empty() {
+            debug!("No active workspace repos to check for PRs");
+            return Ok(());
+        }
+
+        debug!(
+            "Checking {} workspace-repo pairs for new PRs",
+            candidates.len()
+        );
+
+        for candidate in &candidates {
+            if let Err(e) = self.discover_prs_for_workspace_repo(candidate).await {
+                if e.is_environmental() {
+                    debug!(
+                        "Skipping PR discovery for workspace {} repo {} due to environmental error: {}",
+                        candidate.workspace_id, candidate.repo_id, e
+                    );
+                } else {
+                    warn!(
+                        "Error discovering PR for workspace {} repo {}: {}",
+                        candidate.workspace_id, candidate.repo_id, e
+                    );
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Query GitHub for PRs on a workspace branch and link any we don't already know about.
+    /// Only creates pull request records; status updates and archival are handled by
+    /// check_all_open_prs later in the same cycle.
+    async fn discover_prs_for_workspace_repo(
+        &self,
+        candidate: &ActiveWorkspaceRepo,
+    ) -> Result<(), PrMonitorError> {
+        let repo = Repo::find_by_id(&self.db.pool, candidate.repo_id)
+            .await?
+            .ok_or_else(|| {
+                PrMonitorError::GitHostError(GitHostError::PullRequest(format!(
+                    "Repo {} not found",
+                    candidate.repo_id
+                )))
+            })?;
+
+        let git = self.container.git();
+        let remote = git.resolve_remote_for_branch(&repo.path, &candidate.target_branch)?;
+
+        let git_host = GitHostService::from_url(&remote.url)?;
+        let prs = git_host
+            .list_prs_for_branch(&repo.path, &remote.url, &candidate.workspace_branch)
+            .await?;
+
+        if prs.is_empty() {
+            return Ok(());
+        }
+
+        let known_pr_numbers = PullRequest::get_known_pr_numbers(
+            &self.db.pool,
+            candidate.workspace_id,
+            candidate.repo_id,
+        )
+        .await?;
+
+        for pr_info in prs {
+            if known_pr_numbers.contains(&pr_info.number) {
+                continue;
+            }
+
+            info!(
+                "Auto-discovered PR #{} for workspace {} repo {}",
+                pr_info.number, candidate.workspace_id, candidate.repo_id
+            );
+
+            PullRequest::create_for_workspace(
+                &self.db.pool,
+                candidate.workspace_id,
+                candidate.repo_id,
+                &candidate.target_branch,
+                pr_info.number,
+                &pr_info.url,
+            )
+            .await?;
         }
 
         Ok(())

--- a/crates/services/src/services/pr_monitor.rs
+++ b/crates/services/src/services/pr_monitor.rs
@@ -140,8 +140,9 @@ impl<C: ContainerService + Send + Sync + 'static> PrMonitorService<C> {
     }
 
     /// Discover PRs created outside of VK on workspace branches.
-    /// Scans all active workspaces, queries GitHub for PRs on their branch,
-    /// and links any not already known. Runs before check_all_open_prs so
+    /// On the first run, scans all active workspaces; on subsequent runs,
+    /// only checks workspaces updated since the last discovery cycle.
+    /// Links any PRs not already known. Runs before check_all_open_prs so
     /// newly discovered PRs get their status checked in the same cycle.
     async fn discover_new_prs(&self) -> Result<(), PrMonitorError> {
         let updated_since = *self.last_discovery_at.lock().unwrap();

--- a/crates/services/src/services/pr_monitor.rs
+++ b/crates/services/src/services/pr_monitor.rs
@@ -214,6 +214,9 @@ impl<C: ContainerService + Send + Sync + 'static> PrMonitorService<C> {
                 pr_info.number, pr_info.status, candidate.workspace_id, candidate.repo_id
             );
 
+            // Created as 'open' — check_all_open_prs will pick it up on the
+            // next cycle, detect the actual status, and run the full lifecycle
+            // (archival, remote sync, analytics) if already merged/closed.
             PullRequest::create_for_workspace(
                 &self.db.pool,
                 candidate.workspace_id,
@@ -223,19 +226,6 @@ impl<C: ContainerService + Send + Sync + 'static> PrMonitorService<C> {
                 &pr_info.url,
             )
             .await?;
-
-            // create_for_workspace inserts as 'open'; correct the status immediately so
-            // check_all_open_prs doesn't falsely trigger the merged/closed lifecycle.
-            if !matches!(pr_info.status, MergeStatus::Open) {
-                PullRequest::update_status(
-                    &self.db.pool,
-                    &pr_info.url,
-                    &pr_info.status,
-                    pr_info.merged_at,
-                    pr_info.merge_commit_sha.clone(),
-                )
-                .await?;
-            }
         }
 
         Ok(())

--- a/crates/services/src/services/pr_monitor.rs
+++ b/crates/services/src/services/pr_monitor.rs
@@ -1,4 +1,7 @@
-use std::{sync::Arc, sync::Mutex, time::Duration};
+use std::{
+    sync::{Arc, Mutex},
+    time::Duration,
+};
 
 use api_types::{PullRequestStatus, UpdatePullRequestApiRequest, UpsertPullRequestRequest};
 use chrono::{DateTime, Utc};
@@ -146,10 +149,13 @@ impl<C: ContainerService + Send + Sync + 'static> PrMonitorService<C> {
     /// newly discovered PRs get their status checked in the same cycle.
     async fn discover_new_prs(&self) -> Result<(), PrMonitorError> {
         let updated_since = *self.last_discovery_at.lock().unwrap();
-        let candidates = Merge::get_active_workspace_repos(&self.db.pool, updated_since).await?;
 
-        // Record the time before we start checking so we don't miss concurrent updates.
+        // Capture the timestamp before the DB query to prevent a race condition:
+        // a workspace updated between the query and this timestamp would be missed
+        // by both the current and future discovery cycles. Capturing early may
+        // re-query some workspaces, but that is safe since discovery is idempotent.
         let discovery_started_at = Utc::now();
+        let candidates = Merge::get_active_workspace_repos(&self.db.pool, updated_since).await?;
 
         if candidates.is_empty() {
             debug!("No active workspace repos to check for PRs");
@@ -163,6 +169,7 @@ impl<C: ContainerService + Send + Sync + 'static> PrMonitorService<C> {
             updated_since,
         );
 
+        let mut had_failures = false;
         for candidate in &candidates {
             if let Err(e) = self.discover_prs_for_workspace_repo(candidate).await {
                 if e.is_environmental() {
@@ -175,11 +182,16 @@ impl<C: ContainerService + Send + Sync + 'static> PrMonitorService<C> {
                         "Error discovering PR for workspace {} repo {}: {}",
                         candidate.workspace_id, candidate.repo_id, e
                     );
+                    had_failures = true;
                 }
             }
         }
 
-        *self.last_discovery_at.lock().unwrap() = Some(discovery_started_at);
+        // Only advance the watermark if all candidates were successfully processed,
+        // so that failed candidates are retried in the next discovery cycle.
+        if !had_failures {
+            *self.last_discovery_at.lock().unwrap() = Some(discovery_started_at);
+        }
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

When users configure coding agents with skills that create PRs (e.g. via `gh pr create`), those PRs don't appear in the workspace UI because VK only tracks PRs created through its own interface. This makes it hard to tell when an agent's work is done.

This change extends the existing `PrMonitorService` to auto-discover PRs on workspace branches by polling GitHub, linking any it finds to the workspace so they appear in the UI and trigger the normal merged-PR lifecycle (status updates, archival).

## Changes

- **`crates/db/src/models/merge.rs`**: Add `ActiveWorkspaceRepo` struct and two new queries:
  - `get_active_workspace_repos()` — returns all non-archived workspace-repo pairs
  - `get_known_pr_numbers()` — returns PR numbers already linked to a workspace-repo pair
- **`crates/services/src/services/pr_monitor.rs`**: Add PR discovery phase to the 60-second poll loop:
  - Runs *before* `check_all_open_prs()` so newly discovered PRs get their status checked in the same cycle
  - For each active workspace-repo pair, queries GitHub for PRs on the workspace branch via the existing `list_prs_for_branch()` abstraction
  - Skips PRs already known, links any new ones by creating merge records
  - Supports multiple PRs per workspace branch (e.g. an agent closes one PR and opens another)
  - The existing PR monitor then handles status tracking, remote sync, and auto-archival — no duplicated logic

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds periodic git-host polling and new DB queries in a background service; misconfiguration or logic errors could increase API usage/rate-limit pressure or create duplicate/missing PR links, but changes are additive and largely idempotent.
> 
> **Overview**
> Adds a PR *discovery* phase to `PrMonitorService` that, on each poll, enumerates active (non-archived) workspace↔repo pairs (optionally only those updated since the last run) and queries the git host for PRs targeting each workspace branch, creating local `pull_requests` records for any newly found PRs so they appear in the UI and enter the normal status/archival/sync lifecycle.
> 
> Introduces DB helpers to support this (`Merge::get_active_workspace_repos`, `PullRequest::get_known_pr_numbers`) plus associated SQLx query metadata, and tracks a `last_discovery_at` watermark to reduce unnecessary host API calls while retrying failed candidates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 539f044785e24da462cf75f4fc4b8a797445de96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->