### PR TITLE
fix: load non-localhost preview URLs directly in iframe

### DIFF
--- a/packages/web-core/src/pages/workspaces/PreviewBrowserContainer.tsx
+++ b/packages/web-core/src/pages/workspaces/PreviewBrowserContainer.tsx
@@ -33,6 +33,23 @@ import type { PreviewDevToolsMessage } from '@/shared/types/previewDevTools';
 const MIN_RESPONSIVE_WIDTH = 320;
 const MIN_RESPONSIVE_HEIGHT = 480;
 
+const noop = () => {};
+
+/**
+ * Hostnames that are considered loopback/local.
+ * Kept in sync with `LOOPBACK_HOSTS` in usePreviewUrl.ts and
+ * `is_loopback_redirect_host` in the Rust preview-proxy crate.
+ */
+const LOOPBACK_HOSTS = new Set([
+  'localhost',
+  '127.0.0.1',
+  '0.0.0.0',
+  '[::1]',
+  '::1',
+  '[::]',
+  '::',
+]);
+
 function parsePreviewUrl(rawUrl: string, baseUrl?: string): URL | null {
   const trimmed = rawUrl.trim();
   if (!trimmed) return null;
@@ -241,14 +258,33 @@ export function PreviewBrowserContainer({
     );
   }, [hasOverride, urlInfo?.port, effectiveParsedUrl]);
 
-  // Builds the subdomain-based proxy URL loaded by the iframe.
-  //   Dev server at localhost:4000 → iframe loads http://4000.localhost:{proxyPort}/path
-  //   The proxy extracts the target port from the subdomain and forwards to the dev server.
-  //   _refresh query param forces iframe reload on refresh button click.
+  // Whether the preview URL targets a loopback address.
+  // Loopback previews use the subdomain proxy (origin isolation, devtools
+  // script injection, header stripping, SPA bridge navigation).
+  // Non-loopback previews (e.g. Coder port-forwarded URLs) load directly
+  // in the iframe — intentionally degraded: no bridge, no injected scripts,
+  // no Eruda/inspect mode, no SPA navigation via postMessage.
+  const isLoopbackPreview = useMemo(() => {
+    if (!effectiveParsedUrl) return true;
+    return LOOPBACK_HOSTS.has(effectiveParsedUrl.hostname);
+  }, [effectiveParsedUrl]);
+
   const iframeUrl = useMemo(() => {
-    if (!effectiveParsedUrl || !previewProxyPort || !devServerPort) {
+    if (!effectiveParsedUrl || !devServerPort) {
       return undefined;
     }
+
+    // Non-loopback URLs (e.g. Coder port-forwarded URLs like
+    // https://4000--workspace--user.coder.example.com) can be loaded
+    // directly — subdomain proxy routing only works for localhost.
+    if (!isLoopbackPreview) {
+      const directUrl = new URL(effectiveParsedUrl.toString());
+      directUrl.searchParams.set('_refresh', String(previewRefreshKey));
+      return directUrl.toString();
+    }
+
+    // Loopback URLs need the preview proxy for origin isolation
+    if (!previewProxyPort) return undefined;
 
     // Don't proxy to Vibe Kanban's own ports (would create infinite loop)
     const vibeKanbanPort = window.location.port || '80';
@@ -268,13 +304,6 @@ export function PreviewBrowserContainer({
       return undefined;
     }
 
-    // Warn if not on localhost (subdomain routing requires localhost)
-    if (!['localhost', '127.0.0.1'].includes(window.location.hostname)) {
-      console.warn(
-        '[Preview] Preview proxy subdomain routing may not work on non-localhost hostname'
-      );
-    }
-
     const path = effectiveParsedUrl.pathname + effectiveParsedUrl.search;
 
     // Subdomain-based routing: the proxy extracts the port from the Host header
@@ -290,6 +319,7 @@ export function PreviewBrowserContainer({
     devServerPort,
     effectiveParsedUrl,
     hostId,
+    isLoopbackPreview,
     previewProxyPort,
     previewRefreshKey,
   ]);
@@ -337,6 +367,10 @@ export function PreviewBrowserContainer({
   const bridgeRef = useRef<PreviewDevToolsBridge | null>(null);
   const displayedPreviewUrl = useMemo(() => {
     if (navigation?.url) {
+      // Non-loopback (direct) URLs: strip _refresh param and show as-is
+      if (!isLoopbackPreview) {
+        return stripPreviewRefreshParam(navigation.url) ?? navigation.url;
+      }
       if (hostId != null) {
         return stripPreviewRefreshParam(navigation.url) ?? navigation.url;
       }
@@ -356,7 +390,14 @@ export function PreviewBrowserContainer({
     }
 
     return effectiveUrl ?? null;
-  }, [devServerPort, effectiveUrl, hostId, iframeUrl, navigation?.url]);
+  }, [
+    devServerPort,
+    effectiveUrl,
+    hostId,
+    iframeUrl,
+    isLoopbackPreview,
+    navigation?.url,
+  ]);
 
   const handleBridgeMessage = useCallback(
     (message: PreviewDevToolsMessage) => {
@@ -696,20 +737,28 @@ export function PreviewBrowserContainer({
 
     resetNavigation();
 
-    if (showIframe && iframeRef.current?.contentWindow && previewProxyPort) {
-      if (devServerPort != null && normalizedInputDevPort === devServerPort) {
-        const proxyPath =
-          normalizedInputDevParsed.pathname +
-          normalizedInputDevParsed.search +
-          normalizedInputDevParsed.hash;
-        const hostToken =
-          hostId != null
-            ? `${normalizedInputDevPort}--${hostId}`
-            : normalizedInputDevPort;
-        const proxyUrl = `http://${hostToken}.localhost:${previewProxyPort}${proxyPath}`;
-        bridgeRef.current?.navigateTo(proxyUrl);
-        return;
-      }
+    // Bridge SPA navigation only works when the proxy injects devtools_script.js
+    // into the iframe. Non-loopback URLs bypass the proxy entirely, so the bridge
+    // isn't available — fall through to setOverrideUrl for a full iframe reload.
+    if (
+      showIframe &&
+      iframeRef.current?.contentWindow &&
+      isLoopbackPreview &&
+      previewProxyPort &&
+      devServerPort != null &&
+      normalizedInputDevPort === devServerPort
+    ) {
+      const proxyPath =
+        normalizedInputDevParsed.pathname +
+        normalizedInputDevParsed.search +
+        normalizedInputDevParsed.hash;
+      const hostToken =
+        hostId != null
+          ? `${normalizedInputDevPort}--${hostId}`
+          : normalizedInputDevPort;
+      const proxyUrl = `http://${hostToken}.localhost:${previewProxyPort}${proxyPath}`;
+      bridgeRef.current?.navigateTo(proxyUrl);
+      return;
     }
 
     setOverrideUrl(normalizedInputDevUrl);
@@ -719,6 +768,7 @@ export function PreviewBrowserContainer({
     urlInputValue,
     displayedPreviewUrl,
     hostId,
+    isLoopbackPreview,
     hasOverride,
     showIframe,
     previewProxyPort,
@@ -914,10 +964,10 @@ export function PreviewBrowserContainer({
       navigation={navigation}
       onNavigateBack={handleNavigateBack}
       onNavigateForward={handleNavigateForward}
-      isInspectMode={isInspectMode}
-      onToggleInspectMode={toggleInspectMode}
-      isErudaVisible={isErudaVisible}
-      onToggleEruda={handleToggleEruda}
+      isInspectMode={isLoopbackPreview && isInspectMode}
+      onToggleInspectMode={isLoopbackPreview ? toggleInspectMode : noop}
+      isErudaVisible={isLoopbackPreview && isErudaVisible}
+      onToggleEruda={isLoopbackPreview ? handleToggleEruda : noop}
       onIframeLoad={handleIframeLoad}
       isMobile={isMobile}
       mobileUrlExpanded={mobileUrlExpanded}


### PR DESCRIPTION
## Summary

- When the preview URL is not a loopback address (e.g. Coder port-forwarded URLs like `https://4000--workspace.coder.example.com`), load it directly in the iframe instead of routing through the subdomain-based preview proxy
- The subdomain proxy (`http://{port}.localhost:{proxyPort}`) only works when VK runs on localhost — this breaks preview for remote-hosted VK (Coder, cloud workspaces, tunneled environments)
- Direct mode is **intentionally degraded**: no bridge communication, no injected devtools/Eruda/inspect scripts, no SPA navigation via postMessage — URL bar changes trigger a full iframe reload

## Problem

When VK is hosted remotely (e.g. on Coder), the current subdomain-based proxy routing doesn't work:
1. Dev server starts on `localhost:4000` (on the server)
2. VK rewrites the iframe URL to `http://4000.localhost:{proxyPort}` 
3. The browser can't resolve `4000.localhost` from outside → preview is broken

Users can access their dev server via Coder's port-forwarding (`https://4000--workspace.coder.example.com`), but VK still forces the URL through the proxy.

## Changes

- **`LOOPBACK_HOSTS` constant** — shared set matching `usePreviewUrl.ts` and Rust `is_loopback_redirect_host` (includes IPv6 `[::1]`, `[::]`)
- **`isLoopbackPreview` memo** — determines routing mode, reused across the component
- **`iframeUrl`** — non-loopback URLs loaded directly (no proxy needed)
- **`displayedPreviewUrl`** — strips `_refresh` param for direct navigation URLs
- **`handleUrlSubmit`** — bridge SPA navigation gated on `isLoopbackPreview` (devtools script only injected by proxy); non-loopback falls through to `setOverrideUrl` for full iframe reload
- **Eruda/inspect mode** — disabled in direct mode (no injected scripts to handle commands)

## Test plan

- [ ] Local dev: start a dev server, verify preview iframe loads via proxy as before
- [ ] Remote/Coder: set an override URL to a non-localhost address, verify iframe loads it directly
- [ ] URL bar: submit a new path on a non-localhost preview, verify full iframe reload (not silent no-op)
- [ ] Eruda/inspect buttons: verify disabled/no-op in non-localhost mode, functional in localhost mode
- [ ] Refresh: verify refresh button works for both localhost and non-localhost preview URLs
- [ ] IPv6: verify `http://[::1]:3000` is treated as loopback (uses proxy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)