### PR TITLE
Auto-focus and select text in workspace rename modal

### DIFF
--- a/packages/ui/src/components/RenameWorkspaceDialog.tsx
+++ b/packages/ui/src/components/RenameWorkspaceDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   Dialog,
@@ -30,6 +30,12 @@ const RenameWorkspaceDialogImpl = NiceModal.create<RenameWorkspaceDialogProps>(
     const [name, setName] = useState<string>(currentName);
     const [error, setError] = useState<string | null>(null);
     const [isSubmitting, setIsSubmitting] = useState(false);
+
+    const inputRef = useCallback((node: HTMLInputElement | null) => {
+      if (node) {
+        node.select();
+      }
+    }, []);
 
     useEffect(() => {
       setName(currentName);
@@ -90,6 +96,7 @@ const RenameWorkspaceDialogImpl = NiceModal.create<RenameWorkspaceDialogProps>(
                 {t('workspaces.rename.nameLabel')}
               </label>
               <Input
+                ref={inputRef}
                 id="workspace-name"
                 type="text"
                 value={name}


### PR DESCRIPTION
Use a callback ref to call select() on the rename input when it mounts, so the existing workspace name is fully selected and the user can immediately type a replacement. Single file change (1 component, 8 lines added).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adds a callback ref to select the input text on mount; no data, auth, or backend logic is touched.
> 
> **Overview**
> Improves the workspace rename modal UX by introducing a callback `ref` on the name `Input` that calls `select()` when the element mounts, ensuring the existing workspace name is highlighted for quick replacement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4403e211fb203e27a8c2db638491b427945d2498. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->