### PR TITLE
Add pre-commit hook for Rust and frontend quality checks

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -7,8 +7,8 @@ set -euo pipefail
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 
-# Staged files (added, copied, modified).
-STAGED=$(git diff --cached --name-only --diff-filter=ACM)
+# Staged files (added, copied, modified, renamed).
+STAGED=$(git diff --cached --name-only --diff-filter=ACMR)
 
 has_staged() {
   echo "$STAGED" | grep -qE "$1"

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# pre-commit hook: run quality checks gated on which files are staged.
+#
+# Enable for all checkouts (including worktrees) with:
+#   git config core.hooksPath .githooks
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+# Staged files (added, copied, modified).
+STAGED=$(git diff --cached --name-only --diff-filter=ACM)
+
+has_staged() {
+  echo "$STAGED" | grep -qE "$1"
+}
+
+FAILED=0
+
+# --- Rust: fmt, clippy, test (scoped to affected crates) ---
+# affected-crates.py is the single source of truth for whether Rust checks
+# are needed and which crates to check.  It handles .rs, .toml, Cargo.lock,
+# rust-toolchain.toml, etc.
+if command -v cargo &>/dev/null && command -v python3 &>/dev/null; then
+  # Capture exit code without tripping set -e.
+  SCOPE_EXIT=0
+  SCOPE=$(echo "$STAGED" | python3 "$REPO_ROOT/scripts/affected-crates.py" --stdin) || SCOPE_EXIT=$?
+
+  if [ "$SCOPE_EXIT" -eq 2 ]; then
+    # Global file changed (Cargo.lock, rust-toolchain, etc.) — full workspace.
+    echo "pre-commit: global Rust file changed, checking full workspace..."
+    SCOPE="--workspace"
+  elif [ "$SCOPE_EXIT" -ne 0 ]; then
+    echo "pre-commit: affected-crates.py failed (exit $SCOPE_EXIT)" >&2
+    FAILED=1
+    SCOPE=""
+  fi
+
+  if [ -n "$SCOPE" ]; then
+    # fmt always runs workspace-wide (fast, no compilation).
+    echo "pre-commit: cargo fmt..."
+    cargo fmt --all --manifest-path "$REPO_ROOT/Cargo.toml" -- --check || FAILED=1
+
+    echo "pre-commit: cargo clippy $SCOPE..."
+    # shellcheck disable=SC2086
+    cargo clippy $SCOPE --all-targets --locked \
+      --manifest-path "$REPO_ROOT/Cargo.toml" -- -D warnings || FAILED=1
+
+    echo "pre-commit: cargo test $SCOPE..."
+    # shellcheck disable=SC2086
+    cargo test $SCOPE --all-targets --locked \
+      --manifest-path "$REPO_ROOT/Cargo.toml" || FAILED=1
+  fi
+fi
+
+# --- Frontend: format, typecheck, lint (scoped to affected packages) ---
+if command -v pnpm &>/dev/null; then
+  # Package directory -> pnpm filter name.
+  # Only local-web and ui have an eslint "lint" script.
+  declare -A PKG_FILTER=(
+    [packages/local-web]="@vibe/local-web"
+    [packages/web-core]="@vibe/web-core"
+    [packages/remote-web]="@vibe/remote-web"
+    [packages/ui]="@vibe/ui"
+  )
+  declare -A PKG_HAS_LINT=(
+    [packages/local-web]=1
+    [packages/ui]=1
+  )
+
+  AFFECTED_PKGS=()
+  for pkg_dir in "${!PKG_FILTER[@]}"; do
+    if has_staged "^${pkg_dir}/"; then
+      AFFECTED_PKGS+=("$pkg_dir")
+    fi
+  done
+
+  if [ ${#AFFECTED_PKGS[@]} -gt 0 ]; then
+    for pkg_dir in "${AFFECTED_PKGS[@]}"; do
+      filter="${PKG_FILTER[$pkg_dir]}"
+
+      echo "pre-commit: prettier --check ($filter)..."
+      pnpm --filter "$filter" run format:check || FAILED=1
+
+      echo "pre-commit: tsc --noEmit ($filter)..."
+      pnpm --filter "$filter" run check || FAILED=1
+
+      if [ "${PKG_HAS_LINT[$pkg_dir]:-}" = "1" ]; then
+        echo "pre-commit: eslint ($filter)..."
+        pnpm --filter "$filter" run lint || FAILED=1
+      fi
+    done
+  fi
+
+  # --- Legacy frontend paths guard ---
+  if has_staged '^packages/local-web/|^packages/web-core/'; then
+    echo "pre-commit: legacy frontend paths check..."
+    "$REPO_ROOT/scripts/check-legacy-frontend-paths.sh" || FAILED=1
+  fi
+
+  # --- Unused i18n keys ---
+  if has_staged '^packages/.*/src/.*\.(ts|tsx)$|^packages/web-core/src/i18n/'; then
+    echo "pre-commit: unused i18n keys check..."
+    node "$REPO_ROOT/scripts/check-unused-i18n-keys.mjs" || FAILED=1
+  fi
+fi
+
+exit "$FAILED"

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -7,8 +7,8 @@ set -euo pipefail
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 
-# Staged files (added, copied, modified, renamed).
-STAGED=$(git diff --cached --name-only --diff-filter=ACMR)
+# Staged files (added, copied, modified, renamed, deleted).
+STAGED=$(git diff --cached --name-only --diff-filter=ACMRD)
 
 has_staged() {
   echo "$STAGED" | grep -qE "$1"
@@ -25,7 +25,7 @@ if command -v cargo &>/dev/null && command -v python3 &>/dev/null; then
   SCOPE_EXIT=0
   SCOPE=$(echo "$STAGED" | python3 "$REPO_ROOT/scripts/affected-crates.py" --stdin) || SCOPE_EXIT=$?
 
-  if [ "$SCOPE_EXIT" -eq 2 ]; then
+  if [ "$SCOPE_EXIT" -eq 10 ]; then
     # Global file changed (Cargo.lock, rust-toolchain, etc.) — full workspace.
     echo "pre-commit: global Rust file changed, checking full workspace..."
     SCOPE="--workspace"
@@ -56,19 +56,27 @@ fi
 if command -v pnpm &>/dev/null; then
   # Package directory -> pnpm filter name.
   # Only local-web and ui have an eslint "lint" script.
-  declare -A PKG_FILTER=(
-    [packages/local-web]="@vibe/local-web"
-    [packages/web-core]="@vibe/web-core"
-    [packages/remote-web]="@vibe/remote-web"
-    [packages/ui]="@vibe/ui"
-  )
-  declare -A PKG_HAS_LINT=(
-    [packages/local-web]=1
-    [packages/ui]=1
-  )
+  # Avoid associative arrays (require bash 4+; macOS ships bash 3.2).
+  PKG_DIRS="packages/local-web packages/web-core packages/remote-web packages/ui"
+
+  pkg_filter() {
+    case "$1" in
+      packages/local-web)  echo "@vibe/local-web" ;;
+      packages/web-core)   echo "@vibe/web-core" ;;
+      packages/remote-web) echo "@vibe/remote-web" ;;
+      packages/ui)         echo "@vibe/ui" ;;
+    esac
+  }
+
+  pkg_has_lint() {
+    case "$1" in
+      packages/local-web|packages/ui) return 0 ;;
+      *) return 1 ;;
+    esac
+  }
 
   AFFECTED_PKGS=()
-  for pkg_dir in "${!PKG_FILTER[@]}"; do
+  for pkg_dir in $PKG_DIRS; do
     if has_staged "^${pkg_dir}/"; then
       AFFECTED_PKGS+=("$pkg_dir")
     fi
@@ -76,7 +84,7 @@ if command -v pnpm &>/dev/null; then
 
   if [ ${#AFFECTED_PKGS[@]} -gt 0 ]; then
     for pkg_dir in "${AFFECTED_PKGS[@]}"; do
-      filter="${PKG_FILTER[$pkg_dir]}"
+      filter=$(pkg_filter "$pkg_dir")
 
       echo "pre-commit: prettier --check ($filter)..."
       pnpm --filter "$filter" run format:check || FAILED=1
@@ -84,7 +92,7 @@ if command -v pnpm &>/dev/null; then
       echo "pre-commit: tsc --noEmit ($filter)..."
       pnpm --filter "$filter" run check || FAILED=1
 
-      if [ "${PKG_HAS_LINT[$pkg_dir]:-}" = "1" ]; then
+      if pkg_has_lint "$pkg_dir"; then
         echo "pre-commit: eslint ($filter)..."
         pnpm --filter "$filter" run lint || FAILED=1
       fi

--- a/README.md
+++ b/README.md
@@ -87,6 +87,24 @@ Install dependencies:
 pnpm i
 ```
 
+### Pre-commit hook
+
+The repo includes a pre-commit hook that runs quality checks scoped to your staged changes:
+
+- **Rust** — `cargo fmt --check`, `cargo clippy`, and `cargo test` on affected crates (and their reverse dependencies via `scripts/affected-crates.py`)
+- **Frontend** — `prettier --check`, `tsc --noEmit`, and `eslint` on affected packages (`local-web`, `web-core`, `remote-web`, `ui`)
+- **Guards** — legacy frontend path check and unused i18n key detection when relevant files change
+
+Enable it with:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+The hook requires `cargo`, `python3`, and `pnpm` on your `PATH`.
+
+> **Vibe Kanban development:** If you use Vibe Kanban to develop this repo, add `git config core.hooksPath .githooks` to the repository's setup script so every workspace gets the hook automatically.
+
 ### Running the dev server
 
 ```bash

--- a/scripts/affected-crates.py
+++ b/scripts/affected-crates.py
@@ -65,6 +65,7 @@ _GLOBAL_TRIGGERS = {
     "Cargo.toml",
     "rust-toolchain.toml",
     "rust-toolchain",
+    "rustfmt.toml",
     ".cargo/config.toml",
 }
 

--- a/scripts/affected-crates.py
+++ b/scripts/affected-crates.py
@@ -8,9 +8,9 @@ Usage:
 Exit codes:
     0  — printed -p flags (possibly none)
     1  — error
-    2  — full workspace run needed (Cargo.lock, rust-toolchain.toml, etc.)
+    10 — full workspace run needed (Cargo.lock, rust-toolchain.toml, etc.)
 
-When exit code is 2 the caller should run cargo commands with --workspace.
+When exit code is 10 the caller should run cargo commands with --workspace.
 """
 from __future__ import annotations
 
@@ -40,7 +40,11 @@ def _build_maps(meta: dict) -> tuple[str, dict[str, str], dict[str, set[str]]]:
         if pkg["id"] not in ws_member_ids:
             continue
         manifest = pkg["manifest_path"]
-        rel = manifest.removeprefix(ws_root + "/").removesuffix("/Cargo.toml")
+        rel = manifest.removeprefix(ws_root + "/")
+        if rel == "Cargo.toml":
+            rel = ""
+        else:
+            rel = rel.removesuffix("/Cargo.toml")
         dir_to_pkg[rel] = pkg["name"]
 
     # Build reverse-dependency adjacency list (workspace packages only).
@@ -118,7 +122,7 @@ def main() -> int:
     result = affected_packages(files, dir_to_pkg, rdeps)
 
     if result is None:
-        return 2  # caller should use --workspace
+        return 10  # caller should use --workspace
 
     if result:
         print(" ".join(f"-p {name}" for name in sorted(result)))

--- a/scripts/affected-crates.py
+++ b/scripts/affected-crates.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Print -p flags for workspace crates affected by a set of changed files.
+
+Usage:
+    affected-crates.py FILE [FILE ...]
+    git diff --name-only | affected-crates.py --stdin
+
+Exit codes:
+    0  — printed -p flags (possibly none)
+    1  — error
+    2  — full workspace run needed (Cargo.lock, rust-toolchain.toml, etc.)
+
+When exit code is 2 the caller should run cargo commands with --workspace.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from collections import deque
+from pathlib import PurePosixPath
+
+
+def _cargo_metadata() -> dict:
+    raw = subprocess.check_output(
+        ["cargo", "metadata", "--format-version", "1"],
+        stderr=subprocess.DEVNULL,
+    )
+    return json.loads(raw)
+
+
+def _build_maps(meta: dict) -> tuple[str, dict[str, str], dict[str, set[str]]]:
+    """Return (workspace_root, path_prefix->pkg_name, pkg->set of rdeps)."""
+    ws_root = meta["workspace_root"]
+    ws_member_ids = set(meta["workspace_members"])
+
+    # Map crate directory (relative to ws root) -> package name.
+    dir_to_pkg: dict[str, str] = {}
+    for pkg in meta["packages"]:
+        if pkg["id"] not in ws_member_ids:
+            continue
+        manifest = pkg["manifest_path"]
+        rel = manifest.replace(ws_root + "/", "").removesuffix("/Cargo.toml")
+        dir_to_pkg[rel] = pkg["name"]
+
+    # Build reverse-dependency adjacency list (workspace packages only).
+    id_to_name = {p["id"]: p["name"] for p in meta["packages"]}
+    ws_names = {id_to_name[mid] for mid in ws_member_ids}
+    rdeps: dict[str, set[str]] = {name: set() for name in ws_names}
+    for node in meta["resolve"]["nodes"]:
+        if node["id"] not in ws_member_ids:
+            continue
+        depender = id_to_name[node["id"]]
+        for dep in node.get("deps", []):
+            dep_name = id_to_name[dep["pkg"]]
+            if dep_name in ws_names:
+                rdeps.setdefault(dep_name, set()).add(depender)
+
+    return ws_root, dir_to_pkg, rdeps
+
+
+# Files whose change means we must check every crate.
+_GLOBAL_TRIGGERS = {
+    "Cargo.lock",
+    "Cargo.toml",
+    "rust-toolchain.toml",
+    "rust-toolchain",
+    ".cargo/config.toml",
+}
+
+
+def affected_packages(
+    changed_files: list[str],
+    dir_to_pkg: dict[str, str],
+    rdeps: dict[str, set[str]],
+) -> set[str] | None:
+    """Return affected package names, or None for full-workspace run."""
+    direct: set[str] = set()
+
+    for f in changed_files:
+        if f in _GLOBAL_TRIGGERS:
+            return None  # full workspace
+
+        # Walk up path segments to find the containing crate.
+        parts = PurePosixPath(f).parts
+        for i in range(len(parts), 0, -1):
+            prefix = "/".join(parts[:i])
+            if prefix in dir_to_pkg:
+                direct.add(dir_to_pkg[prefix])
+                break
+
+    # BFS for transitive reverse dependents.
+    affected = set(direct)
+    queue = deque(direct)
+    while queue:
+        pkg = queue.popleft()
+        for rdep in rdeps.get(pkg, set()):
+            if rdep not in affected:
+                affected.add(rdep)
+                queue.append(rdep)
+
+    return affected
+
+
+def main() -> int:
+    if "--stdin" in sys.argv:
+        files = [line.strip() for line in sys.stdin if line.strip()]
+    else:
+        files = sys.argv[1:]
+
+    if not files:
+        return 0
+
+    meta = _cargo_metadata()
+    _, dir_to_pkg, rdeps = _build_maps(meta)
+
+    result = affected_packages(files, dir_to_pkg, rdeps)
+
+    if result is None:
+        return 2  # caller should use --workspace
+
+    if result:
+        print(" ".join(f"-p {name}" for name in sorted(result)))
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/affected-crates.py
+++ b/scripts/affected-crates.py
@@ -40,7 +40,7 @@ def _build_maps(meta: dict) -> tuple[str, dict[str, str], dict[str, set[str]]]:
         if pkg["id"] not in ws_member_ids:
             continue
         manifest = pkg["manifest_path"]
-        rel = manifest.replace(ws_root + "/", "").removesuffix("/Cargo.toml")
+        rel = manifest.removeprefix(ws_root + "/").removesuffix("/Cargo.toml")
         dir_to_pkg[rel] = pkg["name"]
 
     # Build reverse-dependency adjacency list (workspace packages only).


### PR DESCRIPTION
Adds a pre-commit hook that:
- detects changed Rust crates (with transitive reverse deps via scripts/affected-crates.py) and runs cargo fmt --check, clippy, and tests. 
- runs prettier/tsc/eslint on affected frontend packages.

Only runs tests/checks on changed code for the commit, to speed up checks -- don't want to check everything.

Should reduce the back-and-forth of contributors with the Github Actions checks...

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds developer tooling and documentation only; no runtime behavior changes, but the hook could slow or block local commits if mis-scoped or if required tools aren’t installed.
> 
> **Overview**
> Adds an opt-in `.githooks/pre-commit` hook that inspects staged files and runs **scoped quality checks**: Rust `cargo fmt --check` plus `clippy`/`test` limited to affected workspace crates (or `--workspace` when global Rust config files change), and frontend `prettier`/`tsc`/`eslint` limited to affected `pnpm` packages.
> 
> Introduces `scripts/affected-crates.py`, which uses `cargo metadata` to compute impacted crates (including reverse-dependents) from changed paths, and updates the README with setup instructions and tool prerequisites for enabling the hook.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac117d77cedba86410f7b6612e0a8895dcc16ac1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->