### PR TITLE
feat: make access token TTL configurable via ACCESS_TOKEN_TTL_SECONDS env var

### DIFF
--- a/crates/remote/src/app.rs
+++ b/crates/remote/src/app.rs
@@ -55,7 +55,10 @@ impl Server {
         }
 
         let auth_config = config.auth.clone();
-        let jwt = Arc::new(JwtService::new(auth_config.jwt_secret().clone()));
+        let jwt = Arc::new(JwtService::new(
+            auth_config.jwt_secret().clone(),
+            auth_config.access_token_ttl_seconds(),
+        ));
 
         let mut registry = ProviderRegistry::new();
 

--- a/crates/remote/src/auth/jwt.rs
+++ b/crates/remote/src/auth/jwt.rs
@@ -170,29 +170,6 @@ impl JwtService {
         })
     }
 
-    pub fn generate_access_token(
-        &self,
-        user_id: Uuid,
-        session_id: Uuid,
-    ) -> Result<String, JwtError> {
-        let now = Utc::now();
-        let access_exp = now + ChronoDuration::seconds(self.access_token_ttl_seconds as i64);
-        let claims = AccessTokenClaims {
-            sub: user_id,
-            session_id,
-            iat: now.timestamp(),
-            exp: access_exp.timestamp(),
-            aud: "access".to_string(),
-        };
-
-        let encoding_key = EncodingKey::from_base64_secret(self.secret.expose_secret())?;
-        Ok(encode(
-            &Header::new(Algorithm::HS256),
-            &claims,
-            &encoding_key,
-        )?)
-    }
-
     pub fn decode_access_token(&self, token: &str) -> Result<AccessTokenDetails, JwtError> {
         self.decode_access_token_with_leeway(token, DEFAULT_JWT_LEEWAY_SECONDS)
     }

--- a/crates/remote/src/auth/jwt.rs
+++ b/crates/remote/src/auth/jwt.rs
@@ -19,8 +19,8 @@ use uuid::Uuid;
 
 use crate::{auth::provider::ProviderTokenDetails, db::auth::AuthSession};
 
-pub(super) const ACCESS_TOKEN_TTL_SECONDS: i64 = 120;
-pub(super) const REFRESH_TOKEN_TTL_DAYS: i64 = 365;
+pub const DEFAULT_ACCESS_TOKEN_TTL_SECONDS: i64 = 120;
+pub const REFRESH_TOKEN_TTL_DAYS: i64 = 365;
 const DEFAULT_JWT_LEEWAY_SECONDS: u64 = 60;
 
 #[derive(Debug, Error)]
@@ -86,6 +86,7 @@ pub struct RefreshTokenDetails {
 #[derive(Clone)]
 pub struct JwtService {
     pub secret: Arc<SecretString>,
+    access_token_ttl_seconds: i64,
 }
 
 #[derive(Debug, Clone)]
@@ -96,9 +97,10 @@ pub struct Tokens {
 }
 
 impl JwtService {
-    pub fn new(secret: SecretString) -> Self {
+    pub fn new(secret: SecretString, access_token_ttl_seconds: i64) -> Self {
         Self {
             secret: Arc::new(secret),
+            access_token_ttl_seconds,
         }
     }
 
@@ -124,8 +126,8 @@ impl JwtService {
     ) -> Result<Tokens, JwtError> {
         let now = Utc::now();
 
-        // Access token, short-lived (~2 minutes)
-        let access_exp = now + ChronoDuration::seconds(ACCESS_TOKEN_TTL_SECONDS);
+        // Access token, short-lived
+        let access_exp = now + ChronoDuration::seconds(self.access_token_ttl_seconds);
         let access_claims = AccessTokenClaims {
             sub: user_id,
             session_id: session.id,
@@ -166,6 +168,29 @@ impl JwtService {
             refresh_token,
             refresh_token_id,
         })
+    }
+
+    pub fn generate_access_token(
+        &self,
+        user_id: Uuid,
+        session_id: Uuid,
+    ) -> Result<String, JwtError> {
+        let now = Utc::now();
+        let access_exp = now + ChronoDuration::seconds(self.access_token_ttl_seconds);
+        let claims = AccessTokenClaims {
+            sub: user_id,
+            session_id,
+            iat: now.timestamp(),
+            exp: access_exp.timestamp(),
+            aud: "access".to_string(),
+        };
+
+        let encoding_key = EncodingKey::from_base64_secret(self.secret.expose_secret())?;
+        Ok(encode(
+            &Header::new(Algorithm::HS256),
+            &claims,
+            &encoding_key,
+        )?)
     }
 
     pub fn decode_access_token(&self, token: &str) -> Result<AccessTokenDetails, JwtError> {

--- a/crates/remote/src/auth/jwt.rs
+++ b/crates/remote/src/auth/jwt.rs
@@ -19,7 +19,7 @@ use uuid::Uuid;
 
 use crate::{auth::provider::ProviderTokenDetails, db::auth::AuthSession};
 
-pub const DEFAULT_ACCESS_TOKEN_TTL_SECONDS: i64 = 120;
+pub const DEFAULT_ACCESS_TOKEN_TTL_SECONDS: u64 = 120;
 pub const REFRESH_TOKEN_TTL_DAYS: i64 = 365;
 const DEFAULT_JWT_LEEWAY_SECONDS: u64 = 60;
 
@@ -86,7 +86,7 @@ pub struct RefreshTokenDetails {
 #[derive(Clone)]
 pub struct JwtService {
     pub secret: Arc<SecretString>,
-    access_token_ttl_seconds: i64,
+    access_token_ttl_seconds: u64,
 }
 
 #[derive(Debug, Clone)]
@@ -97,7 +97,7 @@ pub struct Tokens {
 }
 
 impl JwtService {
-    pub fn new(secret: SecretString, access_token_ttl_seconds: i64) -> Self {
+    pub fn new(secret: SecretString, access_token_ttl_seconds: u64) -> Self {
         Self {
             secret: Arc::new(secret),
             access_token_ttl_seconds,
@@ -127,7 +127,7 @@ impl JwtService {
         let now = Utc::now();
 
         // Access token, short-lived
-        let access_exp = now + ChronoDuration::seconds(self.access_token_ttl_seconds);
+        let access_exp = now + ChronoDuration::seconds(self.access_token_ttl_seconds as i64);
         let access_claims = AccessTokenClaims {
             sub: user_id,
             session_id: session.id,
@@ -176,7 +176,7 @@ impl JwtService {
         session_id: Uuid,
     ) -> Result<String, JwtError> {
         let now = Utc::now();
-        let access_exp = now + ChronoDuration::seconds(self.access_token_ttl_seconds);
+        let access_exp = now + ChronoDuration::seconds(self.access_token_ttl_seconds as i64);
         let claims = AccessTokenClaims {
             sub: user_id,
             session_id,

--- a/crates/remote/src/auth/jwt.rs
+++ b/crates/remote/src/auth/jwt.rs
@@ -21,7 +21,7 @@ use crate::{auth::provider::ProviderTokenDetails, db::auth::AuthSession};
 
 pub const DEFAULT_ACCESS_TOKEN_TTL_SECONDS: u64 = 120;
 pub const REFRESH_TOKEN_TTL_DAYS: i64 = 365;
-const DEFAULT_JWT_LEEWAY_SECONDS: u64 = 60;
+pub(crate) const DEFAULT_JWT_LEEWAY_SECONDS: u64 = 60;
 
 #[derive(Debug, Error)]
 pub enum JwtError {

--- a/crates/remote/src/auth/mod.rs
+++ b/crates/remote/src/auth/mod.rs
@@ -11,5 +11,5 @@ pub(crate) use local::{LocalAuthError, auth_methods_response, is_local_provider,
 pub use middleware::RequestContext;
 pub(crate) use middleware::require_session;
 pub use oauth_token_validator::{OAuthTokenValidationError, OAuthTokenValidator};
-pub use provider::{ProviderRegistry, ProviderTokenDetails};
 pub(crate) use provider::{GitHubOAuthProvider, GoogleOAuthProvider};
+pub use provider::{ProviderRegistry, ProviderTokenDetails};

--- a/crates/remote/src/auth/mod.rs
+++ b/crates/remote/src/auth/mod.rs
@@ -1,5 +1,5 @@
 mod handoff;
-mod jwt;
+pub(crate) mod jwt;
 mod local;
 mod middleware;
 mod oauth_token_validator;
@@ -8,8 +8,8 @@ mod provider;
 pub use handoff::{CallbackResult, HandoffError, OAuthHandoffService};
 pub use jwt::{DEFAULT_ACCESS_TOKEN_TTL_SECONDS, JwtError, JwtService};
 pub(crate) use local::{LocalAuthError, auth_methods_response, is_local_provider, login};
-pub use middleware::{RequestContext, require_session};
+pub use middleware::RequestContext;
+pub(crate) use middleware::require_session;
 pub use oauth_token_validator::{OAuthTokenValidationError, OAuthTokenValidator};
-pub use provider::{
-    GitHubOAuthProvider, GoogleOAuthProvider, ProviderRegistry, ProviderTokenDetails,
-};
+pub use provider::{ProviderRegistry, ProviderTokenDetails};
+pub(crate) use provider::{GitHubOAuthProvider, GoogleOAuthProvider};

--- a/crates/remote/src/auth/mod.rs
+++ b/crates/remote/src/auth/mod.rs
@@ -5,11 +5,11 @@ mod middleware;
 mod oauth_token_validator;
 mod provider;
 
-pub(crate) use handoff::{CallbackResult, HandoffError, OAuthHandoffService};
-pub(crate) use jwt::{JwtError, JwtService};
+pub use handoff::{CallbackResult, HandoffError, OAuthHandoffService};
+pub use jwt::{DEFAULT_ACCESS_TOKEN_TTL_SECONDS, JwtError, JwtService};
 pub(crate) use local::{LocalAuthError, auth_methods_response, is_local_provider, login};
-pub(crate) use middleware::{RequestContext, require_session};
-pub(crate) use oauth_token_validator::{OAuthTokenValidationError, OAuthTokenValidator};
-pub(crate) use provider::{
+pub use middleware::{RequestContext, require_session};
+pub use oauth_token_validator::{OAuthTokenValidationError, OAuthTokenValidator};
+pub use provider::{
     GitHubOAuthProvider, GoogleOAuthProvider, ProviderRegistry, ProviderTokenDetails,
 };

--- a/crates/remote/src/config.rs
+++ b/crates/remote/src/config.rs
@@ -388,9 +388,9 @@ impl AuthConfig {
                 Ok(0) => {
                     tracing::warn!(
                         "ACCESS_TOKEN_TTL_SECONDS=0 is invalid, using default ({}s)",
-                        crate::auth::jwt::DEFAULT_ACCESS_TOKEN_TTL_SECONDS
+                        crate::auth::DEFAULT_ACCESS_TOKEN_TTL_SECONDS
                     );
-                    crate::auth::jwt::DEFAULT_ACCESS_TOKEN_TTL_SECONDS
+                    crate::auth::DEFAULT_ACCESS_TOKEN_TTL_SECONDS
                 }
                 Ok(val) => {
                     if val <= crate::auth::jwt::DEFAULT_JWT_LEEWAY_SECONDS {
@@ -407,12 +407,12 @@ impl AuthConfig {
                     tracing::warn!(
                         "ACCESS_TOKEN_TTL_SECONDS={:?} is not a valid u64, using default ({}s)",
                         v,
-                        crate::auth::jwt::DEFAULT_ACCESS_TOKEN_TTL_SECONDS
+                        crate::auth::DEFAULT_ACCESS_TOKEN_TTL_SECONDS
                     );
-                    crate::auth::jwt::DEFAULT_ACCESS_TOKEN_TTL_SECONDS
+                    crate::auth::DEFAULT_ACCESS_TOKEN_TTL_SECONDS
                 }
             },
-            Err(_) => crate::auth::jwt::DEFAULT_ACCESS_TOKEN_TTL_SECONDS,
+            Err(_) => crate::auth::DEFAULT_ACCESS_TOKEN_TTL_SECONDS,
         };
 
         let github = match env::var("GITHUB_OAUTH_CLIENT_ID") {

--- a/crates/remote/src/config.rs
+++ b/crates/remote/src/config.rs
@@ -392,7 +392,17 @@ impl AuthConfig {
                     );
                     crate::auth::jwt::DEFAULT_ACCESS_TOKEN_TTL_SECONDS
                 }
-                Ok(val) => val,
+                Ok(val) => {
+                    if val <= crate::auth::jwt::DEFAULT_JWT_LEEWAY_SECONDS {
+                        tracing::warn!(
+                            "ACCESS_TOKEN_TTL_SECONDS ({val}s) is at or below the JWT validation leeway ({}s). \
+                             Tokens will remain valid for approximately {}s total.",
+                            crate::auth::jwt::DEFAULT_JWT_LEEWAY_SECONDS,
+                            val + crate::auth::jwt::DEFAULT_JWT_LEEWAY_SECONDS,
+                        );
+                    }
+                    val
+                }
                 Err(_) => {
                     tracing::warn!(
                         "ACCESS_TOKEN_TTL_SECONDS={:?} is not a valid u64, using default ({}s)",

--- a/crates/remote/src/config.rs
+++ b/crates/remote/src/config.rs
@@ -373,7 +373,7 @@ pub struct AuthConfig {
     local: Option<LocalAuthConfig>,
     jwt_secret: SecretString,
     public_base_url: String,
-    access_token_ttl_seconds: i64,
+    access_token_ttl_seconds: u64,
 }
 
 impl AuthConfig {
@@ -383,10 +383,27 @@ impl AuthConfig {
         validate_jwt_secret(&jwt_secret)?;
         let jwt_secret = SecretString::new(jwt_secret.into());
 
-        let access_token_ttl_seconds = env::var("ACCESS_TOKEN_TTL_SECONDS")
-            .ok()
-            .and_then(|v| v.parse::<i64>().ok())
-            .unwrap_or(crate::auth::jwt::DEFAULT_ACCESS_TOKEN_TTL_SECONDS);
+        let access_token_ttl_seconds = match env::var("ACCESS_TOKEN_TTL_SECONDS") {
+            Ok(v) => match v.parse::<u64>() {
+                Ok(0) => {
+                    tracing::warn!(
+                        "ACCESS_TOKEN_TTL_SECONDS=0 is invalid, using default ({}s)",
+                        crate::auth::jwt::DEFAULT_ACCESS_TOKEN_TTL_SECONDS
+                    );
+                    crate::auth::jwt::DEFAULT_ACCESS_TOKEN_TTL_SECONDS
+                }
+                Ok(val) => val,
+                Err(_) => {
+                    tracing::warn!(
+                        "ACCESS_TOKEN_TTL_SECONDS={:?} is not a valid u64, using default ({}s)",
+                        v,
+                        crate::auth::jwt::DEFAULT_ACCESS_TOKEN_TTL_SECONDS
+                    );
+                    crate::auth::jwt::DEFAULT_ACCESS_TOKEN_TTL_SECONDS
+                }
+            },
+            Err(_) => crate::auth::jwt::DEFAULT_ACCESS_TOKEN_TTL_SECONDS,
+        };
 
         let github = match env::var("GITHUB_OAUTH_CLIENT_ID") {
             Ok(client_id) if !client_id.is_empty() => {
@@ -451,7 +468,7 @@ impl AuthConfig {
         &self.public_base_url
     }
 
-    pub fn access_token_ttl_seconds(&self) -> i64 {
+    pub fn access_token_ttl_seconds(&self) -> u64 {
         self.access_token_ttl_seconds
     }
 }

--- a/crates/remote/src/config.rs
+++ b/crates/remote/src/config.rs
@@ -373,6 +373,7 @@ pub struct AuthConfig {
     local: Option<LocalAuthConfig>,
     jwt_secret: SecretString,
     public_base_url: String,
+    access_token_ttl_seconds: i64,
 }
 
 impl AuthConfig {
@@ -381,6 +382,11 @@ impl AuthConfig {
             .map_err(|_| ConfigError::MissingVar("VIBEKANBAN_REMOTE_JWT_SECRET"))?;
         validate_jwt_secret(&jwt_secret)?;
         let jwt_secret = SecretString::new(jwt_secret.into());
+
+        let access_token_ttl_seconds = env::var("ACCESS_TOKEN_TTL_SECONDS")
+            .ok()
+            .and_then(|v| v.parse::<i64>().ok())
+            .unwrap_or(crate::auth::jwt::DEFAULT_ACCESS_TOKEN_TTL_SECONDS);
 
         let github = match env::var("GITHUB_OAUTH_CLIENT_ID") {
             Ok(client_id) if !client_id.is_empty() => {
@@ -421,6 +427,7 @@ impl AuthConfig {
             local,
             jwt_secret,
             public_base_url,
+            access_token_ttl_seconds,
         })
     }
 
@@ -442,6 +449,10 @@ impl AuthConfig {
 
     pub fn public_base_url(&self) -> &str {
         &self.public_base_url
+    }
+
+    pub fn access_token_ttl_seconds(&self) -> i64 {
+        self.access_token_ttl_seconds
     }
 }
 


### PR DESCRIPTION
Makes the access token TTL configurable via the ACCESS_TOKEN_TTL_SECONDS environment variable instead of being hardcoded.

When configured, this should reduce the frequency of re-authentication with the remote.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches JWT issuance and configuration parsing; misconfiguration could weaken session security (overlong TTL) or cause unexpected auth behavior, though defaults and warnings reduce risk.
> 
> **Overview**
> Makes access token expiry configurable via `ACCESS_TOKEN_TTL_SECONDS` instead of a hardcoded value.
> 
> `AuthConfig` now reads/validates this env var (falling back to `DEFAULT_ACCESS_TOKEN_TTL_SECONDS` with warnings for `0`, invalid values, or values at/below JWT leeway), passes it into `JwtService::new`, and `JwtService` uses the configured TTL when generating access tokens; related JWT constants/modules were re-exported to support this.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d67228b7224c1825f36a07d8431620bdd8acc8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->