### PR TITLE
feat: make Loops email template IDs configurable via env vars

### DIFF
--- a/crates/remote/README.md
+++ b/crates/remote/README.md
@@ -28,6 +28,12 @@ VITE_PUBLIC_REACT_VIRTUOSO_LICENSE_KEY=
 
 # Optional — leave empty to disable invitation emails
 LOOPS_EMAIL_API_KEY=
+
+# Loops transactional email template IDs (optional — defaults are the upstream templates).
+# Override these with your own Loops account template IDs if using a custom Loops account.
+LOOPS_INVITE_TEMPLATE_ID=cmhvy2wgs3s13z70i1pxakij9
+LOOPS_REVIEW_READY_TEMPLATE_ID=cmj47k5ge16990iylued9by17
+LOOPS_REVIEW_FAILED_TEMPLATE_ID=cmj49ougk1c8s0iznavijdqpo
 ```
 
 Generate `VIBEKANBAN_REMOTE_JWT_SECRET` once using `openssl rand -base64 48` and copy the value into `.env.remote`.

--- a/crates/remote/docker-compose.yml
+++ b/crates/remote/docker-compose.yml
@@ -100,6 +100,10 @@ services:
       VIBEKANBAN_REMOTE_JWT_SECRET: ${VIBEKANBAN_REMOTE_JWT_SECRET:?set in .env.remote}
       # Optional — leave empty to disable invitation emails
       LOOPS_EMAIL_API_KEY: ${LOOPS_EMAIL_API_KEY:-}
+      # Loops transactional email template IDs (override with your own Loops account templates)
+      LOOPS_INVITE_TEMPLATE_ID: ${LOOPS_INVITE_TEMPLATE_ID:-cmhvy2wgs3s13z70i1pxakij9}
+      LOOPS_REVIEW_READY_TEMPLATE_ID: ${LOOPS_REVIEW_READY_TEMPLATE_ID:-cmj47k5ge16990iylued9by17}
+      LOOPS_REVIEW_FAILED_TEMPLATE_ID: ${LOOPS_REVIEW_FAILED_TEMPLATE_ID:-cmj49ougk1c8s0iznavijdqpo}
       DIGEST_ENABLED: ${DIGEST_ENABLED:-false}
       SERVER_PUBLIC_BASE_URL: ${PUBLIC_BASE_URL:-http://localhost:3000}
       ELECTRIC_ROLE_PASSWORD: ${ELECTRIC_ROLE_PASSWORD:-remote}

--- a/crates/remote/src/mail.rs
+++ b/crates/remote/src/mail.rs
@@ -6,9 +6,16 @@ use serde_json::json;
 
 use crate::digest::DigestError;
 
-const LOOPS_INVITE_TEMPLATE_ID: &str = "cmhvy2wgs3s13z70i1pxakij9";
-const LOOPS_REVIEW_READY_TEMPLATE_ID: &str = "cmj47k5ge16990iylued9by17";
-const LOOPS_REVIEW_FAILED_TEMPLATE_ID: &str = "cmj49ougk1c8s0iznavijdqpo";
+const DEFAULT_INVITE_TEMPLATE_ID: &str = "cmhvy2wgs3s13z70i1pxakij9";
+const DEFAULT_REVIEW_READY_TEMPLATE_ID: &str = "cmj47k5ge16990iylued9by17";
+const DEFAULT_REVIEW_FAILED_TEMPLATE_ID: &str = "cmj49ougk1c8s0iznavijdqpo";
+
+fn env_or(var: &str, default: &str) -> String {
+    std::env::var(var)
+        .ok()
+        .filter(|v| !v.is_empty())
+        .unwrap_or_else(|| default.to_owned())
+}
 
 pub const DIGEST_PREVIEW_COUNT: usize = 5;
 
@@ -107,6 +114,9 @@ impl Mailer for NoopMailer {
 pub struct LoopsMailer {
     client: reqwest::Client,
     api_key: String,
+    invite_template_id: String,
+    review_ready_template_id: String,
+    review_failed_template_id: String,
 }
 
 impl LoopsMailer {
@@ -116,7 +126,20 @@ impl LoopsMailer {
             .build()
             .expect("failed to build reqwest client");
 
-        Self { client, api_key }
+        let invite_template_id =
+            env_or("LOOPS_INVITE_TEMPLATE_ID", DEFAULT_INVITE_TEMPLATE_ID);
+        let review_ready_template_id =
+            env_or("LOOPS_REVIEW_READY_TEMPLATE_ID", DEFAULT_REVIEW_READY_TEMPLATE_ID);
+        let review_failed_template_id =
+            env_or("LOOPS_REVIEW_FAILED_TEMPLATE_ID", DEFAULT_REVIEW_FAILED_TEMPLATE_ID);
+
+        Self {
+            client,
+            api_key,
+            invite_template_id,
+            review_ready_template_id,
+            review_failed_template_id,
+        }
     }
 }
 
@@ -147,7 +170,7 @@ impl Mailer for LoopsMailer {
         }
 
         let payload = json!({
-            "transactionalId": LOOPS_INVITE_TEMPLATE_ID,
+            "transactionalId": self.invite_template_id,
             "email": email,
             "dataVariables": {
                 "org_name": org_name,
@@ -189,7 +212,7 @@ impl Mailer for LoopsMailer {
         }
 
         let payload = json!({
-            "transactionalId": LOOPS_REVIEW_READY_TEMPLATE_ID,
+            "transactionalId": self.review_ready_template_id,
             "email": email,
             "dataVariables": {
                 "review_url": review_url,
@@ -230,7 +253,7 @@ impl Mailer for LoopsMailer {
         }
 
         let payload = json!({
-            "transactionalId": LOOPS_REVIEW_FAILED_TEMPLATE_ID,
+            "transactionalId": self.review_failed_template_id,
             "email": email,
             "dataVariables": {
                 "pr_name": pr_name,

--- a/docs/self-hosting/deploy-docker.mdx
+++ b/docs/self-hosting/deploy-docker.mdx
@@ -78,6 +78,12 @@ GOOGLE_OAUTH_CLIENT_SECRET=
 
 # Email (optional — leave empty to disable invitation emails)
 LOOPS_EMAIL_API_KEY=
+
+# Loops transactional email template IDs (optional — defaults are the upstream templates).
+# Override these with your own Loops account template IDs if using a custom Loops account.
+LOOPS_INVITE_TEMPLATE_ID=cmhvy2wgs3s13z70i1pxakij9
+LOOPS_REVIEW_READY_TEMPLATE_ID=cmj47k5ge16990iylued9by17
+LOOPS_REVIEW_FAILED_TEMPLATE_ID=cmj49ougk1c8s0iznavijdqpo
 ```
 
 ## Step 4: Create Production Docker Compose
@@ -162,6 +168,9 @@ services:
       VIBEKANBAN_REMOTE_JWT_SECRET: ${VIBEKANBAN_REMOTE_JWT_SECRET}
       ELECTRIC_ROLE_PASSWORD: ${ELECTRIC_ROLE_PASSWORD}
       LOOPS_EMAIL_API_KEY: ${LOOPS_EMAIL_API_KEY:-}
+      LOOPS_INVITE_TEMPLATE_ID: ${LOOPS_INVITE_TEMPLATE_ID:-cmhvy2wgs3s13z70i1pxakij9}
+      LOOPS_REVIEW_READY_TEMPLATE_ID: ${LOOPS_REVIEW_READY_TEMPLATE_ID:-cmj47k5ge16990iylued9by17}
+      LOOPS_REVIEW_FAILED_TEMPLATE_ID: ${LOOPS_REVIEW_FAILED_TEMPLATE_ID:-cmj49ougk1c8s0iznavijdqpo}
     healthcheck:
       test: ["CMD", "wget", "--spider", "-q", "http://127.0.0.1:8081/v1/health"]
       interval: 5s

--- a/docs/self-hosting/local-development.mdx
+++ b/docs/self-hosting/local-development.mdx
@@ -85,6 +85,12 @@ VITE_RELAY_API_BASE_URL=http://localhost:8082
 
 # Email invitations (optional — leave empty to disable)
 LOOPS_EMAIL_API_KEY=
+
+# Loops transactional email template IDs (optional — defaults are the upstream templates).
+# Override these with your own Loops account template IDs if using a custom Loops account.
+LOOPS_INVITE_TEMPLATE_ID=cmhvy2wgs3s13z70i1pxakij9
+LOOPS_REVIEW_READY_TEMPLATE_ID=cmj47k5ge16990iylued9by17
+LOOPS_REVIEW_FAILED_TEMPLATE_ID=cmj49ougk1c8s0iznavijdqpo
 ```
 
 For production or self-hosting on a server, add `PUBLIC_BASE_URL` (your public URL, e.g. `https://kanban.example.com`) and `REMOTE_SERVER_PORTS=0.0.0.0:3000:8081` so the server is reachable from other hosts. Defaults keep local dev unchanged.


### PR DESCRIPTION
The invite, review-ready, and review-failed transactional template IDs were hardcoded to the upstream Loops account. Self-hosters using their own Loops account had no way to override them without patching source.

Now read from LOOPS_INVITE_TEMPLATE_ID, LOOPS_REVIEW_READY_TEMPLATE_ID, and LOOPS_REVIEW_FAILED_TEMPLATE_ID env vars at startup, falling back to the original upstream defaults when unset.

Updated docker-compose, deploy docs, local-dev docs, and README.

Made-with: Cursor