### PR TITLE
fix(ws): reconnect after mobile tab suspension in useJsonPatchWsStream

### DIFF
--- a/packages/web-core/src/shared/hooks/useJsonPatchWsStream.ts
+++ b/packages/web-core/src/shared/hooks/useJsonPatchWsStream.ts
@@ -170,20 +170,21 @@ export const useJsonPatchWsStream = <T extends object>(
             // that was already received.
           };
 
-          ws.onclose = (evt) => {
+          ws.onclose = () => {
             setIsConnected(false);
             wsRef.current = null;
 
-            // Do not reconnect if we received a finished message or clean close
-            if (
-              cancelled ||
-              finishedRef.current ||
-              (evt?.code === 1000 && evt?.wasClean)
-            ) {
+            // Do not reconnect if we explicitly cancelled or the server sent a
+            // finished message.  Note: we intentionally do NOT skip reconnect
+            // for clean code-1000 closes here — mobile browsers close WebSocket
+            // connections with code 1000 / wasClean=true when a tab is
+            // backgrounded/suspended, which is NOT a permanent end of stream.
+            // finishedRef already covers the legitimate "stream ended" case.
+            if (cancelled || finishedRef.current) {
               return;
             }
 
-            // Otherwise, reconnect on unexpected/error closures
+            // Reconnect on any unexpected closure (including mobile tab suspension).
             retryAttemptsRef.current += 1;
             // Only show error if we haven't received any data yet
             if (!dataRef.current && retryAttemptsRef.current > 6) {
@@ -237,6 +238,34 @@ export const useJsonPatchWsStream = <T extends object>(
     deduplicatePatches,
     retryNonce,
   ]);
+
+  // Reconnect when the page becomes visible again.  Mobile browsers kill
+  // WebSocket connections when a tab is suspended; the onclose retry timer
+  // is also throttled/frozen in the background, so we need an explicit
+  // visibilitychange trigger to recover promptly when the user returns.
+  useEffect(() => {
+    if (!enabled || !endpoint) return;
+
+    const handleVisibilityChange = () => {
+      if (
+        document.visibilityState === 'visible' &&
+        !finishedRef.current &&
+        !wsRef.current
+      ) {
+        // Cancel any pending backoff timer and reconnect immediately.
+        if (retryTimerRef.current) {
+          window.clearTimeout(retryTimerRef.current);
+          retryTimerRef.current = null;
+        }
+        retryAttemptsRef.current = 0;
+        setRetryNonce((n) => n + 1);
+      }
+    };
+
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    return () =>
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+  }, [enabled, endpoint]);
 
   const isInitializedForCurrentEndpoint =
     isInitialized && initializedForEndpointRef.current === endpoint;


### PR DESCRIPTION
Fixes #3227

## Summary

- Remove the erroneous `(evt?.code === 1000 && evt?.wasClean)` reconnect guard from `useJsonPatchWsStream` — mobile browsers close WebSocket connections with code 1000/wasClean=true when backgrounding a tab, which is not a permanent end-of-stream
- Add a `visibilitychange` listener to reconnect immediately when the user returns to the tab (mobile browsers also throttle/freeze `setTimeout` in the background, so the backoff timer alone is insufficient)

## Test plan

- [ ] On a mobile browser (iOS Safari / Android Chrome), open a workspace session and start an agent turn
- [ ] Switch to another app/tab while the agent is running, wait for it to finish, return → session should show completed state (not stuck "running")
- [ ] Open a workspace session, switch away briefly, return, send a follow-up message → message should remain visible and agent should respond (not disappear)
- [ ] On desktop: verify normal WebSocket streams still work (no regressions to reconnect behavior on non-mobile)
- [ ] Verify that a legitimately finished stream (server sends `{finished:true}`) still does not attempt to reconnect after completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes WebSocket reconnection behavior for all consumers of `useJsonPatchWsStream`, which could cause extra reconnect attempts or subtle lifecycle issues if the visibility/close logic misfires.
> 
> **Overview**
> Improves resiliency of `useJsonPatchWsStream` on mobile by **reconnecting after tab suspension/backgrounding**.
> 
> Removes the guard that skipped reconnects on clean `1000` WebSocket closes, and adds a `visibilitychange` listener that cancels any pending backoff and forces an immediate reconnect when the page becomes visible again (unless the stream is marked `finished`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ca5c00adb7bdc6a5f324057b055c2a64d590679. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->