### PR TITLE
fix(opencode): remove timeout for slash commands

### DIFF
--- a/crates/executors/src/executors/opencode/sdk.rs
+++ b/crates/executors/src/executors/opencode/sdk.rs
@@ -416,8 +416,8 @@ fn build_opencode_client(
     directory: &str,
     password: &str,
 ) -> Result<reqwest::Client, ExecutorError> {
-    const OPENCODE_HTTP_TIMEOUT: Duration = Duration::from_secs(30);
-    const OPENCODE_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+    const OPENCODE_HTTP_TIMEOUT: Duration = Duration::from_secs(180);
+    const OPENCODE_CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
 
     reqwest::Client::builder()
         .default_headers(build_default_headers(directory, password))
@@ -427,7 +427,7 @@ fn build_opencode_client(
         .map_err(|err| ExecutorError::Io(io::Error::other(err)))
 }
 
-const OPENCODE_PROMPT_TIMEOUT: Duration = Duration::from_secs(60 * 30);
+const OPENCODE_PROMPT_TIMEOUT: Duration = Duration::from_hours(24 * 7);
 
 fn append_session_error(session_error: &mut Option<String>, message: String) {
     match session_error {
@@ -713,6 +713,7 @@ pub async fn session_command(
     let resp = client
         .post(format!("{base_url}/session/{session_id}/command"))
         .query(&[("directory", directory)])
+        .timeout(OPENCODE_PROMPT_TIMEOUT)
         .json(&req)
         .send()
         .await
@@ -784,6 +785,7 @@ pub async fn session_summarize(
     let resp = client
         .post(format!("{base_url}/session/{session_id}/summarize"))
         .query(&[("directory", directory)])
+        .timeout(OPENCODE_PROMPT_TIMEOUT)
         .json(&req)
         .send()
         .await


### PR DESCRIPTION
Slash commands are long-running tasks such as `/start-work`, which implements an approved plan.

Fixes #3016
Fixes #3170

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Increases HTTP and per-request timeouts (up to 7 days) for OpenCode command/summarize calls, which could leave hung requests consuming resources longer than before if the server never responds.
> 
> **Overview**
> **Improves support for long-running OpenCode slash commands** by substantially increasing client timeouts.
> 
> The OpenCode `reqwest` client now uses longer connect/request limits (connect: 5s→30s, request: 30s→180s), and `session_command`/`session_summarize` requests apply a new `OPENCODE_PROMPT_TIMEOUT` of **7 days** to avoid timing out lengthy operations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c9d8bdc090629224fd59ae716532290fbfc0d485. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->