### PR TITLE
Fix crash screen i18n: add proper translations for all locales (Vibe Kanban)

### DIFF
--- a/packages/web-core/src/i18n/locales/es/common.json
+++ b/packages/web-core/src/i18n/locales/es/common.json
@@ -510,11 +510,11 @@
     "model": "Modelo"
   },
   "crashScreen": {
-    "title": "Something went wrong",
-    "description": "The application encountered an unexpected error.",
-    "reload": "Reload",
-    "showDetails": "Show details",
-    "hideDetails": "Hide details"
+    "title": "Algo salió mal",
+    "description": "La aplicación encontró un error inesperado.",
+    "reload": "Recargar",
+    "showDetails": "Mostrar detalles",
+    "hideDetails": "Ocultar detalles"
   },
   "syncError": {
     "networkErrors": "Errores de red",

--- a/packages/web-core/src/i18n/locales/fr/common.json
+++ b/packages/web-core/src/i18n/locales/fr/common.json
@@ -510,11 +510,11 @@
     "model": "Modèle"
   },
   "crashScreen": {
-    "title": "Something went wrong",
-    "description": "The application encountered an unexpected error.",
-    "reload": "Reload",
-    "showDetails": "Show details",
-    "hideDetails": "Hide details"
+    "title": "Une erreur est survenue",
+    "description": "L'application a rencontré une erreur inattendue.",
+    "reload": "Recharger",
+    "showDetails": "Afficher les détails",
+    "hideDetails": "Masquer les détails"
   },
   "syncError": {
     "networkErrors": "Erreurs réseau",

--- a/packages/web-core/src/i18n/locales/ja/common.json
+++ b/packages/web-core/src/i18n/locales/ja/common.json
@@ -510,11 +510,11 @@
     "model": "モデル"
   },
   "crashScreen": {
-    "title": "Something went wrong",
-    "description": "The application encountered an unexpected error.",
-    "reload": "Reload",
-    "showDetails": "Show details",
-    "hideDetails": "Hide details"
+    "title": "問題が発生しました",
+    "description": "アプリケーションで予期しないエラーが発生しました。",
+    "reload": "再読み込み",
+    "showDetails": "詳細を表示",
+    "hideDetails": "詳細を非表示"
   },
   "syncError": {
     "networkErrors": "ネットワークエラー",

--- a/packages/web-core/src/i18n/locales/ko/common.json
+++ b/packages/web-core/src/i18n/locales/ko/common.json
@@ -510,11 +510,11 @@
     "model": "모델"
   },
   "crashScreen": {
-    "title": "Something went wrong",
-    "description": "The application encountered an unexpected error.",
-    "reload": "Reload",
-    "showDetails": "Show details",
-    "hideDetails": "Hide details"
+    "title": "문제가 발생했습니다",
+    "description": "애플리케이션에서 예기치 않은 오류가 발생했습니다.",
+    "reload": "새로고침",
+    "showDetails": "세부정보 표시",
+    "hideDetails": "세부정보 숨기기"
   },
   "syncError": {
     "networkErrors": "네트워크 오류",

--- a/packages/web-core/src/i18n/locales/zh-Hans/common.json
+++ b/packages/web-core/src/i18n/locales/zh-Hans/common.json
@@ -510,11 +510,11 @@
     "model": "模型"
   },
   "crashScreen": {
-    "title": "Something went wrong",
-    "description": "The application encountered an unexpected error.",
-    "reload": "Reload",
-    "showDetails": "Show details",
-    "hideDetails": "Hide details"
+    "title": "出了点问题",
+    "description": "应用程序遇到了意外错误。",
+    "reload": "重新加载",
+    "showDetails": "显示详情",
+    "hideDetails": "隐藏详情"
   },
   "syncError": {
     "networkErrors": "网络错误",

--- a/packages/web-core/src/i18n/locales/zh-Hant/common.json
+++ b/packages/web-core/src/i18n/locales/zh-Hant/common.json
@@ -510,11 +510,11 @@
     "model": "模型"
   },
   "crashScreen": {
-    "title": "Something went wrong",
-    "description": "The application encountered an unexpected error.",
-    "reload": "Reload",
-    "showDetails": "Show details",
-    "hideDetails": "Hide details"
+    "title": "發生了錯誤",
+    "description": "應用程式遇到了意外錯誤。",
+    "reload": "重新載入",
+    "showDetails": "顯示詳情",
+    "hideDetails": "隱藏詳情"
   },
   "syncError": {
     "networkErrors": "網路錯誤",


### PR DESCRIPTION
## Summary

- Replace English placeholder values in crash screen i18n keys with proper translations for all 6 non-English locales (es, fr, ja, ko, zh-Hans, zh-Hant)
- Fixes issue introduced in #3235 where `crashScreen.*` keys were added with English text as placeholders

## Changes

| Locale | Title | Reload |
|--------|-------|--------|
| es | Algo salió mal | Recargar |
| fr | Une erreur est survenue | Recharger |
| ja | 問題が発生しました | 再読み込み |
| ko | 문제가 발생했습니다 | 새로고침 |
| zh-Hans | 出了点问题 | 重新加载 |
| zh-Hant | 發生了錯誤 | 重新載入 |

## Test plan

- [ ] Verify `pnpm run check` and i18n checks pass
- [ ] Switch app language to each locale and trigger a crash to verify translated strings appear

This PR was written using [Vibe Kanban](https://vibekanban.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates localized string values in JSON translation files with no logic or schema changes; main risk is accidental wording/consistency issues.
> 
> **Overview**
> Fixes `crashScreen.*` i18n entries by replacing the English placeholder text with proper translations across six locales (`es`, `fr`, `ja`, `ko`, `zh-Hans`, `zh-Hant`). This ensures the crash screen UI shows localized title/description and action labels (reload/show/hide details) when the app language is not English.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 96ff1b04fca1ae8ff4a69ff408ea3a9afa571185. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->