### PR TITLE
Rework WYSIWYG read-only mode: replace Lexical with react-markdown + remark-gfm (Vibe Kanban)

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -45,7 +45,10 @@
     "react-dom": "^18.2.0",
     "react-hotkeys-hook": "^5.1.0",
     "react-i18next": "^15.7.4",
+    "react-markdown": "^10.1.0",
     "react-virtuoso": "^4.14.0",
+    "rehype-highlight": "^7.0.2",
+    "remark-gfm": "^4.0.1",
     "tailwind-merge": "^3.3.1"
   },
   "devDependencies": {

--- a/packages/ui/src/components/wysiwyg/AttachmentRenderer.tsx
+++ b/packages/ui/src/components/wysiwyg/AttachmentRenderer.tsx
@@ -1,0 +1,252 @@
+import { useCallback, useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
+import { Download, File, HelpCircle } from 'lucide-react';
+import {
+  useWorkspaceId,
+  useSessionId,
+  useLocalAttachments,
+  type LocalAttachmentMetadata,
+} from '../WorkspaceContext';
+
+const ATTACHMENT_URL_STALE_TIME = 4 * 60 * 1000;
+
+type AttachmentType = 'file' | 'thumbnail';
+
+interface AttachmentMetadataLike {
+  exists: boolean;
+  file_name?: string | null;
+  size_bytes?: bigint | null;
+  format?: string | null;
+  proxy_url?: string | null;
+}
+
+export interface AttachmentRendererProps {
+  src: string;
+  label: string;
+  fetchAttachmentUrl: (
+    attachmentId: string,
+    type: AttachmentType
+  ) => Promise<string>;
+}
+
+function truncatePath(path: string, maxLength = 24): string {
+  const filename = path.split('/').pop() || path;
+  if (filename.length <= maxLength) return filename;
+  return filename.slice(0, maxLength - 3) + '...';
+}
+
+function formatFileSize(bytes: bigint | number | null | undefined): string {
+  if (!bytes) return '';
+  const num = Number(bytes);
+  if (num < 1024) return `${num} B`;
+  if (num < 1024 * 1024) return `${(num / 1024).toFixed(1)} KB`;
+  return `${(num / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function inferFormat(
+  label: string,
+  explicitFormat?: string | null
+): string | null {
+  if (explicitFormat) {
+    return explicitFormat.toUpperCase();
+  }
+
+  const extension = label.split('.').pop()?.trim();
+  if (!extension || extension === label) {
+    return null;
+  }
+
+  return extension.toUpperCase();
+}
+
+function toMetadataFromLocalAttachment(
+  localAttachment: LocalAttachmentMetadata | undefined
+): AttachmentMetadataLike | null {
+  if (!localAttachment) return null;
+
+  return {
+    exists: true,
+    file_name: localAttachment.file_name,
+    size_bytes: BigInt(localAttachment.size_bytes),
+    format: localAttachment.format,
+    proxy_url: localAttachment.proxy_url,
+  };
+}
+
+function useAttachmentMetadata(
+  workspaceId: string | undefined,
+  sessionId: string | undefined,
+  src: string,
+  localAttachments: LocalAttachmentMetadata[]
+) {
+  const isWorkspaceAttachment = src.startsWith('.vibe-attachments/');
+
+  const localAttachment = useMemo(
+    () => localAttachments.find((attachment) => attachment.path === src),
+    [localAttachments, src]
+  );
+
+  const localAttachmentMetadata = useMemo(
+    () => toMetadataFromLocalAttachment(localAttachment),
+    [localAttachment]
+  );
+
+  const shouldFetch =
+    isWorkspaceAttachment && !!workspaceId && !localAttachment;
+
+  const query = useQuery({
+    queryKey: ['attachment-metadata', workspaceId, sessionId, src],
+    queryFn: async (): Promise<AttachmentMetadataLike | null> => {
+      if (!workspaceId || !sessionId) return null;
+
+      const response = await fetch(
+        `/api/workspaces/${workspaceId}/attachments/metadata?path=${encodeURIComponent(src)}&session_id=${sessionId}`
+      );
+      const payload = await response.json();
+      return payload.data as AttachmentMetadataLike | null;
+    },
+    enabled: shouldFetch && !!sessionId,
+    staleTime: Infinity,
+  });
+
+  return {
+    data: localAttachmentMetadata ?? query.data,
+  };
+}
+
+function useAttachmentFileUrl(
+  attachmentId: string | null,
+  fetchAttachmentUrl: AttachmentRendererProps['fetchAttachmentUrl']
+) {
+  const query = useQuery({
+    queryKey: ['attachment-url', attachmentId, 'file'],
+    queryFn: () => fetchAttachmentUrl(attachmentId as string, 'file'),
+    enabled: !!attachmentId,
+    staleTime: ATTACHMENT_URL_STALE_TIME,
+  });
+
+  return {
+    url: query.data ?? null,
+  };
+}
+
+/**
+ * Standalone attachment renderer for use in react-markdown read-only mode.
+ * Handles attachment://, pending-attachment://, and .vibe-attachments/ URLs.
+ */
+export function AttachmentRenderer({
+  src,
+  label,
+  fetchAttachmentUrl,
+}: AttachmentRendererProps): JSX.Element {
+  const { t } = useTranslation('common');
+  const workspaceId = useWorkspaceId();
+  const sessionId = useSessionId();
+  const localAttachments = useLocalAttachments();
+
+  const isWorkspaceAttachment = src.startsWith('.vibe-attachments/');
+  const isPendingAttachment = src.startsWith('pending-attachment://');
+  const isAttachment = isPendingAttachment || src.startsWith('attachment://');
+  const attachmentId =
+    !isPendingAttachment && isAttachment
+      ? src.replace('attachment://', '')
+      : null;
+
+  const { url: attachmentUrl } = useAttachmentFileUrl(
+    isAttachment && !isPendingAttachment ? attachmentId : null,
+    fetchAttachmentUrl
+  );
+
+  const { data: metadata } = useAttachmentMetadata(
+    workspaceId,
+    sessionId,
+    src,
+    localAttachments
+  );
+
+  const resolvedUrl =
+    metadata?.proxy_url ?? (isAttachment ? attachmentUrl : null);
+  const displayName = truncatePath(
+    metadata?.file_name || label || src || t('kanban.previewFile')
+  );
+  const format = inferFormat(
+    label || metadata?.file_name || src,
+    metadata?.format
+  );
+  const sizeText = formatFileSize(metadata?.size_bytes);
+  const localAttachment = localAttachments.find(
+    (attachment) => attachment.path === src
+  );
+  const metadataLine = localAttachment?.is_pending
+    ? ['Uploading', sizeText].filter(Boolean).join(' · ')
+    : metadata?.exists
+      ? format && sizeText
+        ? `${format} · ${sizeText}`
+        : format || sizeText || null
+      : null;
+
+  const openUrl = useCallback(
+    async (event: React.MouseEvent) => {
+      event.preventDefault();
+      event.stopPropagation();
+
+      let nextUrl = resolvedUrl;
+      if (!nextUrl && attachmentId) {
+        nextUrl = await fetchAttachmentUrl(attachmentId, 'file');
+      }
+
+      if (!nextUrl) return;
+      window.open(nextUrl, '_blank', 'noopener,noreferrer');
+    },
+    [attachmentId, resolvedUrl, fetchAttachmentUrl]
+  );
+
+  const icon =
+    isWorkspaceAttachment || isAttachment ? (
+      <File className="w-5 h-5 text-muted-foreground" />
+    ) : (
+      <HelpCircle className="w-5 h-5 text-muted-foreground" />
+    );
+
+  return (
+    <span
+      className="group relative inline-flex items-center gap-1.5 pl-1.5 pr-5 py-1 ml-0.5 mr-0.5 bg-muted rounded border cursor-pointer border-border hover:border-muted-foreground transition-colors align-bottom"
+      onClick={(event) => {
+        openUrl(event).catch((error) => {
+          console.error('Failed to open attachment:', error);
+        });
+      }}
+      role="button"
+      tabIndex={0}
+    >
+      <span className="w-10 h-10 flex items-center justify-center bg-muted rounded flex-shrink-0">
+        {icon}
+      </span>
+      <span className="flex flex-col min-w-0">
+        <span className="text-xs text-muted-foreground truncate max-w-[120px]">
+          {displayName}
+        </span>
+        {metadataLine && (
+          <span className="text-[10px] text-muted-foreground/70 truncate max-w-[120px]">
+            {metadataLine}
+          </span>
+        )}
+      </span>
+      {resolvedUrl && (
+        <button
+          onClick={(event) => {
+            openUrl(event).catch((error) => {
+              console.error('Failed to open attachment:', error);
+            });
+          }}
+          className="absolute top-1 right-1 w-4 h-4 rounded-full bg-foreground/70 hover:bg-foreground flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity"
+          aria-label={t('kanban.downloadAttachment')}
+          type="button"
+        >
+          <Download className="w-2.5 h-2.5 text-background" />
+        </button>
+      )}
+    </span>
+  );
+}

--- a/packages/ui/src/components/wysiwyg/ComponentInfoRenderer.tsx
+++ b/packages/ui/src/components/wysiwyg/ComponentInfoRenderer.tsx
@@ -1,0 +1,147 @@
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '../RadixTooltip';
+
+/**
+ * Data model for a detected UI component.
+ * Serialized as JSON inside a ```vk-component fenced code block.
+ */
+export interface ComponentInfoData {
+  framework: string;
+  component: string;
+  tagName?: string;
+  file?: string;
+  line?: number;
+  column?: number;
+  cssClass?: string;
+  stack?: Array<{ name: string; file?: string }>;
+  htmlPreview: string;
+}
+
+function toRelativePath(absolutePath: string): string {
+  const worktreeMatch = absolutePath.match(
+    /\/worktrees\/[^/]+\/[^/]+\/(.+)$/
+  );
+  if (worktreeMatch) return worktreeMatch[1];
+
+  const srcMatch = absolutePath.match(/\/(src\/.+)$/);
+  if (srcMatch) return srcMatch[1];
+
+  if (absolutePath.startsWith('/') && absolutePath.split('/').length > 4) {
+    return absolutePath.split('/').slice(-3).join('/');
+  }
+
+  return absolutePath;
+}
+
+export interface ComponentInfoRendererProps {
+  data: ComponentInfoData;
+}
+
+/**
+ * Standalone component info renderer for use in react-markdown read-only mode.
+ * Renders an inline badge with a tooltip showing component details.
+ */
+export function ComponentInfoRenderer({
+  data,
+}: ComponentInfoRendererProps): JSX.Element {
+  const displayName = data.component || data.tagName || 'unknown';
+
+  let file = data.file;
+  let line = data.line;
+  let column = data.column;
+
+  if (!file && data.stack?.length) {
+    const firstFile = data.stack[0]?.file;
+    if (firstFile) {
+      const match = firstFile.match(
+        /^(.+\.(?:tsx|ts|jsx|js|vue|svelte)):(\d+):(\d+)$/
+      );
+      if (match) {
+        file = match[1];
+        line = parseInt(match[2], 10);
+        column = parseInt(match[3], 10);
+      } else {
+        file = firstFile;
+      }
+    }
+  }
+
+  const displayPath = file ? toRelativePath(file) : null;
+  const fileLine = displayPath
+    ? line != null
+      ? `${displayPath}:${line}`
+      : displayPath
+    : null;
+
+  const fileName = file?.split('/').pop();
+  const badgeLabel = fileName
+    ? line != null
+      ? column != null
+        ? `${fileName}:${line}:${column}`
+        : `${fileName}:${line}`
+      : fileName
+    : displayName;
+
+  const stackBreadcrumb =
+    data.stack && data.stack.length > 1
+      ? data.stack.map((s) => `<${s.name}/>`).join(' \u2190 ')
+      : null;
+
+  return (
+    <TooltipProvider delayDuration={350}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span className="inline-flex items-center gap-half px-half bg-muted rounded-sm border border-border text-xs font-ibm-plex-mono text-muted-foreground cursor-default select-none hover:border-muted-foreground transition-colors">
+            {badgeLabel}
+          </span>
+        </TooltipTrigger>
+        <TooltipContent
+          side="top"
+          className="max-w-[400px] px-plusfifty py-base"
+          style={{ backgroundColor: 'hsl(var(--bg-panel))' }}
+        >
+          <div className="flex flex-col gap-half">
+            <div className="flex items-center gap-base">
+              <span className="text-sm text-foreground">{data.component}</span>
+              <span className="text-xs text-muted-foreground bg-muted px-half rounded-sm">
+                {data.framework}
+              </span>
+            </div>
+
+            {fileLine && (
+              <span className="text-xs font-ibm-plex-mono text-muted-foreground break-all leading-relaxed">
+                {fileLine}
+              </span>
+            )}
+
+            {data.cssClass && (
+              <span className="text-xs font-ibm-plex-mono text-muted-foreground break-all">
+                {data.cssClass}
+              </span>
+            )}
+
+            {stackBreadcrumb && (
+              <div className="border-t border-border pt-half">
+                <span className="text-xs text-muted-foreground leading-relaxed break-words">
+                  {stackBreadcrumb}
+                </span>
+              </div>
+            )}
+
+            {data.htmlPreview && (
+              <div className="border-t border-border pt-half">
+                <pre className="text-xs font-ibm-plex-mono text-muted-foreground whitespace-pre overflow-x-auto max-h-[120px] overflow-y-auto leading-relaxed">
+                  {data.htmlPreview}
+                </pre>
+              </div>
+            )}
+          </div>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}

--- a/packages/ui/src/components/wysiwyg/ImageRenderer.tsx
+++ b/packages/ui/src/components/wysiwyg/ImageRenderer.tsx
@@ -1,0 +1,444 @@
+import { useCallback, useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
+import { Download, File, HelpCircle, Loader2 } from 'lucide-react';
+import {
+  useWorkspaceId,
+  useSessionId,
+  useLocalAttachments,
+  type LocalAttachmentMetadata,
+} from '../WorkspaceContext';
+
+const ATTACHMENT_URL_STALE_TIME = 4 * 60 * 1000;
+const IMAGE_FILE_EXTENSION_REGEX =
+  /\.(png|jpe?g|gif|webp|bmp|svg|avif|heic|heif)$/i;
+
+type AttachmentType = 'file' | 'thumbnail';
+
+interface ImageMetadataLike {
+  exists: boolean;
+  file_name?: string | null;
+  size_bytes?: bigint | null;
+  format?: string | null;
+  proxy_url?: string | null;
+}
+
+export interface OpenImagePreviewOptions {
+  imageUrl: string;
+  altText: string;
+  fileName?: string;
+  format?: string;
+  sizeBytes?: bigint | null;
+}
+
+export interface ImageRendererProps {
+  src: string;
+  altText: string;
+  fetchAttachmentUrl: (
+    attachmentId: string,
+    type: AttachmentType
+  ) => Promise<string>;
+  openImagePreview: (options: OpenImagePreviewOptions) => void;
+}
+
+function isImageLikeFileName(name: string): boolean {
+  return IMAGE_FILE_EXTENSION_REGEX.test(name.trim());
+}
+
+function truncatePath(path: string, maxLength = 24): string {
+  const filename = path.split('/').pop() || path;
+  if (filename.length <= maxLength) return filename;
+  return filename.slice(0, maxLength - 3) + '...';
+}
+
+function formatFileSize(bytes: bigint | number | null | undefined): string {
+  if (!bytes) return '';
+  const num = Number(bytes);
+  if (num < 1024) return `${num} B`;
+  if (num < 1024 * 1024) return `${(num / 1024).toFixed(1)} KB`;
+  return `${(num / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+async function downloadBlobUrl(url: string, filename: string): Promise<void> {
+  const response = await fetch(url, {
+    method: 'GET',
+    mode: 'cors',
+    credentials: 'omit',
+  });
+
+  if (!response.ok) {
+    throw new Error('Failed to download attachment');
+  }
+
+  const blob = await response.blob();
+  const objectUrl = URL.createObjectURL(blob);
+
+  try {
+    const anchor = document.createElement('a');
+    anchor.href = objectUrl;
+    anchor.download = filename;
+    document.body.appendChild(anchor);
+    anchor.click();
+    document.body.removeChild(anchor);
+  } finally {
+    URL.revokeObjectURL(objectUrl);
+  }
+}
+
+function toMetadataFromLocalImage(
+  localImage: LocalAttachmentMetadata | undefined
+): ImageMetadataLike | null {
+  if (!localImage) return null;
+
+  return {
+    exists: true,
+    file_name: localImage.file_name,
+    size_bytes: BigInt(localImage.size_bytes),
+    format: localImage.format,
+    proxy_url: localImage.proxy_url,
+  };
+}
+
+function useImageMetadata(
+  workspaceId: string | undefined,
+  sessionId: string | undefined,
+  src: string,
+  localAttachments: LocalAttachmentMetadata[]
+) {
+  const isVibeImage = src.startsWith('.vibe-attachments/');
+
+  const localImage = useMemo(
+    () => localAttachments.find((attachment) => attachment.path === src),
+    [localAttachments, src]
+  );
+
+  const localImageMetadata = useMemo(
+    () => toMetadataFromLocalImage(localImage),
+    [localImage]
+  );
+
+  const shouldFetch = isVibeImage && !!workspaceId && !localImage;
+
+  const query = useQuery({
+    queryKey: ['image-metadata', workspaceId, sessionId, src],
+    queryFn: async (): Promise<ImageMetadataLike | null> => {
+      if (!workspaceId || !sessionId) return null;
+
+      const response = await fetch(
+        `/api/workspaces/${workspaceId}/attachments/metadata?path=${encodeURIComponent(src)}&session_id=${sessionId}`
+      );
+      const payload = await response.json();
+      return payload.data as ImageMetadataLike | null;
+    },
+    enabled: shouldFetch && !!sessionId,
+    staleTime: Infinity,
+  });
+
+  return {
+    data: localImageMetadata ?? query.data,
+    isLoading: localImage ? false : query.isLoading,
+  };
+}
+
+function useAttachmentUrl(
+  attachmentId: string | null,
+  type: AttachmentType,
+  fetchAttachmentUrl: ImageRendererProps['fetchAttachmentUrl']
+) {
+  const query = useQuery({
+    queryKey: ['attachment-url', attachmentId, type],
+    queryFn: () => fetchAttachmentUrl(attachmentId as string, type),
+    enabled: !!attachmentId,
+    staleTime: ATTACHMENT_URL_STALE_TIME,
+  });
+
+  return {
+    url: query.data ?? null,
+    loading: query.isLoading,
+  };
+}
+
+/**
+ * Standalone image renderer for use in react-markdown read-only mode.
+ * Handles attachment://, pending-attachment://, .vibe-attachments/, and external URLs.
+ */
+export function ImageRenderer({
+  src,
+  altText,
+  fetchAttachmentUrl,
+  openImagePreview,
+}: ImageRendererProps): JSX.Element {
+  const { t } = useTranslation('common');
+  const workspaceId = useWorkspaceId();
+  const sessionId = useSessionId();
+  const localAttachments = useLocalAttachments();
+
+  const isVibeImage = src.startsWith('.vibe-attachments/');
+  const isPendingAttachment = src.startsWith('pending-attachment://');
+  const isAttachment = isPendingAttachment || src.startsWith('attachment://');
+  const attachmentId =
+    !isPendingAttachment && isAttachment
+      ? src.replace('attachment://', '')
+      : null;
+  const localAttachment = useMemo(
+    () => localAttachments.find((attachment) => attachment.path === src),
+    [localAttachments, src]
+  );
+  const isImageAttachment =
+    isAttachment &&
+    (localAttachment?.mime_type?.startsWith('image/') ||
+      isImageLikeFileName(altText));
+
+  const { url: thumbnailUrl, loading: attachmentLoading } = useAttachmentUrl(
+    isImageAttachment && !localAttachment ? attachmentId : null,
+    'thumbnail',
+    fetchAttachmentUrl
+  );
+  const { url: fullSizeUrl } = useAttachmentUrl(
+    localAttachment ? null : attachmentId,
+    'file',
+    fetchAttachmentUrl
+  );
+
+  const { data: metadata, isLoading: loading } = useImageMetadata(
+    workspaceId,
+    sessionId,
+    src,
+    localAttachments
+  );
+  const workspaceDisplayName =
+    metadata?.file_name || localAttachment?.file_name || altText || src;
+  const isWorkspaceImage =
+    isVibeImage &&
+    ((localAttachment?.mime_type?.startsWith('image/') ?? false) ||
+      isImageLikeFileName(workspaceDisplayName));
+  const showDownloadButton = Boolean(
+    (isAttachment &&
+      (localAttachment?.proxy_url || fullSizeUrl || metadata?.proxy_url)) ||
+      (!isWorkspaceImage && metadata?.proxy_url)
+  );
+
+  const handleClick = useCallback(
+    (event: React.MouseEvent) => {
+      event.preventDefault();
+      event.stopPropagation();
+
+      const localAttachmentUrl = localAttachment?.proxy_url ?? null;
+
+      if (isAttachment && (localAttachmentUrl || fullSizeUrl)) {
+        const resolvedFullSizeUrl = localAttachmentUrl || fullSizeUrl;
+        if (!resolvedFullSizeUrl) return;
+
+        if (isImageAttachment && (localAttachmentUrl || thumbnailUrl)) {
+          openImagePreview({
+            imageUrl: resolvedFullSizeUrl,
+            altText,
+            fileName: altText || undefined,
+          });
+        } else {
+          window.open(resolvedFullSizeUrl, '_blank', 'noopener,noreferrer');
+        }
+        return;
+      }
+
+      if (metadata?.exists && metadata.proxy_url) {
+        if (isWorkspaceImage) {
+          openImagePreview({
+            imageUrl: metadata.proxy_url,
+            altText,
+            fileName: metadata.file_name ?? undefined,
+            format: metadata.format ?? undefined,
+            sizeBytes: metadata.size_bytes,
+          });
+        } else {
+          window.open(metadata.proxy_url, '_blank', 'noopener,noreferrer');
+        }
+      }
+    },
+    [
+      isAttachment,
+      localAttachment?.proxy_url,
+      fullSizeUrl,
+      isImageAttachment,
+      thumbnailUrl,
+      metadata,
+      isWorkspaceImage,
+      altText,
+      openImagePreview,
+    ]
+  );
+
+  const handleDownload = useCallback(
+    (event: React.MouseEvent) => {
+      event.preventDefault();
+      event.stopPropagation();
+
+      const downloadUrl =
+        localAttachment?.proxy_url ??
+        fullSizeUrl ??
+        (!isWorkspaceImage ? (metadata?.proxy_url ?? null) : null);
+      if (!downloadUrl) return;
+
+      downloadBlobUrl(downloadUrl, altText || 'attachment').catch((error) => {
+        console.error('Failed to download attachment:', error);
+      });
+    },
+    [
+      localAttachment?.proxy_url,
+      fullSizeUrl,
+      isWorkspaceImage,
+      metadata,
+      altText,
+    ]
+  );
+
+  let thumbnailContent: React.ReactNode;
+  let displayName: string;
+  let metadataLine: string | null = null;
+
+  const hasContext = !!workspaceId;
+  const hasLocalImage = localAttachments.some(
+    (attachment) => attachment.path === src
+  );
+
+  if (isAttachment) {
+    const previewUrl = localAttachment?.proxy_url ?? thumbnailUrl;
+
+    if (isImageAttachment && !localAttachment && attachmentLoading) {
+      thumbnailContent = (
+        <div className="w-10 h-10 flex items-center justify-center bg-muted rounded flex-shrink-0">
+          <Loader2 className="w-5 h-5 text-muted-foreground animate-spin" />
+        </div>
+      );
+    } else if (isImageAttachment && previewUrl) {
+      thumbnailContent = (
+        <img
+          src={previewUrl}
+          alt={altText}
+          className="w-10 h-10 object-cover rounded flex-shrink-0"
+          draggable={false}
+        />
+      );
+    } else {
+      thumbnailContent = (
+        <div className="w-10 h-10 flex items-center justify-center bg-muted rounded flex-shrink-0">
+          <File className="w-5 h-5 text-muted-foreground" />
+        </div>
+      );
+    }
+    displayName = truncatePath(
+      altText || t('kanban.imageAttachmentNameFallback')
+    );
+    if (localAttachment?.is_pending) {
+      const parts = ['Uploading'];
+      const sizeText = formatFileSize(localAttachment.size_bytes);
+      if (sizeText) {
+        parts.push(sizeText);
+      }
+      metadataLine = parts.join(' · ');
+    }
+    if (!isImageAttachment) {
+      const format = altText.split('.').pop()?.trim();
+      metadataLine = format ? format.toUpperCase() : null;
+    }
+  } else if (isVibeImage && (hasLocalImage || hasContext)) {
+    if (!isWorkspaceImage) {
+      thumbnailContent = (
+        <div className="w-10 h-10 flex items-center justify-center bg-muted rounded flex-shrink-0">
+          <File className="w-5 h-5 text-muted-foreground" />
+        </div>
+      );
+      displayName = truncatePath(workspaceDisplayName);
+      const parts: string[] = [];
+      if (metadata?.format) {
+        parts.push(metadata.format.toUpperCase());
+      }
+      const sizeText = formatFileSize(metadata?.size_bytes);
+      if (sizeText) {
+        parts.push(sizeText);
+      }
+      metadataLine = parts.length > 0 ? parts.join(' · ') : null;
+    } else if (loading) {
+      thumbnailContent = (
+        <div className="w-10 h-10 flex items-center justify-center bg-muted rounded flex-shrink-0">
+          <Loader2 className="w-5 h-5 text-muted-foreground animate-spin" />
+        </div>
+      );
+      displayName = truncatePath(src);
+    } else if (metadata?.exists && metadata.proxy_url) {
+      thumbnailContent = (
+        <img
+          src={metadata.proxy_url}
+          alt={altText}
+          className="w-10 h-10 object-cover rounded flex-shrink-0"
+          draggable={false}
+        />
+      );
+      displayName = truncatePath(workspaceDisplayName);
+
+      const parts: string[] = [];
+      if (metadata.format) {
+        parts.push(metadata.format.toUpperCase());
+      }
+      const sizeText = formatFileSize(metadata.size_bytes);
+      if (sizeText) {
+        parts.push(sizeText);
+      }
+      if (parts.length > 0) {
+        metadataLine = parts.join(' · ');
+      }
+    } else {
+      thumbnailContent = (
+        <div className="w-10 h-10 flex items-center justify-center bg-muted rounded flex-shrink-0">
+          <HelpCircle className="w-5 h-5 text-muted-foreground" />
+        </div>
+      );
+      displayName = truncatePath(src);
+    }
+  } else if (!isVibeImage) {
+    thumbnailContent = (
+      <div className="w-10 h-10 flex items-center justify-center bg-muted rounded flex-shrink-0">
+        <HelpCircle className="w-5 h-5 text-muted-foreground" />
+      </div>
+    );
+    displayName = truncatePath(altText || src);
+  } else {
+    thumbnailContent = (
+      <div className="w-10 h-10 flex items-center justify-center bg-muted rounded flex-shrink-0">
+        <HelpCircle className="w-5 h-5 text-muted-foreground" />
+      </div>
+    );
+    displayName = truncatePath(src);
+  }
+
+  return (
+    <span
+      className="group relative inline-flex items-center gap-1.5 pl-1.5 pr-5 py-1 ml-0.5 mr-0.5 bg-muted rounded border cursor-pointer border-border hover:border-muted-foreground transition-colors align-bottom"
+      onClick={handleClick}
+      role="button"
+      tabIndex={0}
+    >
+      {thumbnailContent}
+      <span className="flex flex-col min-w-0">
+        <span className="text-xs text-muted-foreground truncate max-w-[120px]">
+          {displayName}
+        </span>
+        {metadataLine && (
+          <span className="text-[10px] text-muted-foreground/70 truncate max-w-[120px]">
+            {metadataLine}
+          </span>
+        )}
+      </span>
+      {showDownloadButton ? (
+        <button
+          onClick={handleDownload}
+          className="absolute top-1 right-1 w-4 h-4 rounded-full bg-foreground/70 hover:bg-foreground flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity"
+          aria-label={t('kanban.downloadAttachment')}
+          type="button"
+        >
+          <Download className="w-2.5 h-2.5 text-background" />
+        </button>
+      ) : null}
+    </span>
+  );
+}

--- a/packages/ui/src/components/wysiwyg/MarkdownReadOnly.tsx
+++ b/packages/ui/src/components/wysiwyg/MarkdownReadOnly.tsx
@@ -1,0 +1,466 @@
+import { useMemo, type ComponentPropsWithoutRef } from 'react';
+import ReactMarkdown, { type Components } from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import rehypeHighlight from 'rehype-highlight';
+import { PrCommentCard } from '../pr-comment-card';
+import {
+  ComponentInfoRenderer,
+  type ComponentInfoData,
+} from './ComponentInfoRenderer';
+import {
+  ImageRenderer,
+  type OpenImagePreviewOptions,
+} from './ImageRenderer';
+import { AttachmentRenderer } from './AttachmentRenderer';
+import { cn } from '../../lib/cn';
+
+type AttachmentType = 'file' | 'thumbnail';
+
+export interface MarkdownReadOnlyProps {
+  value: string;
+  className?: string;
+  fetchAttachmentUrl: (
+    attachmentId: string,
+    type: AttachmentType
+  ) => Promise<string>;
+  openImagePreview: (options: OpenImagePreviewOptions) => void;
+  findMatchingDiffPath?: (text: string) => string | null;
+  onCodeClick?: (fullPath: string) => void;
+}
+
+// --- URL pattern helpers ---
+
+const ATTACHMENT_HREF_RE =
+  /^(attachment:\/\/|pending-attachment:\/\/|\.vibe-attachments\/)/;
+
+const IMAGE_SRC_RE =
+  /^(attachment:\/\/|pending-attachment:\/\/|\.vibe-attachments\/)/;
+
+function sanitizeHref(href?: string): string | undefined {
+  if (typeof href !== 'string') return undefined;
+  const trimmed = href.trim();
+  if (/^(javascript|vbscript|data):/i.test(trimmed)) return undefined;
+  if (
+    trimmed.startsWith('#') ||
+    trimmed.startsWith('./') ||
+    trimmed.startsWith('../') ||
+    trimmed.startsWith('/')
+  )
+    return trimmed;
+  if (/^https:\/\//i.test(trimmed)) return trimmed;
+  return undefined;
+}
+
+function isExternalHref(href?: string): boolean {
+  if (!href) return false;
+  return /^https:\/\//i.test(href);
+}
+
+// --- Remark plugins ---
+
+const remarkPlugins = [remarkGfm];
+const rehypePlugins = [rehypeHighlight];
+
+// --- Component factory ---
+
+function createComponents(
+  fetchAttachmentUrl: MarkdownReadOnlyProps['fetchAttachmentUrl'],
+  openImagePreview: MarkdownReadOnlyProps['openImagePreview'],
+  findMatchingDiffPath?: MarkdownReadOnlyProps['findMatchingDiffPath'],
+  onCodeClick?: MarkdownReadOnlyProps['onCodeClick']
+): Components {
+  return {
+    // --- Images: detect attachment patterns ---
+    img({ src, alt, ...rest }) {
+      if (src && IMAGE_SRC_RE.test(src)) {
+        return (
+          <ImageRenderer
+            src={src}
+            altText={alt ?? ''}
+            fetchAttachmentUrl={fetchAttachmentUrl}
+            openImagePreview={openImagePreview}
+          />
+        );
+      }
+
+      // External / normal image — render as native <img>
+      return (
+        <img
+          src={src}
+          alt={alt}
+          className="max-w-full rounded"
+          loading="lazy"
+          {...rest}
+        />
+      );
+    },
+
+    // --- Links: detect attachment patterns + sanitize ---
+    a({ href, children, ...rest }) {
+      if (href && ATTACHMENT_HREF_RE.test(href)) {
+        // Attachment link → render as attachment card
+        const label =
+          typeof children === 'string'
+            ? children
+            : Array.isArray(children)
+              ? children
+                  .map((c) => (typeof c === 'string' ? c : ''))
+                  .join('')
+              : '';
+        return (
+          <AttachmentRenderer
+            src={href}
+            label={label}
+            fetchAttachmentUrl={fetchAttachmentUrl}
+          />
+        );
+      }
+
+      const safeHref = sanitizeHref(href);
+
+      if (!safeHref) {
+        // Dangerous protocol — render as inert text
+        return <span>{children}</span>;
+      }
+
+      if (isExternalHref(safeHref)) {
+        return (
+          <a
+            href={safeHref}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-blue-600 dark:text-blue-400 underline underline-offset-2 cursor-pointer hover:text-blue-800 dark:hover:text-blue-300"
+            onClick={(e) => e.stopPropagation()}
+            {...rest}
+          >
+            {children}
+          </a>
+        );
+      }
+
+      // Internal/relative link — render as inert text with title
+      return (
+        <span
+          className="text-blue-600 dark:text-blue-400 underline underline-offset-2 cursor-not-allowed"
+          title={href}
+          role="link"
+          aria-disabled="true"
+        >
+          {children}
+        </span>
+      );
+    },
+
+    // --- Code blocks: detect special languages, clickable inline code ---
+    pre({ children, ...rest }) {
+      // react-markdown wraps fenced code blocks in <pre><code>
+      // We intercept at the <pre> level to detect special languages.
+      if (
+        children &&
+        typeof children === 'object' &&
+        'props' in (children as React.ReactElement)
+      ) {
+        const codeElement = children as React.ReactElement<
+          ComponentPropsWithoutRef<'code'> & { className?: string }
+        >;
+        const codeClassName = codeElement.props?.className ?? '';
+        const codeChildren = codeElement.props?.children;
+        const rawText =
+          typeof codeChildren === 'string' ? codeChildren.trim() : '';
+
+        // PR comment: ```gh-comment
+        if (codeClassName.includes('language-gh-comment') && rawText) {
+          try {
+            const data = JSON.parse(rawText);
+            if (data.id && data.comment_type && data.author && data.body) {
+              return (
+                <PrCommentCard
+                  author={data.author}
+                  body={data.body}
+                  createdAt={data.created_at}
+                  url={data.url}
+                  commentType={data.comment_type}
+                  path={data.path}
+                  line={data.line}
+                  diffHunk={data.diff_hunk}
+                  variant="full"
+                  onClick={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    if (data.url) {
+                      window.open(
+                        data.url,
+                        '_blank',
+                        'noopener,noreferrer'
+                      );
+                    }
+                  }}
+                />
+              );
+            }
+          } catch {
+            // Fall through to default rendering
+          }
+        }
+
+        // Component info: ```vk-component
+        if (codeClassName.includes('language-vk-component') && rawText) {
+          try {
+            const data = JSON.parse(rawText) as ComponentInfoData;
+            if (data.framework && data.component && data.htmlPreview) {
+              return <ComponentInfoRenderer data={data} />;
+            }
+          } catch {
+            // Fall through to default rendering
+          }
+        }
+      }
+
+      // Default: render with syntax highlighting (from rehype-highlight)
+      return (
+        <pre
+          className="block font-mono bg-secondary rounded-md px-3 py-2 my-2 whitespace-pre overflow-x-auto"
+          {...rest}
+        >
+          {children}
+        </pre>
+      );
+    },
+
+    code({ className, children, ...rest }) {
+      // Fenced code blocks are handled by the `pre` override above.
+      // This handles inline code only (no `pre` parent → no className prefix).
+      const isInline = !className;
+
+      if (isInline) {
+        const text =
+          typeof children === 'string'
+            ? children.trim()
+            : Array.isArray(children)
+              ? children
+                  .map((c) => (typeof c === 'string' ? c : ''))
+                  .join('')
+                  .trim()
+              : '';
+
+        const matchedPath =
+          findMatchingDiffPath && text
+            ? findMatchingDiffPath(text)
+            : null;
+
+        if (matchedPath && onCodeClick) {
+          return (
+            <code
+              className="font-mono bg-muted bg-panel px-1 py-0.5 rounded cursor-pointer clickable-code"
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                onCodeClick(matchedPath);
+              }}
+              role="button"
+              tabIndex={0}
+              {...rest}
+            >
+              {children}
+            </code>
+          );
+        }
+
+        return (
+          <code
+            className="font-mono bg-muted bg-panel px-1 py-0.5 rounded"
+            {...rest}
+          >
+            {children}
+          </code>
+        );
+      }
+
+      // Fenced code inside pre (shouldn't reach here normally, but safety net)
+      return (
+        <code className={className} {...rest}>
+          {children}
+        </code>
+      );
+    },
+
+    // --- Standard element styling to match existing Lexical theme ---
+    h1: ({ children, ...rest }) => (
+      <h1
+        className="mt-4 mb-2 text-2xl font-semibold"
+        {...rest}
+      >
+        {children}
+      </h1>
+    ),
+    h2: ({ children, ...rest }) => (
+      <h2
+        className="mt-3 mb-2 text-xl font-semibold"
+        {...rest}
+      >
+        {children}
+      </h2>
+    ),
+    h3: ({ children, ...rest }) => (
+      <h3
+        className="mt-3 mb-2 text-lg font-semibold"
+        {...rest}
+      >
+        {children}
+      </h3>
+    ),
+    h4: ({ children, ...rest }) => (
+      <h4
+        className="mt-2 mb-1 text-base font-medium"
+        {...rest}
+      >
+        {children}
+      </h4>
+    ),
+    h5: ({ children, ...rest }) => (
+      <h5
+        className="mt-2 mb-1 text-sm font-medium"
+        {...rest}
+      >
+        {children}
+      </h5>
+    ),
+    h6: ({ children, ...rest }) => (
+      <h6
+        className="mt-2 mb-1 text-xs font-medium uppercase tracking-wide"
+        {...rest}
+      >
+        {children}
+      </h6>
+    ),
+    blockquote: ({ children, ...rest }) => (
+      <blockquote
+        className="my-3 border-l-4 border-primary-foreground pl-4 text-muted-foreground"
+        {...rest}
+      >
+        {children}
+      </blockquote>
+    ),
+    ul: ({ children, ...rest }) => (
+      <ul className="my-1 list-disc list-inside" {...rest}>
+        {children}
+      </ul>
+    ),
+    ol: ({ children, ...rest }) => (
+      <ol className="my-1 list-decimal list-inside" {...rest}>
+        {children}
+      </ol>
+    ),
+    table: ({ children, ...rest }) => (
+      <table
+        className="border-collapse my-2 w-full text-sm"
+        {...rest}
+      >
+        {children}
+      </table>
+    ),
+    th: ({ children, ...rest }) => (
+      <th
+        className="bg-muted font-semibold border border-low px-3 py-2 text-left align-top"
+        {...rest}
+      >
+        {children}
+      </th>
+    ),
+    td: ({ children, ...rest }) => (
+      <td
+        className="border border-low px-3 py-2 text-left align-top"
+        {...rest}
+      >
+        {children}
+      </td>
+    ),
+    hr: ({ ...rest }) => (
+      <hr className="my-4 border-border" {...rest} />
+    ),
+    p: ({ children, ...rest }) => (
+      <p className="mb-1 last:mb-0" {...rest}>
+        {children}
+      </p>
+    ),
+    strong: ({ children, ...rest }) => (
+      <strong className="font-semibold" {...rest}>
+        {children}
+      </strong>
+    ),
+    em: ({ children, ...rest }) => (
+      <em className="italic" {...rest}>
+        {children}
+      </em>
+    ),
+    del: ({ children, ...rest }) => (
+      <del className="line-through" {...rest}>
+        {children}
+      </del>
+    ),
+    // GFM task list items (remark-gfm renders these with input[type=checkbox])
+    input: ({ type, checked, ...rest }) => {
+      if (type === 'checkbox') {
+        return (
+          <input
+            type="checkbox"
+            checked={checked}
+            disabled
+            className="mr-1 align-middle"
+            {...rest}
+          />
+        );
+      }
+      return <input type={type} checked={checked} {...rest} />;
+    },
+  };
+}
+
+/**
+ * Read-only markdown renderer using react-markdown + remark-gfm.
+ *
+ * Handles all custom content types:
+ * - Images with attachment:// and .vibe-attachments/ URLs
+ * - Attachment links
+ * - PR comment fenced code blocks (```gh-comment)
+ * - Component info fenced code blocks (```vk-component)
+ * - Clickable inline code matching diff paths
+ * - Link sanitization
+ */
+export function MarkdownReadOnly({
+  value,
+  className,
+  fetchAttachmentUrl,
+  openImagePreview,
+  findMatchingDiffPath,
+  onCodeClick,
+}: MarkdownReadOnlyProps): JSX.Element {
+  const components = useMemo(
+    () =>
+      createComponents(
+        fetchAttachmentUrl,
+        openImagePreview,
+        findMatchingDiffPath,
+        onCodeClick
+      ),
+    [fetchAttachmentUrl, openImagePreview, findMatchingDiffPath, onCodeClick]
+  );
+
+  // Unescape markdown-escaped underscores for cleaner rendering
+  const normalizedValue = useMemo(
+    () => value.replace(/\\_/g, '_'),
+    [value]
+  );
+
+  return (
+    <div className={cn('wysiwyg text-base', className)}>
+      <ReactMarkdown
+        remarkPlugins={remarkPlugins}
+        rehypePlugins={rehypePlugins}
+        components={components}
+      >
+        {normalizedValue}
+      </ReactMarkdown>
+    </div>
+  );
+}

--- a/packages/ui/src/components/wysiwyg/ReadOnlyStaticToolbar.tsx
+++ b/packages/ui/src/components/wysiwyg/ReadOnlyStaticToolbar.tsx
@@ -1,0 +1,103 @@
+import { type ReactNode } from 'react';
+import {
+  TextB,
+  TextItalic,
+  TextStrikethrough,
+  Code,
+  ListBullets,
+  ListNumbers,
+  ArrowCounterClockwise,
+  type Icon,
+  CheckIcon,
+} from '@phosphor-icons/react';
+import { cn } from '../../lib/cn';
+
+interface ToolbarButtonProps {
+  onClick: () => void;
+  icon: Icon;
+  label: string;
+}
+
+function ToolbarButton({ onClick, icon: Icon, label }: ToolbarButtonProps) {
+  return (
+    <button
+      type="button"
+      onMouseDown={(e) => {
+        e.preventDefault();
+        onClick();
+      }}
+      aria-label={label}
+      title={label}
+      className="p-half rounded-sm transition-colors text-low hover:text-normal hover:bg-panel/50"
+    >
+      <Icon className="size-icon-sm" weight="bold" />
+    </button>
+  );
+}
+
+interface ReadOnlyStaticToolbarProps {
+  saveStatus?: 'idle' | 'saved';
+  extraActions?: ReactNode;
+  onRequestEdit?: () => void;
+}
+
+/**
+ * Static toolbar for read-only mode. Same visual layout as StaticToolbarPlugin
+ * but without Lexical dependency. All buttons call `onRequestEdit` to switch
+ * to edit mode.
+ */
+export function ReadOnlyStaticToolbar({
+  saveStatus,
+  extraActions,
+  onRequestEdit,
+}: ReadOnlyStaticToolbarProps) {
+  const handleClick = () => onRequestEdit?.();
+
+  return (
+    <div className="flex items-center gap-half mt-half px-base py-half border-t border-border/50">
+      <ToolbarButton
+        onClick={handleClick}
+        icon={ArrowCounterClockwise}
+        label="Undo"
+      />
+      <div className="w-px h-4 bg-border mx-half" />
+      <ToolbarButton onClick={handleClick} icon={TextB} label="Bold" />
+      <ToolbarButton onClick={handleClick} icon={TextItalic} label="Italic" />
+      <ToolbarButton
+        onClick={handleClick}
+        icon={TextStrikethrough}
+        label="Strikethrough"
+      />
+      <ToolbarButton onClick={handleClick} icon={Code} label="Inline Code" />
+      <div className="w-px h-4 bg-border mx-half" />
+      <ToolbarButton
+        onClick={handleClick}
+        icon={ListBullets}
+        label="Bullet List"
+      />
+      <ToolbarButton
+        onClick={handleClick}
+        icon={ListNumbers}
+        label="Numbered List"
+      />
+
+      {extraActions && (
+        <>
+          <div className="w-px h-4 bg-border mx-half" />
+          <div className="flex items-center gap-half">{extraActions}</div>
+        </>
+      )}
+
+      {saveStatus && (
+        <div
+          className={cn(
+            'ml-auto mr-base flex items-center transition-opacity duration-300',
+            saveStatus === 'idle' ? 'opacity-0' : 'opacity-100'
+          )}
+        >
+          <CheckIcon className="size-icon-sm text-success" weight="bold" />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/web-core/src/shared/components/WYSIWYGEditor.tsx
+++ b/packages/web-core/src/shared/components/WYSIWYGEditor.tsx
@@ -15,12 +15,7 @@ import { RichTextPlugin } from '@lexical/react/LexicalRichTextPlugin';
 import { HistoryPlugin } from '@lexical/react/LexicalHistoryPlugin';
 import { AutoFocusPlugin } from '@lexical/react/LexicalAutoFocusPlugin';
 import { ContentEditable } from '@lexical/react/LexicalContentEditable';
-import {
-  TRANSFORMERS,
-  TEXT_FORMAT_TRANSFORMERS,
-  CODE,
-  type Transformer,
-} from '@lexical/markdown';
+import { TEXT_FORMAT_TRANSFORMERS, type Transformer } from '@lexical/markdown';
 import { MarkdownInsertPlugin } from '@vibe/ui/components/MarkdownInsertPlugin';
 import { MarkdownListContinuePlugin } from '@vibe/ui/components/MarkdownListContinuePlugin';
 import {
@@ -36,7 +31,6 @@ import {
   COMPONENT_INFO_EXPORT_TRANSFORMER,
   $isComponentInfoNode,
 } from '@vibe/ui/components/component-info-node';
-import { TABLE_TRANSFORMER } from '@vibe/ui/lib/table-transformer';
 import {
   WorkspaceContext as EditorWorkspaceContext,
   SessionContext,
@@ -53,8 +47,6 @@ import { SlashCommandTypeaheadPlugin } from '@vibe/ui/components/SlashCommandTyp
 import { KeyboardCommandsPlugin } from '@vibe/ui/components/KeyboardCommandsPlugin';
 import { ImageKeyboardPlugin } from '@vibe/ui/components/ImageKeyboardPlugin';
 import { ComponentInfoKeyboardPlugin } from '@vibe/ui/components/ComponentInfoKeyboardPlugin';
-import { ReadOnlyLinkPlugin } from '@vibe/ui/components/ReadOnlyLinkPlugin';
-import { ClickableCodePlugin } from '@vibe/ui/components/ClickableCodePlugin';
 import { ToolbarPlugin } from '@vibe/ui/components/ToolbarPlugin';
 import { StaticToolbarPlugin } from '@vibe/ui/components/StaticToolbarPlugin';
 import { PasteMarkdownPlugin } from '@vibe/ui/components/PasteMarkdownPlugin';
@@ -92,6 +84,8 @@ import {
 } from '@/shared/dialogs/command-bar/selections/repoSelection';
 import { fetchAttachmentSasUrl } from '@/shared/lib/remoteApi';
 import { writeClipboardViaBridge } from '@/shared/lib/clipboard';
+import { MarkdownReadOnly } from '@vibe/ui/components/wysiwyg/MarkdownReadOnly';
+import { ReadOnlyStaticToolbar } from '@vibe/ui/components/wysiwyg/ReadOnlyStaticToolbar';
 import type { SendMessageShortcut } from 'shared/types';
 import type { BaseCodingAgent } from 'shared/types';
 
@@ -377,6 +371,12 @@ const WYSIWYGEditor = forwardRef<WYSIWYGEditorRef, WysiwygProps>(
         // noop – bridge handles fallback
       }
     }, [value]);
+    const openImagePreview = useCallback(
+      (options: Parameters<typeof ImagePreviewDialog.show>[0]) => {
+        ImagePreviewDialog.show(options);
+      },
+      []
+    );
     const imageNodeDefinition = useMemo(
       () =>
         createImageNode({
@@ -474,27 +474,6 @@ const WYSIWYGEditor = forwardRef<WYSIWYGEditorRef, WysiwygProps>(
       [ATTACHMENT_TRANSFORMER, IMAGE_TRANSFORMER]
     );
 
-    // Display mode: full markdown rendering
-    const displayTransformers: Transformer[] = useMemo(
-      () => [
-        TABLE_TRANSFORMER,
-        IMAGE_TRANSFORMER,
-        ATTACHMENT_TRANSFORMER,
-        PR_COMMENT_EXPORT_TRANSFORMER,
-        PR_COMMENT_TRANSFORMER,
-        COMPONENT_INFO_EXPORT_TRANSFORMER,
-        COMPONENT_INFO_TRANSFORMER,
-        CODE,
-        ...TRANSFORMERS,
-      ],
-      [ATTACHMENT_TRANSFORMER, IMAGE_TRANSFORMER]
-    );
-
-    // Use display transformers for read-only, edit transformers for editing
-    const activeTransformers = disabled
-      ? displayTransformers
-      : editTransformers;
-
     // Preview toggle state (only used in edit mode with static toolbar)
     const [isPreviewMode, setIsPreviewMode] = useState(false);
 
@@ -542,21 +521,110 @@ const WYSIWYGEditor = forwardRef<WYSIWYGEditorRef, WysiwygProps>(
       [placeholder, className]
     );
 
+    // ── Read-only mode: react-markdown based rendering ──
+    if (disabled) {
+      const readOnlyContent = (
+        <EditorWorkspaceContext.Provider value={workspaceId}>
+          <SessionContext.Provider value={sessionId}>
+            <LocalAttachmentsContext.Provider value={localAttachments ?? []}>
+              <MarkdownReadOnly
+                value={value}
+                className={className}
+                fetchAttachmentUrl={fetchAttachmentSasUrl}
+                openImagePreview={openImagePreview}
+                findMatchingDiffPath={findMatchingDiffPath}
+                onCodeClick={onCodeClick}
+              />
+              {showStaticToolbar && (
+                <ReadOnlyStaticToolbar
+                  saveStatus={saveStatus}
+                  extraActions={staticToolbarActions}
+                  onRequestEdit={onRequestEdit}
+                />
+              )}
+            </LocalAttachmentsContext.Provider>
+          </SessionContext.Provider>
+        </EditorWorkspaceContext.Provider>
+      );
+
+      if (!hideActions) {
+        return (
+          <div className="relative group">
+            <div className="sticky top-0 right-2 z-10 pointer-events-none h-0">
+              <div className="flex justify-end gap-1 opacity-0 group-hover:opacity-100 transition-opacity duration-150">
+                {/* Copy button */}
+                <Button
+                  type="button"
+                  aria-label={copied ? 'Copied!' : 'Copy as Markdown'}
+                  title={copied ? 'Copied!' : 'Copy as Markdown'}
+                  variant="icon"
+                  size="icon"
+                  onClick={handleCopy}
+                  className="pointer-events-auto p-2 bg-muted h-8 w-8"
+                >
+                  {copied ? (
+                    <Check className="w-4 h-4 text-success" />
+                  ) : (
+                    <Clipboard className="w-4 h-4 text-muted-foreground" />
+                  )}
+                </Button>
+                {/* Edit button - only if onEdit provided */}
+                {onEdit && (
+                  <Button
+                    type="button"
+                    aria-label="Edit"
+                    title="Edit"
+                    variant="icon"
+                    size="icon"
+                    onClick={onEdit}
+                    className="pointer-events-auto p-2 bg-muted h-8 w-8"
+                  >
+                    <Pencil className="w-4 h-4 text-muted-foreground" />
+                  </Button>
+                )}
+                {/* Delete button - only if onDelete provided */}
+                {onDelete && (
+                  <Button
+                    type="button"
+                    aria-label="Delete"
+                    title="Delete"
+                    variant="icon"
+                    size="icon"
+                    onClick={onDelete}
+                    className="pointer-events-auto p-2 bg-muted h-8 w-8"
+                  >
+                    <Trash2 className="w-4 h-4 text-muted-foreground" />
+                  </Button>
+                )}
+              </div>
+            </div>
+            {readOnlyContent}
+          </div>
+        );
+      }
+
+      return readOnlyContent;
+    }
+
+    // ── Edit mode: Lexical-based editing (unchanged) ──
     const editorContent = (
       <div className="wysiwyg text-base relative">
-        {/* Preview: render a read-only editor with full markdown rendering */}
-        {!disabled && isPreviewMode && (
-          <div className={cn(className)}>
-            <WYSIWYGEditor
-              value={value}
-              disabled
-              hideActions
-              className={className}
-              workspaceId={workspaceId}
-              sessionId={sessionId}
-              localAttachments={localAttachments}
-            />
-          </div>
+        {/* Preview: render react-markdown based read-only view */}
+        {isPreviewMode && (
+          <EditorWorkspaceContext.Provider value={workspaceId}>
+            <SessionContext.Provider value={sessionId}>
+              <LocalAttachmentsContext.Provider value={localAttachments ?? []}>
+                <div className={cn(className)}>
+                  <MarkdownReadOnly
+                    value={value}
+                    className={className}
+                    fetchAttachmentUrl={fetchAttachmentSasUrl}
+                    openImagePreview={openImagePreview}
+                  />
+                </div>
+              </LocalAttachmentsContext.Provider>
+            </SessionContext.Provider>
+          </EditorWorkspaceContext.Provider>
         )}
 
         <EditorWorkspaceContext.Provider value={workspaceId}>
@@ -568,18 +636,16 @@ const WYSIWYGEditor = forwardRef<WYSIWYGEditorRef, WysiwygProps>(
                   value={value}
                   onChange={onChange}
                   onEditorStateChange={onEditorStateChange}
-                  editable={!disabled}
-                  transformers={activeTransformers}
-                  preserveMarkdownSyntax={!disabled}
+                  editable
+                  transformers={editTransformers}
+                  preserveMarkdownSyntax
                 />
-                {!disabled && !isPreviewMode && !showStaticToolbar && (
-                  <ToolbarPlugin />
-                )}
+                {!isPreviewMode && !showStaticToolbar && <ToolbarPlugin />}
 
                 <div
                   className="relative"
                   style={
-                    !disabled && isPreviewMode
+                    isPreviewMode
                       ? {
                           position: 'absolute',
                           opacity: 0,
@@ -592,9 +658,7 @@ const WYSIWYGEditor = forwardRef<WYSIWYGEditorRef, WysiwygProps>(
                     contentEditable={
                       <ContentEditable
                         className={cn('outline-none', className)}
-                        aria-label={
-                          disabled ? 'Markdown content' : 'Markdown editor'
-                        }
+                        aria-label="Markdown editor"
                         onPasteCapture={handlePaste}
                       />
                     }
@@ -609,11 +673,10 @@ const WYSIWYGEditor = forwardRef<WYSIWYGEditorRef, WysiwygProps>(
                     extraActions={staticToolbarActions}
                     isPreviewMode={isPreviewMode}
                     onTogglePreview={
-                      !disabled && !onRequestEdit
+                      !onRequestEdit
                         ? () => setIsPreviewMode((p) => !p)
                         : undefined
                     }
-                    readOnly={disabled}
                     onRequestEdit={onRequestEdit}
                   />
                 )}
@@ -621,120 +684,49 @@ const WYSIWYGEditor = forwardRef<WYSIWYGEditorRef, WysiwygProps>(
                 <ListPlugin />
                 <TablePlugin />
                 <CodeHighlightPlugin />
-                {/* Only include editing plugins when not in read-only mode */}
-                {!disabled && (
-                  <>
-                    {autoFocus && <AutoFocusPlugin />}
-                    <HistoryPlugin />
-                    <MarkdownInsertPlugin />
-                    <PasteMarkdownPlugin transformers={activeTransformers} />
-                    <TypeaheadOpenProvider>
-                      <MarkdownListContinuePlugin />
-                      <FileTagTypeaheadPlugin
-                        repoIds={repoIds}
-                        diffPaths={diffPaths}
-                        preferredRepoId={preferredRepoId}
-                        setPreferredRepoId={setFileSearchRepo}
-                        listRecentRepos={listRecentRepos}
-                        getRepoById={getRepoById}
-                        chooseRepo={chooseRepo}
-                        onCreateTag={handleCreateTag}
-                        searchTagsAndFiles={searchFileTags}
-                      />
-                      {executor && (
-                        <SlashCommandTypeaheadPlugin
-                          enabled={true}
-                          commands={slashCommandsQuery.commands}
-                          isInitialized={slashCommandsQuery.isInitialized}
-                          isDiscovering={slashCommandsQuery.discovering}
-                        />
-                      )}
-                      <KeyboardCommandsPlugin
-                        onCmdEnter={onCmdEnter}
-                        onShiftCmdEnter={onShiftCmdEnter}
-                        onChange={onChange}
-                        transformers={activeTransformers}
-                        sendShortcut={sendShortcut}
-                      />
-                    </TypeaheadOpenProvider>
-                    <ImageKeyboardPlugin isTargetNode={$isImageNode} />
-                    <ComponentInfoKeyboardPlugin
-                      isTargetNode={$isComponentInfoNode}
-                    />
-                  </>
-                )}
-                {/* Link sanitization for read-only mode */}
-                {disabled && <ReadOnlyLinkPlugin />}
-                {/* Clickable code for file paths in read-only mode */}
-                {disabled && findMatchingDiffPath && onCodeClick && (
-                  <ClickableCodePlugin
-                    findMatchingDiffPath={findMatchingDiffPath}
-                    onCodeClick={onCodeClick}
+                {autoFocus && <AutoFocusPlugin />}
+                <HistoryPlugin />
+                <MarkdownInsertPlugin />
+                <PasteMarkdownPlugin transformers={editTransformers} />
+                <TypeaheadOpenProvider>
+                  <MarkdownListContinuePlugin />
+                  <FileTagTypeaheadPlugin
+                    repoIds={repoIds}
+                    diffPaths={diffPaths}
+                    preferredRepoId={preferredRepoId}
+                    setPreferredRepoId={setFileSearchRepo}
+                    listRecentRepos={listRecentRepos}
+                    getRepoById={getRepoById}
+                    chooseRepo={chooseRepo}
+                    onCreateTag={handleCreateTag}
+                    searchTagsAndFiles={searchFileTags}
                   />
-                )}
+                  {executor && (
+                    <SlashCommandTypeaheadPlugin
+                      enabled={true}
+                      commands={slashCommandsQuery.commands}
+                      isInitialized={slashCommandsQuery.isInitialized}
+                      isDiscovering={slashCommandsQuery.discovering}
+                    />
+                  )}
+                  <KeyboardCommandsPlugin
+                    onCmdEnter={onCmdEnter}
+                    onShiftCmdEnter={onShiftCmdEnter}
+                    onChange={onChange}
+                    transformers={editTransformers}
+                    sendShortcut={sendShortcut}
+                  />
+                </TypeaheadOpenProvider>
+                <ImageKeyboardPlugin isTargetNode={$isImageNode} />
+                <ComponentInfoKeyboardPlugin
+                  isTargetNode={$isComponentInfoNode}
+                />
               </LexicalComposer>
             </LocalAttachmentsContext.Provider>
           </SessionContext.Provider>
         </EditorWorkspaceContext.Provider>
       </div>
     );
-
-    // Wrap with action buttons in read-only mode
-    if (disabled && !hideActions) {
-      return (
-        <div className="relative group">
-          <div className="sticky top-0 right-2 z-10 pointer-events-none h-0">
-            <div className="flex justify-end gap-1 opacity-0 group-hover:opacity-100 transition-opacity duration-150">
-              {/* Copy button */}
-              <Button
-                type="button"
-                aria-label={copied ? 'Copied!' : 'Copy as Markdown'}
-                title={copied ? 'Copied!' : 'Copy as Markdown'}
-                variant="icon"
-                size="icon"
-                onClick={handleCopy}
-                className="pointer-events-auto p-2 bg-muted h-8 w-8"
-              >
-                {copied ? (
-                  <Check className="w-4 h-4 text-success" />
-                ) : (
-                  <Clipboard className="w-4 h-4 text-muted-foreground" />
-                )}
-              </Button>
-              {/* Edit button - only if onEdit provided */}
-              {onEdit && (
-                <Button
-                  type="button"
-                  aria-label="Edit"
-                  title="Edit"
-                  variant="icon"
-                  size="icon"
-                  onClick={onEdit}
-                  className="pointer-events-auto p-2 bg-muted h-8 w-8"
-                >
-                  <Pencil className="w-4 h-4 text-muted-foreground" />
-                </Button>
-              )}
-              {/* Delete button - only if onDelete provided */}
-              {onDelete && (
-                <Button
-                  type="button"
-                  aria-label="Delete"
-                  title="Delete"
-                  variant="icon"
-                  size="icon"
-                  onClick={onDelete}
-                  className="pointer-events-auto p-2 bg-muted h-8 w-8"
-                >
-                  <Trash2 className="w-4 h-4 text-muted-foreground" />
-                </Button>
-              )}
-            </div>
-          </div>
-          {editorContent}
-        </div>
-      );
-    }
 
     return editorContent;
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -550,9 +550,18 @@ importers:
       react-i18next:
         specifier: ^15.7.4
         version: 15.7.4(i18next@25.6.0(typescript@5.9.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.2)
+      react-markdown:
+        specifier: ^10.1.0
+        version: 10.1.0(@types/react@18.3.23)(react@18.3.1)
       react-virtuoso:
         specifier: ^4.14.0
         version: 4.14.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      rehype-highlight:
+        specifier: ^7.0.2
+        version: 7.0.2
+      remark-gfm:
+        specifier: ^4.0.1
+        version: 4.0.1
       tailwind-merge:
         specifier: ^3.3.1
         version: 3.3.1
@@ -2526,6 +2535,12 @@ packages:
   '@types/babel__traverse@7.20.7':
     resolution: {integrity: sha512-dkO5fhS7+/oos4ciWxyEyjWe48zmG6wbCheo/G2ZnHx4fs3EU6YC6UM8rk56gAjNJ9P3MTH2jo5jb92/K6wbng==}
 
+  '@types/debug@4.1.13':
+    resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
+  '@types/estree-jsx@1.0.5':
+    resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -2540,6 +2555,9 @@ packages:
 
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
+  '@types/ms@2.1.0':
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
   '@types/node@20.19.37':
     resolution: {integrity: sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==}
@@ -2565,6 +2583,9 @@ packages:
 
   '@types/semver@7.7.0':
     resolution: {integrity: sha512-k107IF4+Xr7UHjwDc7Cfd6PRQfbdkiRabXGRjo07b4WyPahFBZCZ1sE+BNxYIJPPg73UkfOsVOLwqVc/6ETrIA==}
+
+  '@types/unist@2.0.11':
+    resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
@@ -2809,6 +2830,9 @@ packages:
   babel-plugin-react-compiler@1.0.0:
     resolution: {integrity: sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==}
 
+  bail@2.0.2:
+    resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
@@ -2859,6 +2883,12 @@ packages:
 
   character-entities-legacy@3.0.0:
     resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
+
+  character-entities@2.0.2:
+    resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
+
+  character-reference-invalid@2.0.1:
+    resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
 
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
@@ -2969,6 +2999,9 @@ packages:
   decode-formdata@0.9.0:
     resolution: {integrity: sha512-q5uwOjR3Um5YD+ZWPOF/1sGHVW9A5rCrRwITQChRXlmPkxDFBqCm4jNTIVdGHNH9OnR+V9MoZVgRhsFb+ARbUw==}
 
+  decode-named-character-reference@1.3.0:
+    resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
+
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
@@ -3048,6 +3081,10 @@ packages:
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
+
+  escape-string-regexp@5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
 
   eslint-config-prettier@10.1.5:
     resolution: {integrity: sha512-zc1UmCpNltmVY34vuLRV61r1K27sWuX39E+uyUnY8xS2Bex88VV9cugG+UZbRSRGtGyFboj+D8JODyme1plMpw==}
@@ -3146,9 +3183,15 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-util-is-identifier-name@3.0.0:
+    resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
   fancy-ansi@0.1.3:
     resolution: {integrity: sha512-tRQVTo5jjdSIiydqgzIIEZpKddzSsfGLsSVt6vWdjVm7fbvDTiQkyoPu6Z3dIPlAM4OZk0jP5jmTCX4G8WGgBw==}
@@ -3306,8 +3349,17 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  hast-util-is-element@3.0.0:
+    resolution: {integrity: sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==}
+
   hast-util-to-html@9.0.5:
     resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
+
+  hast-util-to-jsx-runtime@2.3.6:
+    resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
+
+  hast-util-to-text@4.0.2:
+    resolution: {integrity: sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==}
 
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
@@ -3324,6 +3376,9 @@ packages:
 
   html-parse-stringify@3.0.1:
     resolution: {integrity: sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==}
+
+  html-url-attributes@3.0.1:
+    resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
 
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
@@ -3365,6 +3420,15 @@ packages:
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
+  inline-style-parser@0.2.7:
+    resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
+
+  is-alphabetical@2.0.1:
+    resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
+
+  is-alphanumerical@2.0.1:
+    resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
+
   is-binary-path@2.1.0:
     resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
     engines: {node: '>=8'}
@@ -3372,6 +3436,9 @@ packages:
   is-core-module@2.16.1:
     resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
     engines: {node: '>= 0.4'}
+
+  is-decimal@2.0.1:
+    resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
 
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
@@ -3385,6 +3452,9 @@ packages:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
 
+  is-hexadecimal@2.0.1:
+    resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
+
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
@@ -3392,6 +3462,10 @@ packages:
   is-path-inside@3.0.3:
     resolution: {integrity: sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==}
     engines: {node: '>=8'}
+
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
 
   isbot@5.1.35:
     resolution: {integrity: sha512-waFfC72ZNfwLLuJ2iLaoVaqcNo+CAaLR7xCpAn0Y5WfGzkNHv7ZN39Vbi1y+kb+Zs46XHOX3tZNExroFUPX+Kg==}
@@ -3489,6 +3563,9 @@ packages:
   lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
 
+  longest-streak@3.1.0:
+    resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
@@ -3524,6 +3601,9 @@ packages:
     resolution: {integrity: sha512-ISQTe55T2ao7XtlAStud6qwYPZjE4GK1S/BeVPus4jrq6JuOnQ00YKQC581RWhR122W7msZV263KzVeLoqidyQ==}
     engines: {node: '>=12'}
 
+  markdown-table@3.0.4:
+    resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
   markdown-to-jsx@8.0.0:
     resolution: {integrity: sha512-hWEaRxeCDjes1CVUQqU+Ov0mCqBqkGhLKjL98KdbwHSgEWZZSJQeGlJQatVfeZ3RaxrfTrZZ3eczl2dhp5c/pA==}
     engines: {node: '>= 10'}
@@ -3533,27 +3613,138 @@ packages:
       react:
         optional: true
 
+  mdast-util-find-and-replace@3.0.2:
+    resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
+
+  mdast-util-from-markdown@2.0.3:
+    resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
+
+  mdast-util-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==}
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    resolution: {integrity: sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==}
+
+  mdast-util-gfm-table@2.0.0:
+    resolution: {integrity: sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==}
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    resolution: {integrity: sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==}
+
+  mdast-util-gfm@3.1.0:
+    resolution: {integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==}
+
+  mdast-util-mdx-expression@2.0.1:
+    resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
+
+  mdast-util-mdx-jsx@3.2.0:
+    resolution: {integrity: sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==}
+
+  mdast-util-mdxjs-esm@2.0.1:
+    resolution: {integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==}
+
+  mdast-util-phrasing@4.1.0:
+    resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
+
   mdast-util-to-hast@13.2.1:
     resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
+
+  mdast-util-to-markdown@2.1.2:
+    resolution: {integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==}
+
+  mdast-util-to-string@4.0.0:
+    resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
 
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
 
+  micromark-core-commonmark@2.0.3:
+    resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
+
+  micromark-extension-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==}
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    resolution: {integrity: sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==}
+
+  micromark-extension-gfm-table@2.1.1:
+    resolution: {integrity: sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==}
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    resolution: {integrity: sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==}
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    resolution: {integrity: sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==}
+
+  micromark-extension-gfm@3.0.0:
+    resolution: {integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==}
+
+  micromark-factory-destination@2.0.1:
+    resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
+
+  micromark-factory-label@2.0.1:
+    resolution: {integrity: sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==}
+
+  micromark-factory-space@2.0.1:
+    resolution: {integrity: sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==}
+
+  micromark-factory-title@2.0.1:
+    resolution: {integrity: sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==}
+
+  micromark-factory-whitespace@2.0.1:
+    resolution: {integrity: sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==}
+
   micromark-util-character@2.1.1:
     resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-chunked@2.0.1:
+    resolution: {integrity: sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==}
+
+  micromark-util-classify-character@2.0.1:
+    resolution: {integrity: sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==}
+
+  micromark-util-combine-extensions@2.0.1:
+    resolution: {integrity: sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==}
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    resolution: {integrity: sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==}
+
+  micromark-util-decode-string@2.0.1:
+    resolution: {integrity: sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==}
 
   micromark-util-encode@2.0.1:
     resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
 
+  micromark-util-html-tag-name@2.0.1:
+    resolution: {integrity: sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==}
+
+  micromark-util-normalize-identifier@2.0.1:
+    resolution: {integrity: sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==}
+
+  micromark-util-resolve-all@2.0.1:
+    resolution: {integrity: sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==}
+
   micromark-util-sanitize-uri@2.0.1:
     resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-subtokenize@2.1.0:
+    resolution: {integrity: sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==}
 
   micromark-util-symbol@2.0.1:
     resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
 
   micromark-util-types@2.0.2:
     resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
+
+  micromark@4.0.2:
+    resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
@@ -3657,6 +3848,9 @@ packages:
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
+
+  parse-entities@4.0.2:
+    resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -3842,6 +4036,12 @@ packages:
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
+  react-markdown@10.1.0:
+    resolution: {integrity: sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==}
+    peerDependencies:
+      '@types/react': '>=18'
+      react: '>=18'
+
   react-merge-refs@1.1.0:
     resolution: {integrity: sha512-alTKsjEL0dKH/ru1Iyn7vliS2QRcBp9zZPGoWxUOvRGWPUYgjo+V01is7p04It6KhgrzhJGnIj9GgX8W4bZoCQ==}
 
@@ -3937,6 +4137,21 @@ packages:
 
   regex@6.1.0:
     resolution: {integrity: sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==}
+
+  rehype-highlight@7.0.2:
+    resolution: {integrity: sha512-k158pK7wdC2qL3M5NcZROZ2tR/l7zOzjxXd5VGdcfIyoijjQqpHd3JKtYSBDpDZ38UI2WJWuFAtkMDxmx5kstA==}
+
+  remark-gfm@4.0.1:
+    resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
+
+  remark-parse@11.0.0:
+    resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
+
+  remark-rehype@11.1.2:
+    resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
+
+  remark-stringify@11.0.0:
+    resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -4081,6 +4296,12 @@ packages:
   style-mod@4.1.3:
     resolution: {integrity: sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==}
 
+  style-to-js@1.1.21:
+    resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
+
+  style-to-object@1.0.14:
+    resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
+
   sucrase@3.35.0:
     resolution: {integrity: sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -4161,6 +4382,9 @@ packages:
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
 
+  trough@2.2.0:
+    resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
+
   ts-api-utils@1.4.3:
     resolution: {integrity: sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==}
     engines: {node: '>=16'}
@@ -4196,6 +4420,12 @@ packages:
 
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+
+  unified@11.0.5:
+    resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
+
+  unist-util-find-after@5.0.0:
+    resolution: {integrity: sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==}
 
   unist-util-is@6.0.1:
     resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
@@ -6275,6 +6505,14 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
+  '@types/debug@4.1.13':
+    dependencies:
+      '@types/ms': 2.1.0
+
+  '@types/estree-jsx@1.0.5':
+    dependencies:
+      '@types/estree': 1.0.8
+
   '@types/estree@1.0.8': {}
 
   '@types/hast@3.0.4':
@@ -6288,6 +6526,8 @@ snapshots:
   '@types/mdast@4.0.4':
     dependencies:
       '@types/unist': 3.0.3
+
+  '@types/ms@2.1.0': {}
 
   '@types/node@20.19.37':
     dependencies:
@@ -6314,6 +6554,8 @@ snapshots:
       csstype: 3.1.3
 
   '@types/semver@7.7.0': {}
+
+  '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
 
@@ -6599,6 +6841,8 @@ snapshots:
     dependencies:
       '@babel/types': 7.27.6
 
+  bail@2.0.2: {}
+
   balanced-match@1.0.2: {}
 
   binary-extensions@2.3.0: {}
@@ -6646,6 +6890,10 @@ snapshots:
   character-entities-html4@2.1.0: {}
 
   character-entities-legacy@3.0.0: {}
+
+  character-entities@2.0.2: {}
+
+  character-reference-invalid@2.0.1: {}
 
   chokidar@3.6.0:
     dependencies:
@@ -6776,6 +7024,10 @@ snapshots:
 
   decode-formdata@0.9.0: {}
 
+  decode-named-character-reference@1.3.0:
+    dependencies:
+      character-entities: 2.0.2
+
   deep-is@0.1.4: {}
 
   dequal@2.0.3: {}
@@ -6855,6 +7107,8 @@ snapshots:
   escape-string-regexp@1.0.5: {}
 
   escape-string-regexp@4.0.0: {}
+
+  escape-string-regexp@5.0.0: {}
 
   eslint-config-prettier@10.1.5(eslint@8.57.1):
     dependencies:
@@ -6978,7 +7232,11 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-util-is-identifier-name@3.0.0: {}
+
   esutils@2.0.3: {}
+
+  extend@3.0.2: {}
 
   fancy-ansi@0.1.3:
     dependencies:
@@ -7128,6 +7386,10 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hast-util-is-element@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
   hast-util-to-html@9.0.5:
     dependencies:
       '@types/hast': 3.0.4
@@ -7141,6 +7403,33 @@ snapshots:
       space-separated-tokens: 2.0.2
       stringify-entities: 4.0.4
       zwitch: 2.0.4
+
+  hast-util-to-jsx-runtime@2.3.6:
+    dependencies:
+      '@types/estree': 1.0.8
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      comma-separated-tokens: 2.0.3
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      hast-util-whitespace: 3.0.0
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+      style-to-js: 1.1.21
+      unist-util-position: 5.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  hast-util-to-text@4.0.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      hast-util-is-element: 3.0.0
+      unist-util-find-after: 5.0.0
 
   hast-util-whitespace@3.0.0:
     dependencies:
@@ -7157,6 +7446,8 @@ snapshots:
   html-parse-stringify@3.0.1:
     dependencies:
       void-elements: 3.1.0
+
+  html-url-attributes@3.0.1: {}
 
   html-void-elements@3.0.0: {}
 
@@ -7195,6 +7486,15 @@ snapshots:
 
   inherits@2.0.4: {}
 
+  inline-style-parser@0.2.7: {}
+
+  is-alphabetical@2.0.1: {}
+
+  is-alphanumerical@2.0.1:
+    dependencies:
+      is-alphabetical: 2.0.1
+      is-decimal: 2.0.1
+
   is-binary-path@2.1.0:
     dependencies:
       binary-extensions: 2.3.0
@@ -7202,6 +7502,8 @@ snapshots:
   is-core-module@2.16.1:
     dependencies:
       hasown: 2.0.2
+
+  is-decimal@2.0.1: {}
 
   is-extglob@2.1.1: {}
 
@@ -7211,9 +7513,13 @@ snapshots:
     dependencies:
       is-extglob: 2.1.1
 
+  is-hexadecimal@2.0.1: {}
+
   is-number@7.0.0: {}
 
   is-path-inside@3.0.3: {}
+
+  is-plain-obj@4.1.0: {}
 
   isbot@5.1.35: {}
 
@@ -7290,6 +7596,8 @@ snapshots:
 
   lodash@4.17.21: {}
 
+  longest-streak@3.1.0: {}
+
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
@@ -7324,9 +7632,136 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
 
+  markdown-table@3.0.4: {}
+
   markdown-to-jsx@8.0.0(react@18.3.1):
     optionalDependencies:
       react: 18.3.1
+
+  mdast-util-find-and-replace@3.0.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      escape-string-regexp: 5.0.0
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
+  mdast-util-from-markdown@2.0.3:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      mdast-util-to-string: 4.0.0
+      micromark: 4.0.2
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-decode-string: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-find-and-replace: 3.0.2
+      micromark-util-character: 2.1.1
+
+  mdast-util-gfm-footnote@2.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      micromark-util-normalize-identifier: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-table@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      markdown-table: 3.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm@3.1.0:
+    dependencies:
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-gfm-autolink-literal: 2.0.1
+      mdast-util-gfm-footnote: 2.1.0
+      mdast-util-gfm-strikethrough: 2.0.0
+      mdast-util-gfm-table: 2.0.0
+      mdast-util-gfm-task-list-item: 2.0.0
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-expression@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-jsx@3.2.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      parse-entities: 4.0.2
+      stringify-entities: 4.0.4
+      unist-util-stringify-position: 4.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdxjs-esm@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-phrasing@4.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      unist-util-is: 6.0.1
 
   mdast-util-to-hast@13.2.1:
     dependencies:
@@ -7340,14 +7775,175 @@ snapshots:
       unist-util-visit: 5.1.0
       vfile: 6.0.3
 
+  mdast-util-to-markdown@2.1.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      longest-streak: 3.1.0
+      mdast-util-phrasing: 4.1.0
+      mdast-util-to-string: 4.0.0
+      micromark-util-classify-character: 2.0.1
+      micromark-util-decode-string: 2.0.1
+      unist-util-visit: 5.1.0
+      zwitch: 2.0.4
+
+  mdast-util-to-string@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+
   merge2@1.4.1: {}
+
+  micromark-core-commonmark@2.0.3:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-factory-destination: 2.0.1
+      micromark-factory-label: 2.0.1
+      micromark-factory-space: 2.0.1
+      micromark-factory-title: 2.0.1
+      micromark-factory-whitespace: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-html-tag-name: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-footnote@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-table@2.1.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm@3.0.0:
+    dependencies:
+      micromark-extension-gfm-autolink-literal: 2.1.0
+      micromark-extension-gfm-footnote: 2.1.0
+      micromark-extension-gfm-strikethrough: 2.1.0
+      micromark-extension-gfm-table: 2.1.1
+      micromark-extension-gfm-tagfilter: 2.0.0
+      micromark-extension-gfm-task-list-item: 2.1.0
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-destination@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-label@2.0.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-space@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-title@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-whitespace@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
 
   micromark-util-character@2.1.1:
     dependencies:
       micromark-util-symbol: 2.0.1
       micromark-util-types: 2.0.2
 
+  micromark-util-chunked@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-classify-character@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-combine-extensions@2.0.1:
+    dependencies:
+      micromark-util-chunked: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-decode-string@2.0.1:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      micromark-util-character: 2.1.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-symbol: 2.0.1
+
   micromark-util-encode@2.0.1: {}
+
+  micromark-util-html-tag-name@2.0.1: {}
+
+  micromark-util-normalize-identifier@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-resolve-all@2.0.1:
+    dependencies:
+      micromark-util-types: 2.0.2
 
   micromark-util-sanitize-uri@2.0.1:
     dependencies:
@@ -7355,9 +7951,38 @@ snapshots:
       micromark-util-encode: 2.0.1
       micromark-util-symbol: 2.0.1
 
+  micromark-util-subtokenize@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
   micromark-util-symbol@2.0.1: {}
 
   micromark-util-types@2.0.2: {}
+
+  micromark@4.0.2:
+    dependencies:
+      '@types/debug': 4.1.13
+      debug: 4.4.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-encode: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   micromatch@4.0.8:
     dependencies:
@@ -7450,6 +8075,16 @@ snapshots:
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
+
+  parse-entities@4.0.2:
+    dependencies:
+      '@types/unist': 2.0.11
+      character-entities-legacy: 3.0.0
+      character-reference-invalid: 2.0.1
+      decode-named-character-reference: 1.3.0
+      is-alphanumerical: 2.0.1
+      is-decimal: 2.0.1
+      is-hexadecimal: 2.0.1
 
   path-exists@4.0.0: {}
 
@@ -7596,6 +8231,24 @@ snapshots:
 
   react-is@18.3.1: {}
 
+  react-markdown@10.1.0(@types/react@18.3.23)(react@18.3.1):
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/react': 18.3.23
+      devlop: 1.1.0
+      hast-util-to-jsx-runtime: 2.3.6
+      html-url-attributes: 3.0.1
+      mdast-util-to-hast: 13.2.1
+      react: 18.3.1
+      remark-parse: 11.0.0
+      remark-rehype: 11.1.2
+      unified: 11.0.5
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
   react-merge-refs@1.1.0: {}
 
   react-redux@9.2.0(@types/react@18.3.23)(react@18.3.1)(redux@5.0.1):
@@ -7686,6 +8339,48 @@ snapshots:
   regex@6.1.0:
     dependencies:
       regex-utilities: 2.3.0
+
+  rehype-highlight@7.0.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-to-text: 4.0.2
+      lowlight: 3.3.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+
+  remark-gfm@4.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-gfm: 3.1.0
+      micromark-extension-gfm: 3.0.0
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-parse@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      micromark-util-types: 2.0.2
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-rehype@11.1.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      mdast-util-to-hast: 13.2.1
+      unified: 11.0.5
+      vfile: 6.0.3
+
+  remark-stringify@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-to-markdown: 2.1.2
+      unified: 11.0.5
 
   require-directory@2.1.1: {}
 
@@ -7825,6 +8520,14 @@ snapshots:
 
   style-mod@4.1.3: {}
 
+  style-to-js@1.1.21:
+    dependencies:
+      style-to-object: 1.0.14
+
+  style-to-object@1.0.14:
+    dependencies:
+      inline-style-parser: 0.2.7
+
   sucrase@3.35.0:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.8
@@ -7919,6 +8622,8 @@ snapshots:
 
   trim-lines@3.0.1: {}
 
+  trough@2.2.0: {}
+
   ts-api-utils@1.4.3(typescript@5.9.2):
     dependencies:
       typescript: 5.9.2
@@ -7946,6 +8651,21 @@ snapshots:
 
   undici-types@7.16.0:
     optional: true
+
+  unified@11.0.5:
+    dependencies:
+      '@types/unist': 3.0.3
+      bail: 2.0.2
+      devlop: 1.1.0
+      extend: 3.0.2
+      is-plain-obj: 4.1.0
+      trough: 2.2.0
+      vfile: 6.0.3
+
+  unist-util-find-after@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
 
   unist-util-is@6.0.1:
     dependencies:


### PR DESCRIPTION
## Summary

Replaces the Lexical-based read-only rendering in `WYSIWYGEditor` with `react-markdown` + `remark-gfm`, providing full GitHub Flavored Markdown support that Lexical's disabled mode lacked.

**Context:** The Lexical editor with `disabled=true` couldn't render GFM features like task lists, strikethrough, horizontal rules, or proper tables. This required a separate `MarkdownPreview` component (see #3125), creating duplicate rendering paths. This PR unifies read-only rendering under a single `react-markdown`-based component with full GFM support.

## Changes

- **`MarkdownReadOnly.tsx`** — New `react-markdown` renderer with `remark-gfm` and `rehype-highlight`, using custom component overrides for:
  - Images/attachments (`attachment://`, `pending-attachment://` URL patterns)
  - PR comment blocks (`gh-comment` fenced code language)
  - Component info blocks (`vk-component` fenced code language)
  - Clickable code spans (for diff path matching)
  - Full GFM element styling (tables, task lists, strikethrough, blockquotes, etc.)

- **Standalone renderers** extracted from Lexical decorator nodes (no Lexical dependency):
  - `ImageRenderer.tsx` — from `image-node.tsx`
  - `AttachmentRenderer.tsx` — from `attachment-node.tsx`
  - `ComponentInfoRenderer.tsx` — from `component-info-node.tsx`

- **`ReadOnlyStaticToolbar.tsx`** — Lexical-free toolbar for read-only mode; all buttons call `onRequestEdit()` to switch to edit mode

- **`WYSIWYGEditor.tsx`** — When `disabled=true`, renders `MarkdownReadOnly` instead of a full Lexical editor tree. Edit mode remains unchanged. Preview mode in edit also uses `MarkdownReadOnly`.

- **New dependencies** in `packages/ui`: `react-markdown`, `remark-gfm`, `rehype-highlight`

## Implementation notes

- This is **Phase 1** of a larger migration: read-only mode now uses `react-markdown`, while edit mode still uses Lexical. Future phases will replace Lexical edit mode with CodeMirror 6.
- The `ReadOnlyStaticToolbar` was needed because `StaticToolbarPlugin` calls `useLexicalComposerContext()` internally, which would crash without a `<LexicalComposer>` parent in the new Lexical-free read-only path.
- All custom content types (images, attachments, PR comments, component info) are handled via react-markdown's `components` prop, mapping URL patterns and fenced code block languages to the appropriate standalone renderers.

---

This PR was written using [Vibe Kanban](https://vibekanban.com)