### PR TITLE
fix(relay): increase yamux window size and write timeout to prevent stream failures on slow connections (Vibe Kanban)

### DIFF
--- a/crates/relay-tunnel-core/src/client.rs
+++ b/crates/relay-tunnel-core/src/client.rs
@@ -12,9 +12,9 @@ use hyper_util::rt::TokioIo;
 use tokio::net::TcpStream;
 use tokio_tungstenite::tungstenite::client::IntoClientRequest;
 use tokio_util::sync::CancellationToken;
-use tokio_yamux::{Config as YamuxConfig, Session};
+use tokio_yamux::Session;
 
-use crate::{tls::ws_connector, ws_io::tungstenite_ws_stream_io};
+use crate::{tls::ws_connector, ws_io::tungstenite_ws_stream_io, yamux_config};
 
 pub struct RelayClientConfig {
     pub ws_url: String,
@@ -45,7 +45,7 @@ pub async fn start_relay_client(config: RelayClientConfig) -> anyhow::Result<()>
             .context("Failed to connect relay control channel")?;
 
     let ws_io = tungstenite_ws_stream_io(ws_stream);
-    let mut session = Session::new_client(ws_io, YamuxConfig::default());
+    let mut session = Session::new_client(ws_io, yamux_config());
     let mut control = session.control();
 
     tracing::debug!("Relay control channel connected");

--- a/crates/relay-tunnel-core/src/lib.rs
+++ b/crates/relay-tunnel-core/src/lib.rs
@@ -1,7 +1,22 @@
+use std::time::Duration;
+
+use tokio_yamux::Config as YamuxConfig;
+
 pub mod client;
 pub mod server;
 pub mod tls;
 pub mod ws_io;
+
+/// Shared yamux configuration for both client and server sides of the relay tunnel.
+///
+/// Increases the stream window size and write timeout over the defaults (256 KB / 10s)
+/// to handle large HTTP responses over slow connections without triggering write timeouts.
+pub(crate) fn yamux_config() -> YamuxConfig {
+    let mut config = YamuxConfig::default();
+    config.max_stream_window_size = 1024 * 1024; // 1 MB (default: 256 KB)
+    config.connection_write_timeout = Duration::from_secs(30); // (default: 10s)
+    config
+}
 
 /// Convert an HTTP(S) URL to its WebSocket equivalent (ws:// or wss://).
 pub fn http_to_ws_url(http_url: &str) -> anyhow::Result<String> {

--- a/crates/relay-tunnel-core/src/server.rs
+++ b/crates/relay-tunnel-core/src/server.rs
@@ -10,9 +10,9 @@ use futures_util::StreamExt;
 use hyper::{client::conn::http1 as client_http1, upgrade};
 use hyper_util::rt::TokioIo;
 use tokio::sync::Mutex;
-use tokio_yamux::{Config as YamuxConfig, Control, Session};
+use tokio_yamux::{Control, Session};
 
-use crate::ws_io::axum_ws_stream_io;
+use crate::{ws_io::axum_ws_stream_io, yamux_config};
 
 pub type SharedControl = Arc<Mutex<Control>>;
 
@@ -26,7 +26,7 @@ where
     Fut: Future<Output = ()>,
 {
     let ws_io = axum_ws_stream_io(socket);
-    let mut session = Session::new_server(ws_io, YamuxConfig::default());
+    let mut session = Session::new_server(ws_io, yamux_config());
     let control = Arc::new(Mutex::new(session.control()));
 
     on_connected(control).await;


### PR DESCRIPTION
## Summary

Fixes "Yamux stream server connection failed" errors that occur when proxying large HTTP responses (>256KB) over slow connections through the relay tunnel.

## Problem

The relay tunnel multiplexes HTTP requests over yamux streams inside a WebSocket. The default yamux configuration uses a **256KB flow control window** and a **10s write timeout**. When a response body exceeds 256KB, the client must wait for a `WINDOW_UPDATE` frame from the relay server before it can continue writing. On slow connections (e.g., mobile/throttled networks), this round-trip can exceed 10s, causing a write timeout that kills the stream.

**Reproduction**: Send a request through the relay for any endpoint returning >256KB (e.g., a Vite JS chunk), with the browser throttled to Slow 4G. The yamux stream fails with "Yamux stream server connection failed".

## Changes

Replaces `YamuxConfig::default()` with a shared `yamux_config()` function on both the client and server sides of the tunnel:

- **`max_stream_window_size`**: 256 KB → **1 MB** — allows larger responses to be written without blocking on flow control
- **`connection_write_timeout`**: 10s → **30s** — tolerates slow consumer round-trips without killing the stream

These values are conservative compared to libp2p's yamux implementation which auto-tunes up to 16MB.

## Files changed

- `crates/relay-tunnel-core/src/lib.rs` — new shared `yamux_config()` function
- `crates/relay-tunnel-core/src/client.rs` — use `yamux_config()` for client session
- `crates/relay-tunnel-core/src/server.rs` — use `yamux_config()` for server session

- [x] tested

This PR was written using [Vibe Kanban](https://vibekanban.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts yamux session configuration (window size/timeout) shared by client and server; main behavioral impact is altered flow control and timeout characteristics under load/slow links.
> 
> **Overview**
> Reduces relay tunnel stream failures on slow connections by introducing a shared `yamux_config()` and using it for both client and server yamux sessions.
> 
> The config increases `max_stream_window_size` to **1MB** and `connection_write_timeout` to **30s**, replacing `YamuxConfig::default()` on both sides.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f764723e7dde1747afc05559052f8bb13b4dce5f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->