### PR TITLE
fix(relay): strip relay signing headers from preview proxy requests (Vibe Kanban)

### DIFF
--- a/crates/preview-proxy/src/proxy_common.rs
+++ b/crates/preview-proxy/src/proxy_common.rs
@@ -14,6 +14,15 @@ pub const SKIP_REQUEST_HEADERS: &[&str] = &[
     "sec-websocket-extensions",
     "accept-encoding",
     "origin",
+    // Relay signing headers must not leak into preview dev servers. When a VK
+    // instance is the preview target, forwarding these causes it to treat the
+    // request as a relay request and reject it (the preview's signing service
+    // has no knowledge of the session).
+    "x-vk-relayed",
+    "x-vk-sig-session",
+    "x-vk-sig-ts",
+    "x-vk-sig-nonce",
+    "x-vk-sig-signature",
 ];
 
 pub fn normalized_proxy_path(path: &str) -> &str {


### PR DESCRIPTION
## Summary

Fixes 401 errors when previewing a Vibe Kanban instance inside Vibe Kanban via remote relay.

When a preview target is itself a VK instance, the preview proxy was forwarding `x-vk-relayed` and `x-vk-sig-*` headers to the dev server. The target VK's signing middleware interpreted these as relay requests and rejected them because its `RelaySigningService` had no knowledge of the signing session — it was validated by the host, not the preview.

## What changed

Added relay signing headers (`x-vk-relayed`, `x-vk-sig-session`, `x-vk-sig-ts`, `x-vk-sig-nonce`, `x-vk-sig-signature`) to the `SKIP_REQUEST_HEADERS` list in `preview-proxy/src/proxy_common.rs`. This strips them before forwarding requests to any preview dev server.

## Request flow (before fix)

```
Browser → Preview Proxy (subdomain routing)
  → Host Relay Proxy → RelayHostTransport signs → Relay Tunnel → Target Host
    → Signing middleware verifies ✅
    → Preview handler proxies to localhost:3000 (forwarding all headers)
      → Target VK's signing middleware sees x-vk-relayed: 1
      → Looks up signing session → not found ❌ → 401
```

The signing session was registered on the host's signing service, not on the preview VK's signing service (a separate process). These headers should never be forwarded to preview dev servers — they are internal to the relay transport layer.

- [x] tested

---

This PR was written using [Vibe Kanban](https://vibekanban.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is limited to filtering a few additional request headers before proxying, reducing accidental leakage without affecting core routing or auth flows beyond previews.
> 
> **Overview**
> Prevents relay transport signing headers from being forwarded by the preview proxy to upstream dev servers.
> 
> Adds `x-vk-relayed` and `x-vk-sig-*` headers to `SKIP_REQUEST_HEADERS`, so `should_forward_request_header` filters them out during request forwarding to avoid preview targets misinterpreting requests as relay-signed and returning `401`s.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ee5c757bbd82138a39f1a4a6ddd955572a610386. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->