### PR TITLE
fix: link issue-scoped workspaces during create/start

### DIFF
--- a/crates/server/src/routes/workspaces/create.rs
+++ b/crates/server/src/routes/workspaces/create.rs
@@ -15,8 +15,9 @@ use uuid::Uuid;
 use crate::{
     DeploymentImpl,
     error::ApiError,
-    routes::workspaces::attachments::{
-        ImportedIssueAttachment, import_issue_attachments_from_remote,
+    routes::workspaces::{
+        attachments::{ImportedIssueAttachment, import_issue_attachments_from_remote},
+        links::sync_workspace_to_issue,
     },
 };
 
@@ -238,6 +239,10 @@ pub async fn create_and_start_workspace(
         .workspace_manager()
         .load_managed_workspace(create_workspace_record(&deployment, name).await?)
         .await?;
+    let remote_client = match linked_issue.as_ref() {
+        Some(_) => Some(deployment.remote_client()?),
+        None => None,
+    };
 
     for repo in &repos {
         managed_workspace
@@ -250,9 +255,7 @@ pub async fn create_and_start_workspace(
         managed_workspace.associate_attachments(ids).await?;
     }
 
-    if let Some(linked_issue) = &linked_issue
-        && let Ok(client) = deployment.remote_client()
-    {
+    if let (Some(linked_issue), Some(client)) = (linked_issue.as_ref(), remote_client.as_ref()) {
         match import_issue_attachments_from_remote(
             &client,
             deployment.file(),
@@ -294,6 +297,17 @@ pub async fn create_and_start_workspace(
 
     let workspace = managed_workspace.workspace.clone();
     tracing::info!("Created workspace {}", workspace.id);
+
+    if let (Some(linked_issue), Some(client)) = (linked_issue.as_ref(), remote_client.as_ref()) {
+        sync_workspace_to_issue(
+            &deployment,
+            client,
+            &workspace,
+            linked_issue.remote_project_id,
+            linked_issue.issue_id,
+        )
+        .await?;
+    }
 
     let execution_process = deployment
         .container()

--- a/crates/server/src/routes/workspaces/links.rs
+++ b/crates/server/src/routes/workspaces/links.rs
@@ -1,4 +1,7 @@
-use api_types::{CreateWorkspaceRequest, PullRequestStatus, UpsertPullRequestRequest};
+use api_types::{
+    CreateWorkspaceRequest, PullRequestStatus, UpsertPullRequestRequest,
+    Workspace as RemoteWorkspace,
+};
 use axum::{
     Extension, Json, Router,
     extract::{Path as AxumPath, State},
@@ -9,7 +12,11 @@ use axum::{
 use db::models::{merge::MergeStatus, pull_request::PullRequest, workspace::Workspace};
 use deployment::Deployment;
 use serde::Deserialize;
-use services::services::{diff_stream, remote_client::RemoteClientError, remote_sync};
+use services::services::{
+    diff_stream,
+    remote_client::{RemoteClient, RemoteClientError},
+    remote_sync,
+};
 use utils::response::ApiResponse;
 use uuid::Uuid;
 
@@ -21,28 +28,96 @@ pub struct LinkWorkspaceRequest {
     pub issue_id: Uuid,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RemoteWorkspaceSyncAction {
+    Create,
+    Update,
+}
+
+fn classify_remote_workspace_sync(
+    existing_workspace: Option<&RemoteWorkspace>,
+    project_id: Uuid,
+    issue_id: Uuid,
+) -> Result<RemoteWorkspaceSyncAction, ApiError> {
+    let Some(existing_workspace) = existing_workspace else {
+        return Ok(RemoteWorkspaceSyncAction::Create);
+    };
+
+    if existing_workspace.project_id == project_id && existing_workspace.issue_id == Some(issue_id)
+    {
+        return Ok(RemoteWorkspaceSyncAction::Update);
+    }
+
+    Err(ApiError::Conflict(
+        "This workspace is already linked to another issue.".to_string(),
+    ))
+}
+
+pub async fn sync_workspace_to_issue(
+    deployment: &DeploymentImpl,
+    client: &RemoteClient,
+    workspace: &Workspace,
+    project_id: Uuid,
+    issue_id: Uuid,
+) -> Result<(), ApiError> {
+    let existing_workspace = match client.get_workspace_by_local_id(workspace.id).await {
+        Ok(workspace) => Some(workspace),
+        Err(RemoteClientError::Http { status: 404, .. }) => None,
+        Err(error) => return Err(error.into()),
+    };
+
+    let stats =
+        diff_stream::compute_diff_stats(&deployment.db().pool, deployment.git(), workspace).await;
+    let files_changed = stats.as_ref().map(|s| s.files_changed as i32);
+    let lines_added = stats.as_ref().map(|s| s.lines_added as i32);
+    let lines_removed = stats.as_ref().map(|s| s.lines_removed as i32);
+
+    match classify_remote_workspace_sync(existing_workspace.as_ref(), project_id, issue_id)? {
+        RemoteWorkspaceSyncAction::Create => {
+            client
+                .create_workspace(CreateWorkspaceRequest {
+                    project_id,
+                    local_workspace_id: workspace.id,
+                    issue_id,
+                    name: workspace.name.clone(),
+                    archived: Some(workspace.archived),
+                    files_changed,
+                    lines_added,
+                    lines_removed,
+                })
+                .await?;
+        }
+        RemoteWorkspaceSyncAction::Update => {
+            client
+                .update_workspace(
+                    workspace.id,
+                    Some(workspace.name.clone()),
+                    Some(workspace.archived),
+                    files_changed,
+                    lines_added,
+                    lines_removed,
+                )
+                .await?;
+        }
+    }
+
+    Ok(())
+}
+
 pub async fn link_workspace(
     Extension(workspace): Extension<Workspace>,
     State(deployment): State<DeploymentImpl>,
     Json(payload): Json<LinkWorkspaceRequest>,
 ) -> Result<ResponseJson<ApiResponse<()>>, ApiError> {
     let client = deployment.remote_client()?;
-
-    let stats =
-        diff_stream::compute_diff_stats(&deployment.db().pool, deployment.git(), &workspace).await;
-
-    client
-        .create_workspace(CreateWorkspaceRequest {
-            project_id: payload.project_id,
-            local_workspace_id: workspace.id,
-            issue_id: payload.issue_id,
-            name: workspace.name.clone(),
-            archived: Some(workspace.archived),
-            files_changed: stats.as_ref().map(|s| s.files_changed as i32),
-            lines_added: stats.as_ref().map(|s| s.lines_added as i32),
-            lines_removed: stats.as_ref().map(|s| s.lines_removed as i32),
-        })
-        .await?;
+    sync_workspace_to_issue(
+        &deployment,
+        &client,
+        &workspace,
+        payload.project_id,
+        payload.issue_id,
+    )
+    .await?;
 
     {
         let pool = deployment.db().pool.clone();
@@ -113,4 +188,61 @@ pub fn router(deployment: &DeploymentImpl) -> Router<DeploymentImpl> {
     let delete_router = Router::new().route("/", delete(unlink_workspace));
 
     post_router.merge(delete_router)
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::Utc;
+
+    use super::*;
+
+    fn make_remote_workspace(project_id: Uuid, issue_id: Option<Uuid>) -> RemoteWorkspace {
+        RemoteWorkspace {
+            id: Uuid::new_v4(),
+            project_id,
+            owner_user_id: Uuid::new_v4(),
+            issue_id,
+            local_workspace_id: Some(Uuid::new_v4()),
+            name: Some("Workspace".to_string()),
+            archived: false,
+            files_changed: None,
+            lines_added: None,
+            lines_removed: None,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn classify_remote_workspace_sync_creates_when_workspace_is_missing() {
+        let action = classify_remote_workspace_sync(None, Uuid::new_v4(), Uuid::new_v4()).unwrap();
+
+        assert_eq!(action, RemoteWorkspaceSyncAction::Create);
+    }
+
+    #[test]
+    fn classify_remote_workspace_sync_updates_when_issue_matches() {
+        let project_id = Uuid::new_v4();
+        let issue_id = Uuid::new_v4();
+        let existing_workspace = make_remote_workspace(project_id, Some(issue_id));
+
+        let action =
+            classify_remote_workspace_sync(Some(&existing_workspace), project_id, issue_id)
+                .unwrap();
+
+        assert_eq!(action, RemoteWorkspaceSyncAction::Update);
+    }
+
+    #[test]
+    fn classify_remote_workspace_sync_conflicts_when_issue_differs() {
+        let project_id = Uuid::new_v4();
+        let existing_workspace = make_remote_workspace(project_id, Some(Uuid::new_v4()));
+
+        let result =
+            classify_remote_workspace_sync(Some(&existing_workspace), project_id, Uuid::new_v4());
+
+        assert!(
+            matches!(result, Err(ApiError::Conflict(message)) if message == "This workspace is already linked to another issue.")
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #3250.

This change makes issue-scoped workspace creation persist the remote issue link during the backend create/start flow instead of relying on a second best-effort client request.

It also makes explicit workspace linking idempotent when the workspace is already linked to the same issue, while still returning a conflict if the workspace is already linked elsewhere.

## What changed

- added a shared server-side helper to sync a local workspace into the remote issue/workspace store
- called that helper from `create_and_start_workspace` whenever `linked_issue` is present
- updated `/api/workspaces/{id}/links` to reuse the same helper instead of always attempting a blind create
- added unit coverage for create-vs-update-vs-conflict link classification

## Why this fixes the bug

Before this patch, `CreateAndStartWorkspaceRequest` already carried `linked_issue`, but the backend ignored it for remote linkage. The issue page only showed workspaces present in the remote store, so a workspace could exist locally, run a session, and still be invisible on the issue page until someone manually POSTed to `/api/workspaces/{id}/links`.

After this patch, create/start ensures that the remote link exists before it reports success.

## Testing

- `cargo test -p server classify_remote_workspace_sync`
- `cargo check -p server`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds remote workspace create/update logic into the create/start path and changes link behavior to update-or-conflict based on existing remote state, which could affect workspace visibility and error handling across integrations.
> 
> **Overview**
> Issue-linked workspaces are now **synced to the remote issue/workspace store during `create_and_start_workspace`** (via new `sync_workspace_to_issue`), so the remote link exists immediately without relying on a follow-up client call.
> 
> `POST /api/workspaces/{id}/links` now reuses the same sync helper and becomes *idempotent*: it creates the remote workspace when missing, updates it when already linked to the same issue, and returns a `409 Conflict` when the workspace is linked to a different issue. Basic unit tests were added for the create/update/conflict classification.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 87f2c2cf1f627aa77eed1235f4777f57606cdc67. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->