### PR TITLE
server: surface nested git and worktree container errors

### DIFF
--- a/crates/server/src/error.rs
+++ b/crates/server/src/error.rs
@@ -51,13 +51,13 @@ pub enum ApiError {
     #[error(transparent)]
     Deployment(#[from] DeploymentError),
     #[error(transparent)]
-    Container(#[from] ContainerError),
+    Container(ContainerError),
     #[error(transparent)]
     Executor(#[from] ExecutorError),
     #[error(transparent)]
     Database(#[from] sqlx::Error),
     #[error(transparent)]
-    Worktree(#[from] WorktreeError),
+    Worktree(WorktreeError),
     #[error(transparent)]
     Config(#[from] ConfigError),
     #[error(transparent)]
@@ -134,6 +134,29 @@ impl From<WorkspaceManagerError> for ApiError {
                 ApiError::BadRequest("Workspace has no repositories configured".to_string())
             }
             WorkspaceManagerError::PartialCreation(msg) => ApiError::Conflict(msg),
+        }
+    }
+}
+
+impl From<WorktreeError> for ApiError {
+    fn from(err: WorktreeError) -> Self {
+        match err {
+            WorktreeError::GitService(e) => ApiError::GitService(e),
+            other => ApiError::Worktree(other),
+        }
+    }
+}
+
+impl From<ContainerError> for ApiError {
+    fn from(err: ContainerError) -> Self {
+        match err {
+            ContainerError::GitServiceError(e) => ApiError::GitService(e),
+            ContainerError::Workspace(e) => ApiError::Workspace(e),
+            ContainerError::Session(e) => ApiError::Session(e),
+            ContainerError::ExecutionProcess(e) => ApiError::ExecutionProcess(e),
+            ContainerError::ExecutorError(e) => ApiError::Executor(e),
+            ContainerError::Worktree(e) => e.into(),
+            other => ApiError::Container(other),
         }
     }
 }
@@ -291,52 +314,6 @@ fn remote_client_error(err: &RemoteClientError) -> ErrorInfo {
     }
 }
 
-fn git_service_error(err: &GitServiceError) -> ErrorInfo {
-    match err {
-        GitServiceError::MergeConflicts { message, .. } => {
-            ErrorInfo::conflict("GitServiceError", message.clone())
-        }
-        GitServiceError::RebaseInProgress => ErrorInfo::conflict(
-            "GitServiceError",
-            "A rebase is already in progress. Resolve conflicts or abort the rebase, then retry.",
-        ),
-        GitServiceError::BranchNotFound(branch) => ErrorInfo::not_found(
-            "GitServiceError",
-            format!(
-                "Branch '{}' not found. Try changing the target branch.",
-                branch
-            ),
-        ),
-        GitServiceError::BranchesDiverged(msg) => ErrorInfo::conflict(
-            "GitServiceError",
-            format!(
-                "{} Rebase onto the target branch first, then retry the merge.",
-                msg
-            ),
-        ),
-        GitServiceError::WorktreeDirty(branch, files) => ErrorInfo::conflict(
-            "GitServiceError",
-            format!(
-                "Branch '{}' has uncommitted changes ({}). Commit or revert them before retrying.",
-                branch, files
-            ),
-        ),
-        GitServiceError::GitCLI(git::GitCliError::AuthFailed(msg)) => ErrorInfo::with_status(
-            StatusCode::UNAUTHORIZED,
-            "GitServiceError",
-            format!(
-                "{}. Check your git credentials or SSH keys and try again.",
-                msg
-            ),
-        ),
-        _ => ErrorInfo::with_status(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "GitServiceError",
-            format!("Git operation failed: {}", err),
-        ),
-    }
-}
-
 impl IntoResponse for ApiError {
     fn into_response(self) -> Response {
         let info = match &self {
@@ -396,7 +373,51 @@ impl IntoResponse for ApiError {
             }
             ApiError::ExecutionProcess(_) => ErrorInfo::internal("ExecutionProcessError"),
 
-            ApiError::GitService(e) => git_service_error(e),
+            ApiError::GitService(GitServiceError::MergeConflicts { message, .. }) => {
+                ErrorInfo::conflict("GitServiceError", message.clone())
+            }
+            ApiError::GitService(GitServiceError::RebaseInProgress) => ErrorInfo::conflict(
+                "GitServiceError",
+                "A rebase is already in progress. Resolve conflicts or abort the rebase, then retry.",
+            ),
+            ApiError::GitService(GitServiceError::BranchNotFound(branch)) => ErrorInfo::not_found(
+                "GitServiceError",
+                format!(
+                    "Branch '{}' not found. Try changing the target branch.",
+                    branch
+                ),
+            ),
+            ApiError::GitService(GitServiceError::BranchesDiverged(msg)) => ErrorInfo::conflict(
+                "GitServiceError",
+                format!(
+                    "{} Rebase onto the target branch first, then retry the merge.",
+                    msg
+                ),
+            ),
+            ApiError::GitService(GitServiceError::WorktreeDirty(branch, files)) => {
+                ErrorInfo::conflict(
+                    "GitServiceError",
+                    format!(
+                        "Branch '{}' has uncommitted changes ({}). Commit or revert them before retrying.",
+                        branch, files
+                    ),
+                )
+            }
+            ApiError::GitService(GitServiceError::GitCLI(git::GitCliError::AuthFailed(msg))) => {
+                ErrorInfo::with_status(
+                    StatusCode::UNAUTHORIZED,
+                    "GitServiceError",
+                    format!(
+                        "{}. Check your git credentials or SSH keys and try again.",
+                        msg
+                    ),
+                )
+            }
+            ApiError::GitService(e) => ErrorInfo::with_status(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "GitServiceError",
+                format!("Git operation failed: {}", e),
+            ),
             ApiError::GitHost(_) => ErrorInfo::internal("GitHostError"),
 
             ApiError::File(FileError::TooLarge(size, max)) => ErrorInfo::with_status(
@@ -463,37 +484,15 @@ impl IntoResponse for ApiError {
             ),
 
             ApiError::Deployment(_) => ErrorInfo::internal("DeploymentError"),
-            ApiError::Container(err) => match err {
-                ContainerError::GitServiceError(err) => git_service_error(err),
-                ContainerError::Workspace(WorkspaceError::WorkspaceNotFound) => {
-                    ErrorInfo::not_found("ContainerError", "Workspace not found.")
-                }
-                ContainerError::Workspace(WorkspaceError::ValidationError(msg)) => {
-                    ErrorInfo::bad_request("ContainerError", msg.clone())
-                }
-                ContainerError::Workspace(WorkspaceError::BranchNotFound(branch)) => {
-                    ErrorInfo::not_found(
-                        "ContainerError",
-                        format!("Branch '{}' not found.", branch),
-                    )
-                }
-                ContainerError::ExecutorError(e) => ErrorInfo::with_status(
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    "ContainerError",
-                    format!("Executor error: {e}"),
-                ),
-                ContainerError::Worktree(WorktreeError::GitService(err)) => git_service_error(err),
-                ContainerError::Worktree(err) => ErrorInfo::with_status(
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    "WorktreeError",
-                    format!("Worktree operation failed: {}", err),
-                ),
-                _ => ErrorInfo::internal("ContainerError"),
-            },
+            ApiError::Container(_) => ErrorInfo::internal("ContainerError"),
             ApiError::Executor(_) => ErrorInfo::internal("ExecutorError"),
             ApiError::CommandBuilder(_) => ErrorInfo::internal("CommandBuildError"),
             ApiError::Database(_) => ErrorInfo::internal("DatabaseError"),
-            ApiError::Worktree(_) => ErrorInfo::internal("WorktreeError"),
+            ApiError::Worktree(err) => ErrorInfo::with_status(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "WorktreeError",
+                format!("Worktree operation failed: {}", err),
+            ),
             ApiError::Config(_) => ErrorInfo::internal("ConfigError"),
             ApiError::Io(_) => ErrorInfo::internal("IoError"),
             ApiError::Migration(MigrationError::Database(_)) => {


### PR DESCRIPTION
## Summary
- reuse the existing git service to API error mapping through a helper
- surface nested `ContainerError::GitServiceError` failures as concrete git errors
- surface nested worktree failures, including `WorktreeError::GitService(...)`, instead of flattening them to a generic internal error

## Why
When an existing workspace points at a stale repo path after a repo rename or path change, follow-up actions can fail deep in git/worktree resolution. Right now some of those failures are returned as a generic internal error, which makes the session failure hard to diagnose.

## Testing
- `cargo fmt --package server`
- `cargo check -p server`

Related to #3255.

This PR does not fix workspace repo rebinding. It only makes these failures actionable for the user and easier to debug.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to error conversion/mapping and HTTP response messaging, with no changes to core business logic or data handling; main risk is altered status/message surfaced to clients.
> 
> **Overview**
> Improves server API error propagation so failures occurring inside `ContainerError` and `WorktreeError` are surfaced as their underlying `GitServiceError`/workspace/session/executor errors instead of being flattened into generic internal errors.
> 
> Adds explicit `From<ContainerError>`/`From<WorktreeError>` mappings to unwrap nested causes (notably git failures), and adjusts response formatting to include a more specific worktree failure message while keeping generic handling for other container errors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 89658cd3818a301d6cb2a0edbd9e1e9f31b3e985. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->