### PR TITLE
fix(kanban): persist draft issues across navigation using scratch storage (Vibe Kanban)

### DIFF
--- a/packages/remote-web/src/routes/__root.tsx
+++ b/packages/remote-web/src/routes/__root.tsx
@@ -17,7 +17,6 @@ import { TerminalProvider } from "@/shared/providers/TerminalProvider";
 import { LogsPanelProvider } from "@/shared/providers/LogsPanelProvider";
 import { ActionsProvider } from "@/shared/providers/ActionsProvider";
 import { useAuth } from "@/shared/hooks/auth/useAuth";
-import { useKanbanIssueComposerScratch } from "@/shared/hooks/useKanbanIssueComposerScratch";
 import { useUiPreferencesScratch } from "@/shared/hooks/useUiPreferencesScratch";
 import { useWorkspaceContext } from "@/shared/hooks/useWorkspaceContext";
 import { AppNavigationProvider } from "@/shared/hooks/useAppNavigation";
@@ -109,7 +108,6 @@ function WorkspaceRouteProviders({ children }: { children: ReactNode }) {
 function RootLayout() {
   useSystemTheme();
   useUiPreferencesScratch();
-  useKanbanIssueComposerScratch();
   const { isSignedIn } = useAuth();
   const location = useLocation();
   const { hostId } = useParams({ strict: false });

--- a/packages/web-core/src/pages/kanban/KanbanIssuePanelContainer.tsx
+++ b/packages/web-core/src/pages/kanban/KanbanIssuePanelContainer.tsx
@@ -626,6 +626,7 @@ export function KanbanIssuePanelContainer({
 
     cancelDebouncedTitle();
     cancelDebouncedDescription();
+    cancelDebouncedIssueDraft();
     skipUnmountSaveRef.current = false;
 
     let nextCreateFormData: IssueFormData | null = null;
@@ -646,8 +647,7 @@ export function KanbanIssuePanelContainer({
           title: scratchDraft.title,
           description: scratchDraft.description ?? null,
           statusId: scratchDraft.status_id || createModeDefaults.statusId,
-          priority:
-            (scratchDraft.priority as IssuePriority | null) ?? null,
+          priority: (scratchDraft.priority as IssuePriority | null) ?? null,
           assigneeIds: scratchDraft.assignee_ids,
           tagIds: scratchDraft.tag_ids ?? createModeDefaults.tagIds,
           createDraftWorkspace:
@@ -682,6 +682,7 @@ export function KanbanIssuePanelContainer({
     selectedKanbanIssueId,
     cancelDebouncedTitle,
     cancelDebouncedDescription,
+    cancelDebouncedIssueDraft,
     createModeDefaults,
     issueComposerKey,
     isIssueDraftScratchLoading,
@@ -693,11 +694,15 @@ export function KanbanIssuePanelContainer({
   useEffect(() => {
     if (!kanbanCreateMode || !createFormData || !isCreateDraftDirty) return;
     debouncedSaveIssueDraft(createFormData);
+    return () => {
+      cancelDebouncedIssueDraft();
+    };
   }, [
     kanbanCreateMode,
     createFormData,
     isCreateDraftDirty,
     debouncedSaveIssueDraft,
+    cancelDebouncedIssueDraft,
   ]);
 
   // Flush pending draft save on unmount (e.g., navigation away).

--- a/packages/web-core/src/pages/kanban/KanbanIssuePanelContainer.tsx
+++ b/packages/web-core/src/pages/kanban/KanbanIssuePanelContainer.tsx
@@ -647,12 +647,8 @@ export function KanbanIssuePanelContainer({
           description: scratchDraft.description ?? null,
           statusId: scratchDraft.status_id || createModeDefaults.statusId,
           priority:
-            (scratchDraft.priority as IssuePriority | null) ??
-            createModeDefaults.priority,
-          assigneeIds:
-            scratchDraft.assignee_ids.length > 0
-              ? scratchDraft.assignee_ids
-              : createModeDefaults.assigneeIds,
+            (scratchDraft.priority as IssuePriority | null) ?? null,
+          assigneeIds: scratchDraft.assignee_ids,
           tagIds: scratchDraft.tag_ids ?? createModeDefaults.tagIds,
           createDraftWorkspace:
             scratchDraft.create_draft_workspace ??

--- a/packages/web-core/src/pages/kanban/KanbanIssuePanelContainer.tsx
+++ b/packages/web-core/src/pages/kanban/KanbanIssuePanelContainer.tsx
@@ -8,9 +8,14 @@ import {
 } from 'react';
 import { useDropzone } from 'react-dropzone';
 import { useTranslation } from 'react-i18next';
-import type { OrganizationMemberWithProfile } from 'shared/types';
+import type {
+  OrganizationMemberWithProfile,
+  DraftIssueData,
+} from 'shared/types';
+import { ScratchType } from 'shared/types';
 import type { IssuePriority } from 'shared/remote-types';
 import { useDebouncedCallback } from '@/shared/hooks/useDebouncedCallback';
+import { useScratch } from '@/shared/hooks/useScratch';
 import { useProjectContext } from '@/shared/hooks/useProjectContext';
 import { useOrgContext } from '@/shared/hooks/useOrgContext';
 import { useProjectWorkspaceCreateDraft } from '@/shared/hooks/useProjectWorkspaceCreateDraft';
@@ -61,7 +66,6 @@ import {
   patchKanbanIssueComposer,
   resetKanbanIssueComposer,
   useKanbanIssueComposer,
-  useKanbanIssueComposerStore,
 } from '@/shared/stores/useKanbanIssueComposerStore';
 
 interface KanbanIssuePanelContainerProps {
@@ -121,6 +125,17 @@ export function KanbanIssuePanelContainer({
   );
   const issueComposer = useKanbanIssueComposer(issueComposerKey);
   const kanbanCreateMode = issueComposer !== null;
+
+  // Persistent draft storage via the scratch system.
+  // On local-web this uses SQLite (WebSocket stream); on remote-web it uses
+  // localStorage — both survive navigation and port changes.
+  const {
+    scratch: issueDraftScratch,
+    updateScratch: updateIssueDraftScratch,
+    deleteScratch: deleteIssueDraftScratch,
+    isLoading: isIssueDraftScratchLoading,
+  } = useScratch(ScratchType.DRAFT_ISSUE, projectId);
+
   const createComposerInitial = issueComposer?.initial ?? null;
   const kanbanCreateDefaultStatusId = createComposerInitial?.statusId ?? null;
   const kanbanCreateDefaultPriority = createComposerInitial?.priority ?? null;
@@ -175,6 +190,44 @@ export function KanbanIssuePanelContainer({
 
     resetKanbanIssueComposer(issueComposerKey);
   }, [issueComposerKey]);
+
+  const saveIssueDraftToScratch = useCallback(
+    async (formData: IssueFormData) => {
+      try {
+        await updateIssueDraftScratch({
+          payload: {
+            type: 'DRAFT_ISSUE',
+            data: {
+              title: formData.title,
+              description: formData.description ?? null,
+              status_id: formData.statusId,
+              priority: formData.priority,
+              assignee_ids: formData.assigneeIds,
+              tag_ids: formData.tagIds,
+              create_draft_workspace: formData.createDraftWorkspace,
+              project_id: projectId,
+              parent_issue_id: createComposerInitial?.parentIssueId ?? null,
+            } satisfies DraftIssueData,
+          },
+        });
+      } catch (e) {
+        console.error(
+          '[KanbanIssuePanelContainer] Failed to save issue draft:',
+          e
+        );
+      }
+    },
+    [updateIssueDraftScratch, projectId, createComposerInitial?.parentIssueId]
+  );
+
+  const {
+    debounced: debouncedSaveIssueDraft,
+    cancel: cancelDebouncedIssueDraft,
+  } = useDebouncedCallback(saveIssueDraftToScratch, 500);
+
+  const createFormDataRef = useRef<IssueFormData | null>(null);
+  const saveIssueDraftToScratchRef = useRef(saveIssueDraftToScratch);
+  const skipUnmountSaveRef = useRef(false);
 
   const { isLoading: orgLoading, membersWithProfilesById } = useOrgContext();
 
@@ -287,6 +340,8 @@ export function KanbanIssuePanelContainer({
     createInitialKanbanIssuePanelFormState
   );
   const createFormData = formState.createFormData;
+  createFormDataRef.current = createFormData;
+  saveIssueDraftToScratchRef.current = saveIssueDraftToScratch;
 
   useEffect(() => {
     if (mode !== 'create') return;
@@ -559,47 +614,61 @@ export function KanbanIssuePanelContainer({
     const shouldSeedCreateForm = mode === 'create' && createFormData === null;
 
     if (!isNewIssue && !shouldSeedCreateForm) {
-      // Same issue - no reset needed
-      // (dropdown fields derive from server state, text fields preserve local edits)
       return;
     }
 
-    // Track the new issue ID
+    // Wait for scratch to finish loading before seeding create mode.
+    if (mode === 'create' && isIssueDraftScratchLoading) {
+      return;
+    }
+
     prevIssueIdRef.current = currentIssueId;
 
-    // Cancel any pending debounced saves when switching issues
     cancelDebouncedTitle();
     cancelDebouncedDescription();
+    skipUnmountSaveRef.current = false;
 
     let nextCreateFormData: IssueFormData | null = null;
     let restoredFromScratch = false;
 
     if (mode === 'create') {
-      // Check if the composer store has a saved draft (e.g., restored from
-      // localStorage on remote-web). Use it to seed the form instead of defaults.
-      const composerDraft =
-        useKanbanIssueComposerStore.getState().byKey[issueComposerKey]?.draft;
-      const hasSavedDraft =
-        composerDraft != null &&
-        (composerDraft.title !== '' || composerDraft.description != null);
+      const scratchDraft: DraftIssueData | undefined =
+        issueDraftScratch?.payload?.type === 'DRAFT_ISSUE'
+          ? issueDraftScratch.payload.data
+          : undefined;
+      const hasScratchDraft =
+        scratchDraft != null &&
+        scratchDraft.project_id === projectId &&
+        (scratchDraft.title !== '' || scratchDraft.description != null);
 
-      if (hasSavedDraft) {
+      if (hasScratchDraft) {
         nextCreateFormData = {
-          title: composerDraft.title,
-          description: composerDraft.description ?? null,
-          statusId: composerDraft.statusId ?? createModeDefaults.statusId,
+          title: scratchDraft.title,
+          description: scratchDraft.description ?? null,
+          statusId: scratchDraft.status_id || createModeDefaults.statusId,
           priority:
-            composerDraft.priority === undefined
-              ? createModeDefaults.priority
-              : composerDraft.priority,
+            (scratchDraft.priority as IssuePriority | null) ??
+            createModeDefaults.priority,
           assigneeIds:
-            composerDraft.assigneeIds ?? createModeDefaults.assigneeIds,
-          tagIds: composerDraft.tagIds ?? createModeDefaults.tagIds,
+            scratchDraft.assignee_ids.length > 0
+              ? scratchDraft.assignee_ids
+              : createModeDefaults.assigneeIds,
+          tagIds: scratchDraft.tag_ids ?? createModeDefaults.tagIds,
           createDraftWorkspace:
-            composerDraft.createDraftWorkspace ??
+            scratchDraft.create_draft_workspace ??
             createModeDefaults.createDraftWorkspace,
         };
         restoredFromScratch = true;
+
+        patchKanbanIssueComposer(issueComposerKey, {
+          title: nextCreateFormData.title,
+          description: nextCreateFormData.description,
+          statusId: nextCreateFormData.statusId,
+          priority: nextCreateFormData.priority,
+          assigneeIds: nextCreateFormData.assigneeIds,
+          tagIds: nextCreateFormData.tagIds,
+          createDraftWorkspace: nextCreateFormData.createDraftWorkspace,
+        });
       } else {
         nextCreateFormData = createModeDefaults;
       }
@@ -619,7 +688,33 @@ export function KanbanIssuePanelContainer({
     cancelDebouncedDescription,
     createModeDefaults,
     issueComposerKey,
+    isIssueDraftScratchLoading,
+    issueDraftScratch,
+    projectId,
   ]);
+
+  // Autosave: persist dirty create-mode drafts to scratch storage.
+  useEffect(() => {
+    if (!kanbanCreateMode || !createFormData || !isCreateDraftDirty) return;
+    debouncedSaveIssueDraft(createFormData);
+  }, [
+    kanbanCreateMode,
+    createFormData,
+    isCreateDraftDirty,
+    debouncedSaveIssueDraft,
+  ]);
+
+  // Flush pending draft save on unmount (e.g., navigation away).
+  useEffect(() => {
+    return () => {
+      cancelDebouncedIssueDraft();
+      if (skipUnmountSaveRef.current) return;
+      const form = createFormDataRef.current;
+      if (form && (form.title || form.description)) {
+        void saveIssueDraftToScratchRef.current(form);
+      }
+    };
+  }, [cancelDebouncedIssueDraft]);
 
   useEffect(() => {
     const wasPending = prevHasPendingAttachmentsRef.current;
@@ -890,6 +985,10 @@ export function KanbanIssuePanelContainer({
           });
         }
 
+        skipUnmountSaveRef.current = true;
+        cancelDebouncedIssueDraft();
+        void deleteIssueDraftScratch();
+
         if (issueComposerKey) {
           closeKanbanIssueComposer(issueComposerKey);
         }
@@ -972,12 +1071,19 @@ export function KanbanIssuePanelContainer({
   }, [mode, handleSubmit]);
 
   const handleDeleteDraft = useCallback(() => {
+    cancelDebouncedIssueDraft();
+    void deleteIssueDraftScratch();
     dispatchFormState({
       type: 'setCreateFormData',
       createFormData: createModeDefaults,
     });
     resetIssueComposerDraft();
-  }, [createModeDefaults, resetIssueComposerDraft]);
+  }, [
+    createModeDefaults,
+    resetIssueComposerDraft,
+    cancelDebouncedIssueDraft,
+    deleteIssueDraftScratch,
+  ]);
 
   // Tag create callback - returns the new tag ID so it can be auto-selected
   const handleCreateTag = useCallback(


### PR DESCRIPTION
## Summary

Draft issue content was lost when navigating away from the kanban create panel and returning — the form would reset to blank. This happened because the composer state only lived in an in-memory Zustand store (`useKanbanIssueComposerStore`) with no persistent backing on local-web, and a custom localStorage sync on remote-web that was also cleared on navigation.

## What changed

### `KanbanIssuePanelContainer.tsx` (main fix)

- **Added `useScratch(ScratchType.DRAFT_ISSUE, projectId)`** — hooks into the existing runtime-aware scratch system that already powers workspace drafts, comment drafts, and UI preferences. On local-web this persists to SQLite via WebSocket; on remote-web it uses localStorage. Both survive navigation and port changes.

- **Rewrote the init effect** to restore form data from scratch storage (instead of the Zustand store) when entering create mode. Waits for scratch loading to complete before seeding the form, and syncs restored data back to the Zustand store for dialog compatibility (e.g., `AssigneeSelectionDialog`).

- **Added autosave effect** — watches `createFormData` changes and debounce-saves (500ms) dirty drafts to scratch storage.

- **Added unmount flush** — on component unmount (navigation away), cancels pending debounce and immediately saves the latest form state. Skipped when the draft was already submitted or explicitly deleted.

- **Updated `handleSubmit`** — cleans up scratch storage after successful issue creation.

- **Updated `handleDeleteDraft`** — clears both the in-memory form state and the persistent scratch entry.

### `remote-web/__root.tsx` (cleanup)

- Removed `useKanbanIssueComposerScratch()` call and import — this custom localStorage-only sync hook is superseded by the proper `useScratch`-based persistence that works on both runtimes.

## Why this approach

The codebase already had the infrastructure for this fix:

- `ScratchType.DRAFT_ISSUE` and `DraftIssueData` were already defined in both Rust (`crates/db/src/models/scratch.rs`) and generated TypeScript (`shared/types.ts`) — just unused by the frontend.
- The `useScratch` hook transparently handles both runtimes (SQLite/WebSocket for local-web where ports change every launch, localStorage for remote-web's stable domain).
- No Rust/backend changes or migrations were needed.

## How it works now

| Step | Before (broken) | After (fixed) |
|------|-----------------|---------------|
| User types in create form | In-memory Zustand store only | Zustand store + debounced save to scratch |
| User navigates away | `closeComposer` deletes draft from memory | UI closes; scratch persists; unmount flushes pending save |
| User clicks "+" again | Fresh blank form | Scratch data loaded → form restored |
| User submits issue | Draft discarded | `deleteIssueDraftScratch()` cleans up |
| User clicks "Delete draft" | Form reset to defaults | Form reset + scratch cleanup |

---

This PR was written using [Vibe Kanban](https://vibekanban.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes create-mode state restoration/autosave/unmount behavior, which could cause unexpected draft overwrites or stale restores if scratch keys/payloads are wrong, but it’s confined to frontend draft persistence.
> 
> **Overview**
> Fixes kanban create-mode drafts being lost by moving persistence from a remote-only localStorage sync to the runtime-aware scratch system (`ScratchType.DRAFT_ISSUE`). The create panel now restores initial form state from scratch (waiting for scratch load), debounced-autosaves dirty form changes, flushes a final save on unmount, and deletes the scratch entry on successful submit or explicit draft deletion.
> 
> Cleans up `remote-web` root routing by removing the global `useKanbanIssueComposerScratch()` hook since draft persistence is now handled in `KanbanIssuePanelContainer`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d4539dafb943e3a89e576084b1429a838a687cb9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->