### PR TITLE
bump codex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1128,8 +1128,8 @@ checksum = "e9b18233253483ce2f65329a24072ec414db782531bdbb7d0bbc4bd2ce6b7e21"
 
 [[package]]
 name = "codex-app-server-protocol"
-version = "0.114.0"
-source = "git+https://github.com/openai/codex.git?tag=rust-v0.114.0#b9904c0ae4ecb773549efd6ea3fb05229402fdb9"
+version = "0.116.0"
+source = "git+https://github.com/openai/codex.git?tag=rust-v0.116.0#38771c9082535aa16b4c4d0395d3532f32f656ff"
 dependencies = [
  "anyhow",
  "clap",
@@ -1152,8 +1152,8 @@ dependencies = [
 
 [[package]]
 name = "codex-execpolicy"
-version = "0.114.0"
-source = "git+https://github.com/openai/codex.git?tag=rust-v0.114.0#b9904c0ae4ecb773549efd6ea3fb05229402fdb9"
+version = "0.116.0"
+source = "git+https://github.com/openai/codex.git?tag=rust-v0.116.0#38771c9082535aa16b4c4d0395d3532f32f656ff"
 dependencies = [
  "anyhow",
  "clap",
@@ -1168,8 +1168,8 @@ dependencies = [
 
 [[package]]
 name = "codex-experimental-api-macros"
-version = "0.114.0"
-source = "git+https://github.com/openai/codex.git?tag=rust-v0.114.0#b9904c0ae4ecb773549efd6ea3fb05229402fdb9"
+version = "0.116.0"
+source = "git+https://github.com/openai/codex.git?tag=rust-v0.116.0#38771c9082535aa16b4c4d0395d3532f32f656ff"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1178,8 +1178,8 @@ dependencies = [
 
 [[package]]
 name = "codex-git"
-version = "0.114.0"
-source = "git+https://github.com/openai/codex.git?tag=rust-v0.114.0#b9904c0ae4ecb773549efd6ea3fb05229402fdb9"
+version = "0.116.0"
+source = "git+https://github.com/openai/codex.git?tag=rust-v0.116.0#38771c9082535aa16b4c4d0395d3532f32f656ff"
 dependencies = [
  "once_cell",
  "regex",
@@ -1193,8 +1193,8 @@ dependencies = [
 
 [[package]]
 name = "codex-protocol"
-version = "0.114.0"
-source = "git+https://github.com/openai/codex.git?tag=rust-v0.114.0#b9904c0ae4ecb773549efd6ea3fb05229402fdb9"
+version = "0.116.0"
+source = "git+https://github.com/openai/codex.git?tag=rust-v0.116.0#38771c9082535aa16b4c4d0395d3532f32f656ff"
 dependencies = [
  "codex-execpolicy",
  "codex-git",
@@ -1218,8 +1218,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-absolute-path"
-version = "0.114.0"
-source = "git+https://github.com/openai/codex.git?tag=rust-v0.114.0#b9904c0ae4ecb773549efd6ea3fb05229402fdb9"
+version = "0.116.0"
+source = "git+https://github.com/openai/codex.git?tag=rust-v0.116.0#38771c9082535aa16b4c4d0395d3532f32f656ff"
 dependencies = [
  "dirs 6.0.0",
  "path-absolutize",
@@ -1230,8 +1230,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-cache"
-version = "0.114.0"
-source = "git+https://github.com/openai/codex.git?tag=rust-v0.114.0#b9904c0ae4ecb773549efd6ea3fb05229402fdb9"
+version = "0.116.0"
+source = "git+https://github.com/openai/codex.git?tag=rust-v0.116.0#38771c9082535aa16b4c4d0395d3532f32f656ff"
 dependencies = [
  "lru 0.16.3",
  "sha1",
@@ -1240,8 +1240,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-image"
-version = "0.114.0"
-source = "git+https://github.com/openai/codex.git?tag=rust-v0.114.0#b9904c0ae4ecb773549efd6ea3fb05229402fdb9"
+version = "0.116.0"
+source = "git+https://github.com/openai/codex.git?tag=rust-v0.116.0#38771c9082535aa16b4c4d0395d3532f32f656ff"
 dependencies = [
  "base64 0.22.1",
  "codex-utils-cache",

--- a/crates/executors/Cargo.toml
+++ b/crates/executors/Cargo.toml
@@ -36,8 +36,8 @@ convert_case = "0.6"
 sqlx = "0.8.6"
 shlex = "1.3.0"
 agent-client-protocol = { version = "0.8", features = ["unstable"] }
-codex-protocol = { git = "https://github.com/openai/codex.git", package = "codex-protocol", tag = "rust-v0.114.0" }
-codex-app-server-protocol = { git = "https://github.com/openai/codex.git", package = "codex-app-server-protocol", tag = "rust-v0.114.0" }
+codex-protocol = { git = "https://github.com/openai/codex.git", package = "codex-protocol", tag = "rust-v0.116.0" }
+codex-app-server-protocol = { git = "https://github.com/openai/codex.git", package = "codex-app-server-protocol", tag = "rust-v0.116.0" }
 sha2 = "0.10"
 derivative = "2.2.0"
 reqwest = { workspace = true }

--- a/crates/executors/src/executors/codex.rs
+++ b/crates/executors/src/executors/codex.rs
@@ -429,7 +429,7 @@ impl StandardCodingAgentExecutor for Codex {
 
 impl Codex {
     pub fn base_command() -> &'static str {
-        "npx -y @openai/codex@0.114.0"
+        "npx -y @openai/codex@0.116.0"
     }
 
     fn build_command_builder(&self) -> Result<CommandBuilder, CommandBuildError> {

--- a/crates/executors/src/executors/codex/client.rs
+++ b/crates/executors/src/executors/codex/client.rs
@@ -11,16 +11,17 @@ use async_trait::async_trait;
 use codex_app_server_protocol::{
     ClientInfo, ClientNotification, ClientRequest, CommandExecutionApprovalDecision,
     CommandExecutionRequestApprovalResponse, ConfigBatchWriteParams, ConfigEdit, ConfigReadParams,
-    ConfigReadResponse, ConfigWriteResponse, FileChangeApprovalDecision,
-    FileChangeRequestApprovalResponse, GetAccountParams, GetAccountRateLimitsResponse,
-    GetAccountResponse, InitializeCapabilities, InitializeParams, InitializeResponse,
-    ItemCompletedNotification, JSONRPCError, JSONRPCNotification, JSONRPCRequest, JSONRPCResponse,
-    ListMcpServerStatusParams, ListMcpServerStatusResponse, RequestId, ReviewStartParams,
-    ReviewStartResponse, ReviewTarget, ServerRequest, ThreadCompactStartParams,
-    ThreadCompactStartResponse, ThreadForkParams, ThreadForkResponse, ThreadItem, ThreadReadParams,
-    ThreadReadResponse, ThreadStartParams, ThreadStartResponse, ToolRequestUserInputAnswer,
-    ToolRequestUserInputQuestion, ToolRequestUserInputResponse, TurnCompletedNotification,
-    TurnStartParams, TurnStartResponse, TurnStatus, UserInput,
+    ConfigReadResponse, ConfigWriteResponse, DynamicToolCallOutputContentItem,
+    DynamicToolCallResponse, FileChangeApprovalDecision, FileChangeRequestApprovalResponse,
+    GetAccountParams, GetAccountRateLimitsResponse, GetAccountResponse, InitializeCapabilities,
+    InitializeParams, InitializeResponse, ItemCompletedNotification, JSONRPCError,
+    JSONRPCNotification, JSONRPCRequest, JSONRPCResponse, ListMcpServerStatusParams,
+    ListMcpServerStatusResponse, RequestId, ReviewStartParams, ReviewStartResponse, ReviewTarget,
+    ServerRequest, ThreadCompactStartParams, ThreadCompactStartResponse, ThreadForkParams,
+    ThreadForkResponse, ThreadItem, ThreadReadParams, ThreadReadResponse, ThreadStartParams,
+    ThreadStartResponse, ToolRequestUserInputAnswer, ToolRequestUserInputQuestion,
+    ToolRequestUserInputResponse, TurnCompletedNotification, TurnStartParams, TurnStartResponse,
+    TurnStatus, UserInput,
 };
 use codex_protocol::config_types::{CollaborationMode, ModeKind, Settings};
 use futures::TryFutureExt;
@@ -417,8 +418,25 @@ impl AppServerClient {
                 send_server_response(peer, request_id, response).await?;
                 Ok(())
             }
-            ServerRequest::DynamicToolCall { .. }
-            | ServerRequest::ChatgptAuthTokensRefresh { .. }
+            ServerRequest::DynamicToolCall { request_id, params } => {
+                tracing::warn!(
+                    "received unsupported dynamic tool call: tool={} call_id={}",
+                    params.tool,
+                    params.call_id
+                );
+                let response = DynamicToolCallResponse {
+                    content_items: vec![DynamicToolCallOutputContentItem::InputText {
+                        text: format!(
+                            "Dynamic tool '{}' is not supported by this client.",
+                            params.tool
+                        ),
+                    }],
+                    success: false,
+                };
+                send_server_response(peer, request_id, response).await?;
+                Ok(())
+            }
+            ServerRequest::ChatgptAuthTokensRefresh { .. }
             | ServerRequest::McpServerElicitationRequest { .. }
             | ServerRequest::PermissionsRequestApproval { .. } => {
                 tracing::warn!("received unhandled v2 server request: {:?}", request);

--- a/crates/executors/src/executors/codex/normalize_logs.rs
+++ b/crates/executors/src/executors/codex/normalize_logs.rs
@@ -6,10 +6,18 @@ use std::{
 };
 
 use codex_app_server_protocol::{
-    JSONRPCNotification, JSONRPCResponse, ServerNotification, ThreadForkResponse,
-    ThreadStartResponse,
+    CommandExecutionOutputDeltaNotification, CommandExecutionStatus as AppCommandExecutionStatus,
+    DynamicToolCallOutputContentItem as AppDynamicToolCallOutputContentItem,
+    DynamicToolCallStatus as AppDynamicToolCallStatus, FileChangeOutputDeltaNotification,
+    ItemCompletedNotification as AppItemCompletedNotification,
+    ItemStartedNotification as AppItemStartedNotification, JSONRPCNotification, JSONRPCRequest,
+    JSONRPCResponse, McpToolCallProgressNotification, McpToolCallStatus as AppMcpToolCallStatus,
+    PatchApplyStatus as AppPatchApplyStatus, ServerNotification, ServerRequest, ThreadForkResponse,
+    ThreadItem as AppThreadItem, ThreadStartResponse, ThreadTokenUsageUpdatedNotification,
+    ToolRequestUserInputQuestion,
 };
 use codex_protocol::{
+    dynamic_tools::DynamicToolCallOutputContentItem as CoreDynamicToolCallOutputContentItem,
     items::TurnItem,
     openai_models::ReasoningEffort,
     plan_tool::{StepStatus, UpdatePlanArgs},
@@ -121,6 +129,37 @@ struct McpToolState {
     invocation: McpInvocation,
     result: Option<ToolResult>,
     status: ToolStatus,
+}
+
+struct DynamicToolState {
+    index: Option<usize>,
+    tool: String,
+    arguments: Value,
+    result: Option<ToolResult>,
+    status: ToolStatus,
+    call_id: String,
+}
+
+impl ToNormalizedEntry for DynamicToolState {
+    fn to_normalized_entry(&self) -> NormalizedEntry {
+        NormalizedEntry {
+            timestamp: None,
+            entry_type: NormalizedEntryType::ToolUse {
+                tool_name: self.tool.clone(),
+                action_type: ActionType::Tool {
+                    tool_name: self.tool.clone(),
+                    arguments: Some(self.arguments.clone()),
+                    result: self.result.clone(),
+                },
+                status: self.status.clone(),
+            },
+            content: self.tool.clone(),
+            metadata: serde_json::to_value(ToolCallMetadata {
+                tool_call_id: self.call_id.clone(),
+            })
+            .ok(),
+        }
+    }
 }
 
 impl ToNormalizedEntry for McpToolState {
@@ -336,6 +375,7 @@ struct LogState {
     thinking: Option<StreamingText>,
     commands: HashMap<String, CommandState>,
     mcp_tools: HashMap<String, McpToolState>,
+    dynamic_tools: HashMap<String, DynamicToolState>,
     patches: HashMap<String, PatchState>,
     web_searches: HashMap<String, WebSearchState>,
     user_input_requests: HashMap<String, UserInputRequestState>,
@@ -363,6 +403,7 @@ impl LogState {
             thinking: None,
             commands: HashMap::new(),
             mcp_tools: HashMap::new(),
+            dynamic_tools: HashMap::new(),
             patches: HashMap::new(),
             web_searches: HashMap::new(),
             user_input_requests: HashMap::new(),
@@ -464,6 +505,11 @@ impl LogState {
             if let Some(index) = mcp.index {
                 replace_normalized_entry(msg_store, index, mcp.to_normalized_entry());
             }
+        } else if let Some(dynamic_tool) = self.dynamic_tools.get_mut(call_id) {
+            dynamic_tool.status = status.clone();
+            if let Some(index) = dynamic_tool.index {
+                replace_normalized_entry(msg_store, index, dynamic_tool.to_normalized_entry());
+            }
         } else if let Some(patch_state) = self.patches.get_mut(call_id) {
             for entry in &mut patch_state.entries {
                 entry.status = status.clone();
@@ -484,7 +530,27 @@ impl LogState {
             if let Some(index) = plan_state.index {
                 replace_normalized_entry(msg_store, index, plan_state.to_normalized_entry());
             }
+        } else if matches!(status, ToolStatus::PendingApproval { .. }) {
+            let command_state = self.command_state(call_id.to_string());
+            command_state.status = status.clone();
+            if clear_awaiting {
+                command_state.awaiting_approval = false;
+            } else if matches!(status, ToolStatus::PendingApproval { .. }) {
+                command_state.awaiting_approval = true;
+            }
+            if let Some(index) = command_state.index {
+                replace_normalized_entry(msg_store, index, command_state.to_normalized_entry());
+            }
         }
+    }
+
+    fn command_state(&mut self, call_id: String) -> &mut CommandState {
+        self.commands
+            .entry(call_id.clone())
+            .or_insert_with(|| CommandState {
+                call_id,
+                ..Default::default()
+            })
     }
 }
 
@@ -528,6 +594,842 @@ fn normalize_file_changes(
             (relative, file_changes)
         })
         .collect()
+}
+
+fn normalize_app_file_changes(
+    worktree_path: &str,
+    changes: &[codex_app_server_protocol::FileUpdateChange],
+) -> Vec<(String, Vec<FileChange>)> {
+    changes
+        .iter()
+        .map(|change| {
+            let relative = make_path_relative(&change.path, worktree_path);
+            let file_changes = match &change.kind {
+                codex_app_server_protocol::PatchChangeKind::Add => vec![FileChange::Write {
+                    content: change.diff.clone(),
+                }],
+                codex_app_server_protocol::PatchChangeKind::Delete => vec![FileChange::Delete],
+                codex_app_server_protocol::PatchChangeKind::Update { move_path } => {
+                    let mut edits = Vec::new();
+                    if let Some(dest) = move_path {
+                        let dest_rel = make_path_relative(&dest.to_string_lossy(), worktree_path);
+                        edits.push(FileChange::Rename { new_path: dest_rel });
+                    }
+                    edits.push(FileChange::Edit {
+                        unified_diff: normalize_unified_diff(&relative, &change.diff),
+                        has_line_numbers: true,
+                    });
+                    edits
+                }
+            };
+            (relative, file_changes)
+        })
+        .collect()
+}
+
+fn app_command_status_to_tool_status(status: &AppCommandExecutionStatus) -> ToolStatus {
+    match status {
+        AppCommandExecutionStatus::InProgress => ToolStatus::Created,
+        AppCommandExecutionStatus::Completed => ToolStatus::Success,
+        AppCommandExecutionStatus::Failed => ToolStatus::Failed,
+        AppCommandExecutionStatus::Declined => ToolStatus::Denied { reason: None },
+    }
+}
+
+fn app_patch_status_to_tool_status(status: &AppPatchApplyStatus) -> ToolStatus {
+    match status {
+        AppPatchApplyStatus::InProgress => ToolStatus::Created,
+        AppPatchApplyStatus::Completed => ToolStatus::Success,
+        AppPatchApplyStatus::Failed => ToolStatus::Failed,
+        AppPatchApplyStatus::Declined => ToolStatus::Denied { reason: None },
+    }
+}
+
+fn app_mcp_status_to_tool_status(status: &AppMcpToolCallStatus) -> ToolStatus {
+    match status {
+        AppMcpToolCallStatus::InProgress => ToolStatus::Created,
+        AppMcpToolCallStatus::Completed => ToolStatus::Success,
+        AppMcpToolCallStatus::Failed => ToolStatus::Failed,
+    }
+}
+
+fn app_dynamic_tool_status_to_tool_status(status: &AppDynamicToolCallStatus) -> ToolStatus {
+    match status {
+        AppDynamicToolCallStatus::InProgress => ToolStatus::Created,
+        AppDynamicToolCallStatus::Completed => ToolStatus::Success,
+        AppDynamicToolCallStatus::Failed => ToolStatus::Failed,
+    }
+}
+
+fn dynamic_tool_markdown_from_app_items(items: &[AppDynamicToolCallOutputContentItem]) -> String {
+    items
+        .iter()
+        .map(|item| match item {
+            AppDynamicToolCallOutputContentItem::InputText { text } => text.clone(),
+            AppDynamicToolCallOutputContentItem::InputImage { image_url } => {
+                format!("Image: {image_url}")
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn dynamic_tool_markdown_from_core_items(items: &[CoreDynamicToolCallOutputContentItem]) -> String {
+    items
+        .iter()
+        .map(|item| match item {
+            CoreDynamicToolCallOutputContentItem::InputText { text } => text.clone(),
+            CoreDynamicToolCallOutputContentItem::InputImage { image_url } => {
+                format!("Image: {image_url}")
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+struct DynamicToolUpdate {
+    call_id: String,
+    tool: String,
+    arguments: Value,
+    status: ToolStatus,
+    result: Option<ToolResult>,
+}
+
+fn upsert_dynamic_tool_state(
+    state: &mut LogState,
+    msg_store: &Arc<MsgStore>,
+    entry_index: &EntryIndexProvider,
+    update: DynamicToolUpdate,
+) {
+    let DynamicToolUpdate {
+        call_id,
+        tool,
+        arguments,
+        status,
+        result,
+    } = update;
+    let dynamic_tool_state = state
+        .dynamic_tools
+        .entry(call_id.clone())
+        .or_insert_with(|| DynamicToolState {
+            index: None,
+            tool: tool.clone(),
+            arguments: arguments.clone(),
+            result: None,
+            status: ToolStatus::Created,
+            call_id: call_id.clone(),
+        });
+    dynamic_tool_state.tool = tool;
+    dynamic_tool_state.arguments = arguments;
+    dynamic_tool_state.status = status;
+    dynamic_tool_state.result = result;
+    let index = if let Some(index) = dynamic_tool_state.index {
+        index
+    } else {
+        let index = add_normalized_entry(
+            msg_store,
+            entry_index,
+            dynamic_tool_state.to_normalized_entry(),
+        );
+        dynamic_tool_state.index = Some(index);
+        index
+    };
+    replace_normalized_entry(msg_store, index, dynamic_tool_state.to_normalized_entry());
+}
+
+fn add_thread_token_usage(
+    notification: ThreadTokenUsageUpdatedNotification,
+    msg_store: &Arc<MsgStore>,
+    entry_index: &EntryIndexProvider,
+) {
+    add_normalized_entry(
+        msg_store,
+        entry_index,
+        NormalizedEntry {
+            timestamp: None,
+            entry_type: NormalizedEntryType::TokenUsageInfo(crate::logs::TokenUsageInfo {
+                total_tokens: notification.token_usage.last.total_tokens as u32,
+                model_context_window: notification
+                    .token_usage
+                    .model_context_window
+                    .unwrap_or_default() as u32,
+            }),
+            content: format!(
+                "Tokens used: {} / Context window: {}",
+                notification.token_usage.last.total_tokens,
+                notification
+                    .token_usage
+                    .model_context_window
+                    .unwrap_or_default()
+            ),
+            metadata: None,
+        },
+    );
+}
+
+trait QuestionLike {
+    fn question(&self) -> &str;
+    fn header(&self) -> &str;
+    fn options(&self) -> Option<&[impl QuestionOptionLike]>;
+}
+
+trait QuestionOptionLike {
+    fn label(&self) -> &str;
+    fn description(&self) -> &str;
+}
+
+impl QuestionLike for ToolRequestUserInputQuestion {
+    fn question(&self) -> &str {
+        &self.question
+    }
+
+    fn header(&self) -> &str {
+        &self.header
+    }
+
+    fn options(&self) -> Option<&[impl QuestionOptionLike]> {
+        self.options.as_deref()
+    }
+}
+
+impl QuestionOptionLike for codex_app_server_protocol::ToolRequestUserInputOption {
+    fn label(&self) -> &str {
+        &self.label
+    }
+
+    fn description(&self) -> &str {
+        &self.description
+    }
+}
+
+impl QuestionLike for codex_protocol::request_user_input::RequestUserInputQuestion {
+    fn question(&self) -> &str {
+        &self.question
+    }
+
+    fn header(&self) -> &str {
+        &self.header
+    }
+
+    fn options(&self) -> Option<&[impl QuestionOptionLike]> {
+        self.options.as_deref()
+    }
+}
+
+impl QuestionOptionLike for codex_protocol::request_user_input::RequestUserInputQuestionOption {
+    fn label(&self) -> &str {
+        &self.label
+    }
+
+    fn description(&self) -> &str {
+        &self.description
+    }
+}
+
+fn question_state_from_questions<T: QuestionLike>(questions: &[T]) -> UserInputRequestState {
+    let questions: Vec<AskUserQuestionItem> = questions
+        .iter()
+        .map(|q| AskUserQuestionItem {
+            question: q.question().to_string(),
+            header: q.header().to_string(),
+            options: q
+                .options()
+                .unwrap_or(&[])
+                .iter()
+                .map(|o| AskUserQuestionOption {
+                    label: o.label().to_string(),
+                    description: o.description().to_string(),
+                })
+                .collect(),
+            multi_select: false,
+        })
+        .collect();
+
+    let content = if questions.len() == 1 {
+        questions[0].question.clone()
+    } else {
+        format!("{} questions", questions.len())
+    };
+
+    UserInputRequestState {
+        index: None,
+        questions,
+        content,
+        status: ToolStatus::Created,
+    }
+}
+
+fn upsert_question_request_state(
+    state: &mut LogState,
+    msg_store: &Arc<MsgStore>,
+    entry_index: &EntryIndexProvider,
+    call_id: String,
+    questions: &[impl QuestionLike],
+) {
+    let mut tool_state = question_state_from_questions(questions);
+    let fallback_command = state.commands.remove(&call_id);
+    if let Some(command_state) = fallback_command.as_ref()
+        && matches!(command_state.status, ToolStatus::PendingApproval { .. })
+    {
+        tool_state.status = command_state.status.clone();
+    }
+    let existing_index = state
+        .user_input_requests
+        .get(&call_id)
+        .and_then(|s| s.index)
+        .or_else(|| fallback_command.and_then(|cmd| cmd.index));
+    let index = existing_index.unwrap_or_else(|| {
+        add_normalized_entry(msg_store, entry_index, tool_state.to_normalized_entry())
+    });
+    tool_state.index = Some(index);
+    replace_normalized_entry(msg_store, index, tool_state.to_normalized_entry());
+    state.user_input_requests.insert(call_id, tool_state);
+}
+
+fn handle_direct_item_started(
+    notification: AppItemStartedNotification,
+    state: &mut LogState,
+    msg_store: &Arc<MsgStore>,
+    entry_index: &EntryIndexProvider,
+    worktree_path: &str,
+) {
+    state.assistant = None;
+    state.thinking = None;
+
+    match notification.item {
+        AppThreadItem::Plan { id, .. } => {
+            let mut plan_state = PlanState {
+                index: None,
+                text: String::new(),
+                status: ToolStatus::Created,
+            };
+            let index =
+                add_normalized_entry(msg_store, entry_index, plan_state.to_normalized_entry());
+            plan_state.index = Some(index);
+            state.plans.insert(id, plan_state);
+        }
+        AppThreadItem::CommandExecution { id, command, .. } => {
+            let mut command_state = state.commands.remove(&id).unwrap_or_default();
+            command_state.command = command;
+            command_state.status = ToolStatus::Created;
+            command_state.awaiting_approval = false;
+            command_state.call_id = id.clone();
+            let index = command_state.index.unwrap_or_else(|| {
+                add_normalized_entry(msg_store, entry_index, command_state.to_normalized_entry())
+            });
+            command_state.index = Some(index);
+            replace_normalized_entry(msg_store, index, command_state.to_normalized_entry());
+            state.commands.insert(id, command_state);
+        }
+        AppThreadItem::FileChange { id, changes, .. } => {
+            let normalized = normalize_app_file_changes(worktree_path, &changes);
+            let patch_state = state.patches.entry(id.clone()).or_default();
+            let normalized_len = normalized.len();
+            let mut iter = normalized.into_iter();
+
+            for entry in &mut patch_state.entries {
+                if let Some((path, file_changes)) = iter.next() {
+                    entry.path = path;
+                    entry.changes = file_changes;
+                    entry.status = ToolStatus::Created;
+                    entry.awaiting_approval = false;
+                    let index = entry.index.unwrap_or_else(|| {
+                        add_normalized_entry(msg_store, entry_index, entry.to_normalized_entry())
+                    });
+                    entry.index = Some(index);
+                    replace_normalized_entry(msg_store, index, entry.to_normalized_entry());
+                }
+            }
+
+            if normalized_len < patch_state.entries.len() {
+                for entry in patch_state.entries.drain(normalized_len..) {
+                    if let Some(index) = entry.index {
+                        msg_store.push_patch(ConversationPatch::remove(index));
+                    }
+                }
+            }
+
+            for (path, file_changes) in iter {
+                let mut entry = PatchEntry {
+                    index: None,
+                    path,
+                    changes: file_changes,
+                    status: ToolStatus::Created,
+                    awaiting_approval: false,
+                    call_id: id.clone(),
+                };
+                let index =
+                    add_normalized_entry(msg_store, entry_index, entry.to_normalized_entry());
+                entry.index = Some(index);
+                patch_state.entries.push(entry);
+            }
+        }
+        AppThreadItem::McpToolCall {
+            id,
+            server,
+            tool,
+            arguments,
+            ..
+        } => {
+            let tool_state = state.mcp_tools.entry(id.clone()).or_insert(McpToolState {
+                index: None,
+                invocation: McpInvocation {
+                    server,
+                    tool,
+                    arguments: Some(arguments),
+                },
+                result: None,
+                status: ToolStatus::Created,
+            });
+            tool_state.status = ToolStatus::Created;
+            let index = tool_state.index.unwrap_or_else(|| {
+                add_normalized_entry(msg_store, entry_index, tool_state.to_normalized_entry())
+            });
+            tool_state.index = Some(index);
+            replace_normalized_entry(msg_store, index, tool_state.to_normalized_entry());
+        }
+        AppThreadItem::DynamicToolCall {
+            id,
+            tool,
+            arguments,
+            ..
+        } => {
+            upsert_dynamic_tool_state(
+                state,
+                msg_store,
+                entry_index,
+                DynamicToolUpdate {
+                    call_id: id,
+                    tool,
+                    arguments,
+                    status: ToolStatus::Created,
+                    result: None,
+                },
+            );
+        }
+        AppThreadItem::WebSearch { id, .. } => {
+            state.web_searches.insert(id.clone(), WebSearchState::new());
+            let web_search_state = state.web_searches.get_mut(&id).unwrap();
+            let normalized_entry = web_search_state.to_normalized_entry();
+            let index = add_normalized_entry(msg_store, entry_index, normalized_entry);
+            web_search_state.index = Some(index);
+        }
+        AppThreadItem::EnteredReviewMode { review, .. } => {
+            let mut review_state = ReviewState {
+                index: None,
+                description: review,
+                status: ToolStatus::Created,
+                result: None,
+            };
+            let index =
+                add_normalized_entry(msg_store, entry_index, review_state.to_normalized_entry());
+            review_state.index = Some(index);
+            state.review = Some(review_state);
+        }
+        _ => {}
+    }
+}
+
+fn handle_direct_item_completed(
+    notification: AppItemCompletedNotification,
+    state: &mut LogState,
+    msg_store: &Arc<MsgStore>,
+    entry_index: &EntryIndexProvider,
+    worktree_path: &str,
+) {
+    match notification.item {
+        AppThreadItem::AgentMessage { text, .. } => {
+            state.thinking = None;
+            let (entry, index, is_new) = state.assistant_message(text);
+            upsert_normalized_entry(msg_store, index, entry, is_new);
+            state.assistant = None;
+        }
+        AppThreadItem::Reasoning { summary, .. } => {
+            if !summary.is_empty() {
+                state.assistant = None;
+                let (entry, index, is_new) = state.thinking(summary.join("\n\n"));
+                upsert_normalized_entry(msg_store, index, entry, is_new);
+                state.thinking = None;
+            }
+        }
+        AppThreadItem::Plan { id, text } => {
+            if let Some(plan_state) = state.plans.get_mut(&id) {
+                plan_state.text = text;
+                if let Some(index) = plan_state.index {
+                    replace_normalized_entry(msg_store, index, plan_state.to_normalized_entry());
+                }
+            }
+        }
+        AppThreadItem::CommandExecution {
+            id,
+            aggregated_output,
+            exit_code,
+            status,
+            ..
+        } => {
+            if let Some(mut command_state) = state.commands.remove(&id) {
+                command_state.formatted_output = aggregated_output;
+                command_state.exit_code = exit_code;
+                command_state.awaiting_approval = false;
+                command_state.status = app_command_status_to_tool_status(&status);
+                if let Some(index) = command_state.index {
+                    replace_normalized_entry(msg_store, index, command_state.to_normalized_entry());
+                }
+            }
+        }
+        AppThreadItem::FileChange { id, status, .. } => {
+            if let Some(patch_state) = state.patches.remove(&id) {
+                let tool_status = app_patch_status_to_tool_status(&status);
+                for mut entry in patch_state.entries {
+                    entry.status = tool_status.clone();
+                    if let Some(index) = entry.index {
+                        replace_normalized_entry(msg_store, index, entry.to_normalized_entry());
+                    }
+                }
+            }
+        }
+        AppThreadItem::McpToolCall {
+            id,
+            status,
+            result,
+            error,
+            ..
+        } => {
+            if let Some(mut mcp_tool_state) = state.mcp_tools.remove(&id) {
+                mcp_tool_state.status = app_mcp_status_to_tool_status(&status);
+                if let Some(result) = result {
+                    if result
+                        .content
+                        .iter()
+                        .all(|block| block.get("type").and_then(|t| t.as_str()) == Some("text"))
+                    {
+                        mcp_tool_state.result = Some(ToolResult {
+                            r#type: ToolResultValueType::Markdown,
+                            value: Value::String(
+                                result
+                                    .content
+                                    .iter()
+                                    .filter_map(|block| {
+                                        block
+                                            .get("text")
+                                            .and_then(|t| t.as_str())
+                                            .map(|s| s.to_owned())
+                                    })
+                                    .collect::<Vec<String>>()
+                                    .join("\n"),
+                            ),
+                        });
+                    } else {
+                        mcp_tool_state.result = Some(ToolResult {
+                            r#type: ToolResultValueType::Json,
+                            value: result.structured_content.unwrap_or_else(|| {
+                                serde_json::to_value(result.content).unwrap_or_default()
+                            }),
+                        });
+                    }
+                } else if let Some(error) = error {
+                    mcp_tool_state.result = Some(ToolResult {
+                        r#type: ToolResultValueType::Markdown,
+                        value: Value::String(error.message),
+                    });
+                }
+                if let Some(index) = mcp_tool_state.index {
+                    replace_normalized_entry(
+                        msg_store,
+                        index,
+                        mcp_tool_state.to_normalized_entry(),
+                    );
+                }
+            }
+        }
+        AppThreadItem::DynamicToolCall {
+            id,
+            tool,
+            arguments,
+            status,
+            content_items,
+            success,
+            ..
+        } => {
+            let dynamic_status = match success {
+                Some(false) => ToolStatus::Failed,
+                _ => app_dynamic_tool_status_to_tool_status(&status),
+            };
+            let dynamic_result = content_items
+                .map(|items| ToolResult::markdown(dynamic_tool_markdown_from_app_items(&items)));
+            upsert_dynamic_tool_state(
+                state,
+                msg_store,
+                entry_index,
+                DynamicToolUpdate {
+                    call_id: id,
+                    tool,
+                    arguments,
+                    status: dynamic_status,
+                    result: dynamic_result,
+                },
+            );
+        }
+        AppThreadItem::WebSearch { id, query, .. } => {
+            if let Some(mut entry) = state.web_searches.remove(&id) {
+                entry.status = ToolStatus::Success;
+                entry.query = Some(query);
+                if let Some(index) = entry.index {
+                    replace_normalized_entry(msg_store, index, entry.to_normalized_entry());
+                }
+            }
+        }
+        AppThreadItem::ImageView { path, .. } => {
+            let relative_path = make_path_relative(&path, worktree_path);
+            add_normalized_entry(
+                msg_store,
+                entry_index,
+                NormalizedEntry {
+                    timestamp: None,
+                    entry_type: NormalizedEntryType::ToolUse {
+                        tool_name: "view_image".to_string(),
+                        action_type: ActionType::FileRead {
+                            path: relative_path.clone(),
+                        },
+                        status: ToolStatus::Success,
+                    },
+                    content: relative_path,
+                    metadata: None,
+                },
+            );
+        }
+        AppThreadItem::ExitedReviewMode { review, .. } => {
+            if let Some(mut review_state) = state.review.take() {
+                review_state.status = ToolStatus::Success;
+                review_state.result = Some(ToolResult::markdown(review));
+                if let Some(index) = review_state.index {
+                    replace_normalized_entry(msg_store, index, review_state.to_normalized_entry());
+                }
+            }
+        }
+        AppThreadItem::ContextCompaction { .. } => {
+            add_normalized_entry(
+                msg_store,
+                entry_index,
+                NormalizedEntry {
+                    timestamp: None,
+                    entry_type: NormalizedEntryType::SystemMessage,
+                    content: "Context compacted".to_string(),
+                    metadata: None,
+                },
+            );
+        }
+        _ => {}
+    }
+}
+
+fn handle_direct_request(
+    request: ServerRequest,
+    state: &mut LogState,
+    msg_store: &Arc<MsgStore>,
+    entry_index: &EntryIndexProvider,
+) -> bool {
+    match request {
+        ServerRequest::CommandExecutionRequestApproval { params, .. } => {
+            let call_id = params.item_id;
+            let approval_id = params.approval_id.unwrap_or_default();
+            let command_state = state.command_state(call_id.clone());
+            if let Some(command) = params.command.filter(|command| !command.is_empty()) {
+                command_state.command = command;
+            } else if command_state.command.is_empty() {
+                command_state.command = params
+                    .reason
+                    .filter(|reason| !reason.is_empty())
+                    .unwrap_or_else(|| "command execution".to_string());
+            }
+            command_state.awaiting_approval = true;
+            command_state.status = ToolStatus::PendingApproval { approval_id };
+            if let Some(index) = command_state.index {
+                replace_normalized_entry(msg_store, index, command_state.to_normalized_entry());
+            } else {
+                let index = add_normalized_entry(
+                    msg_store,
+                    entry_index,
+                    command_state.to_normalized_entry(),
+                );
+                command_state.index = Some(index);
+            }
+            true
+        }
+        ServerRequest::ToolRequestUserInput { params, .. } => {
+            upsert_question_request_state(
+                state,
+                msg_store,
+                entry_index,
+                params.item_id,
+                &params.questions,
+            );
+            true
+        }
+        ServerRequest::DynamicToolCall { params, .. } => {
+            upsert_dynamic_tool_state(
+                state,
+                msg_store,
+                entry_index,
+                DynamicToolUpdate {
+                    call_id: params.call_id,
+                    tool: params.tool,
+                    arguments: params.arguments,
+                    status: ToolStatus::Created,
+                    result: None,
+                },
+            );
+            true
+        }
+        _ => false,
+    }
+}
+
+fn handle_direct_notification(
+    notification: ServerNotification,
+    state: &mut LogState,
+    msg_store: &Arc<MsgStore>,
+    entry_index: &EntryIndexProvider,
+    worktree_path: &str,
+) -> bool {
+    match notification {
+        ServerNotification::ThreadStarted(n) => {
+            msg_store.push_session_id(n.thread.id);
+            true
+        }
+        ServerNotification::ThreadTokenUsageUpdated(notification) => {
+            add_thread_token_usage(notification, msg_store, entry_index);
+            true
+        }
+        ServerNotification::AgentMessageDelta(notification) => {
+            state.thinking = None;
+            let (entry, index, is_new) = state.assistant_message_append(notification.delta);
+            upsert_normalized_entry(msg_store, index, entry, is_new);
+            true
+        }
+        ServerNotification::ReasoningSummaryTextDelta(notification) => {
+            state.assistant = None;
+            let (entry, index, is_new) = state.thinking_append(notification.delta);
+            upsert_normalized_entry(msg_store, index, entry, is_new);
+            true
+        }
+        ServerNotification::ReasoningSummaryPartAdded(..) => {
+            state.assistant = None;
+            state.thinking = None;
+            true
+        }
+        ServerNotification::PlanDelta(notification) => {
+            state.thinking = None;
+            if let Some(plan_state) = state.plans.get_mut(&notification.item_id) {
+                plan_state.text.push_str(&notification.delta);
+                if let Some(index) = plan_state.index {
+                    replace_normalized_entry(msg_store, index, plan_state.to_normalized_entry());
+                }
+            } else {
+                let (entry, index, is_new) = state.assistant_message_append(notification.delta);
+                upsert_normalized_entry(msg_store, index, entry, is_new);
+            }
+            true
+        }
+        ServerNotification::CommandExecutionOutputDelta(
+            CommandExecutionOutputDeltaNotification { item_id, delta, .. },
+        ) => {
+            if let Some(command_state) = state.commands.get_mut(&item_id) {
+                command_state.stdout.push_str(&delta);
+                if let Some(index) = command_state.index {
+                    replace_normalized_entry(msg_store, index, command_state.to_normalized_entry());
+                }
+            }
+            true
+        }
+        ServerNotification::FileChangeOutputDelta(FileChangeOutputDeltaNotification { .. })
+        | ServerNotification::McpToolCallProgress(McpToolCallProgressNotification { .. })
+        | ServerNotification::ReasoningTextDelta(..)
+        | ServerNotification::ThreadStatusChanged(..)
+        | ServerNotification::TurnCompleted(..)
+        | ServerNotification::TurnStarted(..) => true,
+        ServerNotification::ItemStarted(notification) => {
+            handle_direct_item_started(notification, state, msg_store, entry_index, worktree_path);
+            true
+        }
+        ServerNotification::ItemCompleted(notification) => {
+            handle_direct_item_completed(
+                notification,
+                state,
+                msg_store,
+                entry_index,
+                worktree_path,
+            );
+            true
+        }
+        ServerNotification::ModelRerouted(notification) => {
+            add_normalized_entry(
+                msg_store,
+                entry_index,
+                NormalizedEntry {
+                    timestamp: None,
+                    entry_type: NormalizedEntryType::SystemMessage,
+                    content: format!(
+                        "warning: model rerouted from {} to {}",
+                        notification.from_model, notification.to_model
+                    ),
+                    metadata: None,
+                },
+            );
+            true
+        }
+        ServerNotification::ConfigWarning(notification) => {
+            let details = notification
+                .details
+                .as_deref()
+                .map(str::trim)
+                .filter(|details| !details.is_empty())
+                .map(|details| format!("\n{details}"))
+                .unwrap_or_default();
+            add_normalized_entry(
+                msg_store,
+                entry_index,
+                NormalizedEntry {
+                    timestamp: None,
+                    entry_type: NormalizedEntryType::ErrorMessage {
+                        error_type: NormalizedEntryError::Other,
+                    },
+                    content: format!("{}{}", notification.summary, details),
+                    metadata: None,
+                },
+            );
+            true
+        }
+        ServerNotification::Error(notification) => {
+            add_normalized_entry(
+                msg_store,
+                entry_index,
+                NormalizedEntry {
+                    timestamp: None,
+                    entry_type: NormalizedEntryType::ErrorMessage {
+                        error_type: NormalizedEntryError::Other,
+                    },
+                    content: format!("Error: {}", notification.error.message),
+                    metadata: None,
+                },
+            );
+            true
+        }
+        ServerNotification::ContextCompacted(..) => {
+            add_normalized_entry(
+                msg_store,
+                entry_index,
+                NormalizedEntry {
+                    timestamp: None,
+                    entry_type: NormalizedEntryType::SystemMessage,
+                    content: "Context compacted".to_string(),
+                    metadata: None,
+                },
+            );
+            true
+        }
+        _ => false,
+    }
 }
 
 fn format_todo_status(status: &StepStatus) -> String {
@@ -651,10 +1553,15 @@ pub fn normalize_logs(
             }
 
             if let Ok(server_notification) = serde_json::from_str::<ServerNotification>(&line) {
-                if let ServerNotification::ThreadStarted(n) = server_notification {
-                    msg_store.push_session_id(n.thread.id);
+                if handle_direct_notification(
+                    server_notification,
+                    &mut state,
+                    &msg_store,
+                    &entry_index,
+                    &worktree_path_str,
+                ) {
+                    continue;
                 }
-                continue;
             } else if let Some(session_id) = line
                 .strip_prefix(r#"{"method":"sessionConfigured","params":{"sessionId":""#)
                 .and_then(|suffix| SESSION_ID.captures(suffix).and_then(|caps| caps.get(1)))
@@ -662,6 +1569,13 @@ pub fn normalize_logs(
                 // Best-effort extraction of session ID from logs in case the JSON parsing fails.
                 // This could happen if the line is truncated due to size limits because it includes the full session history.
                 msg_store.push_session_id(session_id.as_str().to_string());
+                continue;
+            }
+
+            if let Ok(request) = serde_json::from_str::<JSONRPCRequest>(&line)
+                && let Ok(server_request) = ServerRequest::try_from(request)
+                && handle_direct_request(server_request, &mut state, &msg_store, &entry_index)
+            {
                 continue;
             }
 
@@ -1042,6 +1956,54 @@ pub fn normalize_logs(
                         );
                     }
                 }
+                EventMsg::DynamicToolCallRequest(request) => {
+                    upsert_dynamic_tool_state(
+                        &mut state,
+                        &msg_store,
+                        &entry_index,
+                        DynamicToolUpdate {
+                            call_id: request.call_id,
+                            tool: request.tool,
+                            arguments: request.arguments,
+                            status: ToolStatus::Created,
+                            result: None,
+                        },
+                    );
+                }
+                EventMsg::DynamicToolCallResponse(response) => {
+                    let mut result_text =
+                        dynamic_tool_markdown_from_core_items(&response.content_items);
+                    if let Some(error) = response.error
+                        && !error.trim().is_empty()
+                    {
+                        if !result_text.is_empty() {
+                            result_text.push('\n');
+                        }
+                        result_text.push_str(&error);
+                    }
+                    let result = if result_text.is_empty() {
+                        None
+                    } else {
+                        Some(ToolResult::markdown(result_text))
+                    };
+                    let status = if response.success {
+                        ToolStatus::Success
+                    } else {
+                        ToolStatus::Failed
+                    };
+                    upsert_dynamic_tool_state(
+                        &mut state,
+                        &msg_store,
+                        &entry_index,
+                        DynamicToolUpdate {
+                            call_id: response.call_id,
+                            tool: response.tool,
+                            arguments: response.arguments,
+                            status,
+                            result,
+                        },
+                    );
+                }
                 EventMsg::PatchApplyBegin(PatchApplyBeginEvent {
                     call_id, changes, ..
                 }) => {
@@ -1341,45 +2303,13 @@ pub fn normalize_logs(
                         continue;
                     }
 
-                    let questions: Vec<AskUserQuestionItem> = event_questions
-                        .iter()
-                        .map(|q| AskUserQuestionItem {
-                            question: q.question.clone(),
-                            header: q.header.clone(),
-                            options: q
-                                .options
-                                .as_deref()
-                                .unwrap_or(&[])
-                                .iter()
-                                .map(|o| AskUserQuestionOption {
-                                    label: o.label.clone(),
-                                    description: o.description.clone(),
-                                })
-                                .collect(),
-                            multi_select: false,
-                        })
-                        .collect();
-
-                    let content = if questions.len() == 1 {
-                        questions[0].question.clone()
-                    } else {
-                        format!("{} questions", questions.len())
-                    };
-
-                    let index = entry_index.next();
-                    let tool_state = UserInputRequestState {
-                        index: Some(index),
-                        questions,
-                        content,
-                        status: ToolStatus::Created,
-                    };
-                    upsert_normalized_entry(
+                    upsert_question_request_state(
+                        &mut state,
                         &msg_store,
-                        index,
-                        tool_state.to_normalized_entry(),
-                        true,
+                        &entry_index,
+                        call_id,
+                        &event_questions,
                     );
-                    state.user_input_requests.insert(call_id, tool_state);
                 }
                 EventMsg::PlanDelta(PlanDeltaEvent { delta, item_id, .. }) => {
                     state.thinking = None;
@@ -1482,10 +2412,6 @@ pub fn normalize_logs(
                 | EventMsg::CollabResumeBegin(..)
                 | EventMsg::CollabResumeEnd(..)
                 | EventMsg::ThreadNameUpdated(..)
-                | EventMsg::DynamicToolCallRequest(..)
-                | EventMsg::DynamicToolCallResponse(..)
-                | EventMsg::ListRemoteSkillsResponse(..)
-                | EventMsg::RemoteSkillDownloaded(..)
                 | EventMsg::RealtimeConversationStarted(..)
                 | EventMsg::RealtimeConversationRealtime(..)
                 | EventMsg::RealtimeConversationClosed(..)
@@ -1493,7 +2419,8 @@ pub fn normalize_logs(
                 | EventMsg::ImageGenerationEnd(..)
                 | EventMsg::RequestPermissions(..)
                 | EventMsg::HookCompleted(..)
-                | EventMsg::HookStarted(..) => {}
+                | EventMsg::HookStarted(..)
+                | EventMsg::GuardianAssessment(..) => {}
             }
         }
     });
@@ -1762,6 +2689,234 @@ impl ToNormalizedEntryOpt for Approval {
                 content: format!("Approval timed out for tool {tool_name}"),
                 metadata: None,
             }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::BTreeMap, sync::Arc};
+
+    use serde_json::json;
+    use workspace_utils::{log_msg::LogMsg, msg_store::MsgStore};
+
+    use super::*;
+    use crate::logs::{
+        ActionType, NormalizedEntryType, utils::patch::extract_normalized_entry_from_patch,
+    };
+
+    fn latest_normalized_entries(msg_store: &MsgStore) -> Vec<NormalizedEntry> {
+        let mut entries = BTreeMap::new();
+        for msg in msg_store.get_history() {
+            if let LogMsg::JsonPatch(patch) = msg
+                && let Some((index, entry)) = extract_normalized_entry_from_patch(&patch)
+            {
+                entries.insert(index, entry);
+            }
+        }
+        entries.into_values().collect()
+    }
+
+    async fn normalize_lines(lines: &[String]) -> Vec<NormalizedEntry> {
+        let msg_store = Arc::new(MsgStore::new());
+        for line in lines {
+            msg_store.push_stdout(format!("{line}\n"));
+        }
+        msg_store.push_finished();
+
+        for handle in normalize_logs(msg_store.clone(), Path::new("/tmp/test-worktree")) {
+            handle.await.unwrap();
+        }
+
+        latest_normalized_entries(&msg_store)
+    }
+
+    fn tool_use<'a>(entries: &'a [NormalizedEntry], tool_name: &str) -> &'a NormalizedEntry {
+        entries
+            .iter()
+            .find(|entry| {
+                matches!(
+                    &entry.entry_type,
+                    NormalizedEntryType::ToolUse { tool_name: name, .. } if name == tool_name
+                )
+            })
+            .unwrap_or_else(|| panic!("missing tool entry for {tool_name}"))
+    }
+
+    fn request_user_input_line(request_id: &str, call_id: &str) -> String {
+        json!({
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "method": "item/tool/requestUserInput",
+            "params": {
+                "threadId": "thread-1",
+                "turnId": "turn-1",
+                "itemId": call_id,
+                "questions": [{
+                    "id": "lang",
+                    "header": "Language",
+                    "question": "Which language?",
+                    "options": [{
+                        "label": "Rust",
+                        "description": "Use Rust"
+                    }]
+                }]
+            }
+        })
+        .to_string()
+    }
+
+    #[tokio::test]
+    async fn preserves_direct_command_denial_without_item_started() {
+        let call_id = "cmd-1";
+        let entries = normalize_lines(&[
+            json!({
+                "jsonrpc": "2.0",
+                "id": "req-1",
+                "method": "item/commandExecution/requestApproval",
+                "params": {
+                    "threadId": "thread-1",
+                    "turnId": "turn-1",
+                    "itemId": call_id,
+                    "approvalId": "approval-1",
+                    "command": "git push"
+                }
+            })
+            .to_string(),
+            Approval::approval_response(
+                call_id.to_string(),
+                "codex.exec_command".to_string(),
+                ApprovalStatus::Denied {
+                    reason: Some("Denied by user".to_string()),
+                },
+            )
+            .raw(),
+        ])
+        .await;
+
+        let command = tool_use(&entries, "bash");
+        match &command.entry_type {
+            NormalizedEntryType::ToolUse {
+                action_type: ActionType::CommandRun { command, .. },
+                status: ToolStatus::Denied { reason },
+                ..
+            } => {
+                assert_eq!(command, "git push");
+                assert_eq!(reason.as_deref(), Some("Denied by user"));
+            }
+            other => panic!("unexpected command entry: {other:?}"),
+        }
+
+        assert!(entries.iter().any(|entry| matches!(
+            &entry.entry_type,
+            NormalizedEntryType::UserFeedback { denied_tool } if denied_tool == "Exec Command"
+        )));
+    }
+
+    #[tokio::test]
+    async fn normalizes_direct_request_user_input_and_answer() {
+        let call_id = "question-1";
+        let entries = normalize_lines(&[
+            request_user_input_line("req-3", call_id),
+            Approval::question_response(
+                call_id.to_string(),
+                QuestionStatus::Answered {
+                    answers: vec![workspace_utils::approvals::QuestionAnswer {
+                        question: "Which language?".to_string(),
+                        answer: vec!["Rust".to_string()],
+                    }],
+                },
+            )
+            .raw(),
+        ])
+        .await;
+
+        let question = tool_use(&entries, "question");
+        match &question.entry_type {
+            NormalizedEntryType::ToolUse {
+                action_type: ActionType::AskUserQuestion { questions },
+                status: ToolStatus::Success,
+                ..
+            } => {
+                assert_eq!(questions.len(), 1);
+                assert_eq!(questions[0].question, "Which language?");
+            }
+            other => panic!("unexpected question entry: {other:?}"),
+        }
+
+        assert!(entries.iter().any(|entry| matches!(
+            &entry.entry_type,
+            NormalizedEntryType::UserAnsweredQuestions { answers }
+                if answers.len() == 1 && answers[0].question == "Which language?"
+        )));
+    }
+
+    #[tokio::test]
+    async fn normalizes_direct_dynamic_tool_success() {
+        let call_id = "call-dyn-1";
+        let tool_name = "lookup_ticket";
+        let entries = normalize_lines(&[
+            json!({
+                "jsonrpc": "2.0",
+                "id": "req-dyn-1",
+                "method": "item/tool/call",
+                "params": {
+                    "threadId": "thread-1",
+                    "turnId": "turn-1",
+                    "callId": call_id,
+                    "tool": tool_name,
+                    "arguments": {"id": "ABC-123"}
+                }
+            })
+            .to_string(),
+            json!({
+                "jsonrpc": "2.0",
+                "method": "item/completed",
+                "params": {
+                    "threadId": "thread-1",
+                    "turnId": "turn-1",
+                    "item": {
+                        "type": "dynamicToolCall",
+                        "id": call_id,
+                        "tool": tool_name,
+                        "arguments": {"id": "ABC-123"},
+                        "status": "completed",
+                        "contentItems": [{
+                            "type": "inputText",
+                            "text": "Ticket ABC-123 is open."
+                        }],
+                        "success": true,
+                        "durationMs": 1
+                    }
+                }
+            })
+            .to_string(),
+        ])
+        .await;
+
+        let dynamic = tool_use(&entries, tool_name);
+        match &dynamic.entry_type {
+            NormalizedEntryType::ToolUse {
+                action_type:
+                    ActionType::Tool {
+                        tool_name,
+                        arguments,
+                        result,
+                    },
+                status: ToolStatus::Success,
+                ..
+            } => {
+                assert_eq!(tool_name, "lookup_ticket");
+                assert_eq!(arguments.as_ref().unwrap()["id"], "ABC-123");
+                assert_eq!(
+                    result
+                        .as_ref()
+                        .and_then(|r| r.value.as_str())
+                        .unwrap_or_default(),
+                    "Ticket ABC-123 is open."
+                );
+            }
+            other => panic!("unexpected dynamic tool entry: {other:?}"),
         }
     }
 }

--- a/crates/executors/src/executors/codex/slash_commands.rs
+++ b/crates/executors/src/executors/codex/slash_commands.rs
@@ -256,6 +256,7 @@ impl Codex {
                 Ok(message) => EventMsg::AgentMessage(AgentMessageEvent {
                     message,
                     phase: None,
+                    memory_citation: None,
                 }),
                 Err(message) => EventMsg::Error(ErrorEvent {
                     message,
@@ -319,6 +320,7 @@ pub async fn log_event_raw(log_writer: &LogWriter, message: String) -> Result<()
         EventMsg::AgentMessage(AgentMessageEvent {
             message,
             phase: None,
+            memory_citation: None,
         }),
     )
     .await

--- a/packages/web-core/src/features/workspace-chat/ui/DisplayConversationEntry.tsx
+++ b/packages/web-core/src/features/workspace-chat/ui/DisplayConversationEntry.tsx
@@ -192,6 +192,11 @@ function renderToolUseEntry(
 
   // Plan presentation - use ChatApprovalCard
   if (action_type.action === 'plan_presentation') {
+    // Codex can emit an initial empty plan placeholder before content arrives.
+    // Suppress empty cards to avoid duplicate-looking plan boxes.
+    if (!action_type.plan.trim()) {
+      return null;
+    }
     return (
       <PlanEntry
         plan={action_type.plan}
@@ -260,6 +265,11 @@ function renderToolUseEntry(
 
   // Generic tool pending approval - use plan-style card
   if (status.status === 'pending_approval') {
+    // Question approvals are rendered via askQuestionMode in SessionChatBoxContainer.
+    // Avoid showing a duplicate inline approval card in the conversation timeline.
+    if (action_type.action === 'ask_user_question') {
+      return null;
+    }
     return (
       <GenericToolApprovalEntry
         toolName={entryType.tool_name}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk because it upgrades Codex protocol/CLI versions and significantly expands log normalization for new JSON-RPC request/notification shapes (dynamic tools, direct item events), which could affect session rendering and approval flows.
> 
> **Overview**
> Bumps Codex dependencies and runtime (`@openai/codex`, `codex-protocol`, `codex-app-server-protocol`) from `0.114.0` to `0.116.0`.
> 
> Updates the Codex executor to handle newer app-server protocol events: adds normalization for *direct* `ServerRequest`/`ServerNotification` streams (item started/completed, token usage updates, model reroute, config warnings/errors), tracks and renders `DynamicToolCall` tool uses with status/results, and refactors user-input question normalization to work across both core and app-server question types (with new tests covering direct approvals/questions/dynamic tools).
> 
> Tweaks the web conversation timeline to suppress empty plan placeholders and to avoid duplicate inline approval cards for question prompts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a9367cee105793c0c3004623737b2c143bc20e63. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->