### PR TITLE
fix: surface issue link failures after workspace creation

### DIFF
--- a/packages/web-core/src/shared/components/CreateChatBoxContainer.tsx
+++ b/packages/web-core/src/shared/components/CreateChatBoxContainer.tsx
@@ -16,6 +16,7 @@ import {
 } from '@/shared/lib/string';
 import type { BaseCodingAgent, Repo } from 'shared/types';
 import { CreateChatBox } from '@vibe/ui/components/CreateChatBox';
+import { ConfirmDialog } from '@vibe/ui/components/ConfirmDialog';
 import { SettingsDialog } from '@/shared/dialogs/settings/SettingsDialog';
 import { CreateModeRepoPickerBar } from './CreateModeRepoPickerBar';
 import { ModelSelectorContainer } from '@/shared/components/ModelSelectorContainer';
@@ -253,6 +254,19 @@ export function CreateChatBoxContainer({
       data,
       linkToIssue,
     });
+
+    if (result.linkErrorMessage) {
+      await ConfirmDialog.show({
+        title: t('common:error'),
+        message: t('workspaces.linkAfterCreateError', {
+          defaultValue:
+            'The workspace was created and started, but linking it to the issue failed. It will not appear in the issue workspace list until you link it. Error: {{error}}',
+          error: result.linkErrorMessage,
+        }),
+        confirmText: t('common:ok'),
+        showCancelButton: false,
+      });
+    }
 
     if (result.workspace) {
       onWorkspaceCreated(result.workspace.id);

--- a/packages/web-core/src/shared/hooks/useCreateWorkspace.ts
+++ b/packages/web-core/src/shared/hooks/useCreateWorkspace.ts
@@ -1,6 +1,9 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { workspacesApi } from '@/shared/lib/api';
-import type { CreateAndStartWorkspaceRequest } from 'shared/types';
+import type {
+  CreateAndStartWorkspaceRequest,
+  CreateAndStartWorkspaceResponse,
+} from 'shared/types';
 import { workspaceSummaryKeys } from '@/shared/hooks/workspaceSummaryKeys';
 
 interface CreateWorkspaceParams {
@@ -11,12 +14,21 @@ interface CreateWorkspaceParams {
   };
 }
 
+interface CreateWorkspaceResult {
+  workspace: CreateAndStartWorkspaceResponse['workspace'];
+  linkErrorMessage?: string;
+}
+
 export function useCreateWorkspace() {
   const queryClient = useQueryClient();
 
   const createWorkspace = useMutation({
-    mutationFn: async ({ data, linkToIssue }: CreateWorkspaceParams) => {
+    mutationFn: async ({
+      data,
+      linkToIssue,
+    }: CreateWorkspaceParams): Promise<CreateWorkspaceResult> => {
       const { workspace } = await workspacesApi.createAndStart(data);
+      let linkErrorMessage: string | undefined;
 
       if (linkToIssue && workspace) {
         try {
@@ -26,11 +38,20 @@ export function useCreateWorkspace() {
             linkToIssue.issueId
           );
         } catch (linkError) {
-          console.error('Failed to link workspace to issue:', linkError);
+          linkErrorMessage =
+            linkError instanceof Error
+              ? linkError.message
+              : 'Unknown error while linking workspace to issue';
+          console.error('Failed to link workspace to issue:', {
+            workspaceId: workspace.id,
+            projectId: linkToIssue.remoteProjectId,
+            issueId: linkToIssue.issueId,
+            error: linkError,
+          });
         }
       }
 
-      return { workspace };
+      return { workspace, linkErrorMessage };
     },
     onSuccess: () => {
       // Invalidate workspace summaries so they refresh with the new workspace included


### PR DESCRIPTION
Fixes #3269

## Summary

- return structured link-failure information from the workspace create/start mutation
- show an explicit dialog when the workspace is created but linking it to the issue fails
- preserve the existing successful flow while making the failure mode visible to the user

## Why

The issue page only lists workspaces whose remote `issue_id` matches the current issue. The local create/start flow links the issue in a follow-up request, so if that request fails the workspace still opens but silently disappears from the issue page. This change makes that state obvious to the user instead of swallowing it in `console.error`.

## Testing

- `pnpm run format`
- `pnpm --filter @vibe/web-core run check` *(fails on clean `origin/main` due unrelated existing type/dependency issues, including missing `@vibe/ui` component exports and missing `@tanstack/react-virtual` / markdown-related modules in `packages/web-core`)*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: UI/UX and mutation return-shape changes that only affect the post-create issue-linking path; main workspace creation flow remains unchanged.
> 
> **Overview**
> Surfaces failures when linking a newly created workspace to an issue, instead of only logging them.
> 
> `useCreateWorkspace` now returns a structured `linkErrorMessage` alongside the created `workspace` when the follow-up `linkToIssue` call fails, and `CreateChatBoxContainer` displays a blocking `ConfirmDialog` warning the user that the workspace won’t appear in the issue’s workspace list until manually linked.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ec2586e2440e14077a5515e0ed77979c64742061. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->