### PR TITLE
Fix macOS app menu branding to Vibe Kanban (Vibe Kanban)

### DIFF
--- a/crates/tauri-app/Info.plist
+++ b/crates/tauri-app/Info.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleDisplayName</key>
+	<string>Vibe Kanban</string>
+	<key>CFBundleName</key>
+	<string>Vibe Kanban</string>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsLocalNetworking</key>

--- a/crates/tauri-app/tauri.conf.json
+++ b/crates/tauri-app/tauri.conf.json
@@ -20,6 +20,9 @@
   "bundle": {
     "active": true,
     "targets": "all",
+    "macOS": {
+      "bundleName": "Vibe Kanban"
+    },
     "windows": {},
     "icon": [
       "icons/32x32.png",


### PR DESCRIPTION
## Summary
This PR fixes desktop app branding in the macOS application menu so users only see **Vibe Kanban** instead of the internal binary name (`vibe-kanban-tauri`).

## What Changed
- Updated macOS bundle metadata in `crates/tauri-app/Info.plist`:
  - Added `CFBundleDisplayName = Vibe Kanban`
  - Added `CFBundleName = Vibe Kanban`
- Updated Tauri config in `crates/tauri-app/tauri.conf.json`:
  - Added `bundle.macOS.bundleName = Vibe Kanban`

## Why
The production app UI was exposing the internal executable name in the Apple app menu entries (e.g., About/Hide/Quit), which is user-facing and inconsistent with the product brand. This change ensures the menu labels consistently display **Vibe Kanban**.

## Implementation Details
- `Info.plist` overrides ensure macOS resolves the app display name correctly at runtime.
- `tauri.conf.json` adds an explicit `bundleName` for macOS bundling to keep metadata consistent during packaging.
- The change is intentionally limited to branding metadata; no runtime logic was modified.

This PR was written using [Vibe Kanban](https://vibekanban.com)
