### PR TITLE
fix(server): return 404 when attempt-context path does not match a workspace

### DIFF
--- a/crates/server/src/error.rs
+++ b/crates/server/src/error.rs
@@ -488,6 +488,9 @@ impl IntoResponse for ApiError {
             },
             ApiError::Executor(_) => ErrorInfo::internal("ExecutorError"),
             ApiError::CommandBuilder(_) => ErrorInfo::internal("CommandBuildError"),
+            ApiError::Database(sqlx::Error::RowNotFound) => {
+                ErrorInfo::not_found("DatabaseError", "Resource not found.")
+            }
             ApiError::Database(_) => ErrorInfo::internal("DatabaseError"),
             ApiError::Worktree(_) => ErrorInfo::internal("WorktreeError"),
             ApiError::Config(_) => ErrorInfo::internal("ConfigError"),
@@ -616,6 +619,20 @@ impl From<RelayApiError> for ApiError {
     fn from(err: RelayApiError) -> Self {
         tracing::warn!(%err, "Relay transport failed");
         ApiError::BadGateway(err.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{http::StatusCode, response::IntoResponse};
+
+    use super::ApiError;
+
+    #[test]
+    fn database_row_not_found_maps_to_not_found() {
+        let response = ApiError::Database(sqlx::Error::RowNotFound).into_response();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
     }
 }
 


### PR DESCRIPTION
## Summary
- map `sqlx::Error::RowNotFound` to `404 Not Found` instead of `500 Internal Server Error`
- add a regression test covering the row-not-found mapping

## Why this is safe
`crates/mcp/src/task_server/mod.rs` already treats non-success responses from this endpoint as "no context", so returning `404` preserves the current caller behavior while fixing the HTTP semantics and logs.

## Validation
- `cargo test -p server`
- `cargo fmt --all`
- `pnpm run format` reaches frontend formatting, but this local worktree does not have `node_modules`, so `prettier` is unavailable

Fixes #3272

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only HTTP error mapping for `sqlx::Error::RowNotFound` from 500 to 404 and adds a focused regression test, with no data writes or auth logic impacted.
> 
> **Overview**
> Returns **`404 Not Found`** (instead of `500`) when `ApiError::Database` wraps `sqlx::Error::RowNotFound`, improving semantics and reducing noisy internal-error logging.
> 
> Adds a small unit test in `crates/server/src/error.rs` to ensure the `RowNotFound` mapping produces a `NOT_FOUND` response.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dd250ceaa28647e7ccad9f61fbe1647b5b0391c0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->