### PR TITLE
feat(oauth): polling-based login for desktop app (Vibe Kanban)

### DIFF
--- a/crates/api-types/src/oauth.rs
+++ b/crates/api-types/src/oauth.rs
@@ -92,3 +92,22 @@ pub struct StatusResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub degraded: Option<bool>,
 }
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct HandoffPollRequest {
+    pub handoff_id: Uuid,
+    pub app_verifier: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(tag = "status", rename_all = "lowercase")]
+pub enum HandoffPollResponse {
+    Pending,
+    Complete {
+        access_token: String,
+        refresh_token: String,
+    },
+    Error {
+        error: String,
+    },
+}

--- a/crates/local-deployment/src/lib.rs
+++ b/crates/local-deployment/src/lib.rs
@@ -81,10 +81,13 @@ pub struct LocalDeployment {
     pr_sync_notify: Arc<Notify>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 struct PendingHandoff {
     provider: String,
     app_verifier: String,
+    /// Handle for the background poll task (desktop flow).
+    /// Aborted when the handoff is taken or replaced.
+    poll_task: Option<tokio::task::JoinHandle<()>>,
 }
 
 #[async_trait]
@@ -456,22 +459,33 @@ impl LocalDeployment {
         handoff_id: Uuid,
         provider: String,
         app_verifier: String,
+        poll_task: Option<tokio::task::JoinHandle<()>>,
     ) {
-        self.oauth_handoffs.write().await.insert(
+        let mut handoffs = self.oauth_handoffs.write().await;
+        // Abort any existing poll task for this handoff (e.g. user retried).
+        if let Some(old) = handoffs.remove(&handoff_id) {
+            if let Some(handle) = old.poll_task {
+                handle.abort();
+            }
+        }
+        handoffs.insert(
             handoff_id,
             PendingHandoff {
                 provider,
                 app_verifier,
+                poll_task,
             },
         );
     }
 
     pub async fn take_oauth_handoff(&self, handoff_id: &Uuid) -> Option<(String, String)> {
-        self.oauth_handoffs
-            .write()
-            .await
-            .remove(handoff_id)
-            .map(|state| (state.provider, state.app_verifier))
+        let removed = self.oauth_handoffs.write().await.remove(handoff_id);
+        removed.map(|state| {
+            if let Some(handle) = state.poll_task {
+                handle.abort();
+            }
+            (state.provider, state.app_verifier)
+        })
     }
 
     pub fn pty(&self) -> &PtyService {

--- a/crates/local-deployment/src/lib.rs
+++ b/crates/local-deployment/src/lib.rs
@@ -1,6 +1,9 @@
 use std::{
     collections::HashMap,
-    sync::{Arc, OnceLock},
+    sync::{
+        Arc, OnceLock,
+        atomic::{AtomicBool, Ordering},
+    },
 };
 
 use api_types::LoginStatus;
@@ -85,9 +88,9 @@ pub struct LocalDeployment {
 struct PendingHandoff {
     provider: String,
     app_verifier: String,
-    /// Handle for the background poll task (desktop flow).
-    /// Aborted when the handoff is taken or replaced.
-    poll_task: Option<tokio::task::JoinHandle<()>>,
+    /// Cooperative cancellation flag for the background poll task.
+    /// Set to `true` to signal the task to stop at the next loop iteration.
+    cancelled: Arc<AtomicBool>,
 }
 
 #[async_trait]
@@ -459,35 +462,34 @@ impl LocalDeployment {
         handoff_id: Uuid,
         provider: String,
         app_verifier: String,
-        poll_task: Option<tokio::task::JoinHandle<()>>,
-    ) {
+    ) -> Arc<AtomicBool> {
         let mut handoffs = self.oauth_handoffs.write().await;
-        // Abort all existing poll tasks — a new handoff_init means the user
-        // retried, and each retry generates a fresh handoff_id, so we can't
-        // look up the old entry by the new ID.
+        // Signal all existing poll tasks to stop — a new handoff_init means
+        // the user retried, and each retry generates a fresh handoff_id.
         for (_, old) in handoffs.drain() {
-            if let Some(handle) = old.poll_task {
-                handle.abort();
-            }
+            old.cancelled.store(true, Ordering::Relaxed);
         }
+        let cancelled = Arc::new(AtomicBool::new(false));
         handoffs.insert(
             handoff_id,
             PendingHandoff {
                 provider,
                 app_verifier,
-                poll_task,
+                cancelled: cancelled.clone(),
             },
         );
+        cancelled
     }
 
     pub async fn take_oauth_handoff(&self, handoff_id: &Uuid) -> Option<(String, String)> {
-        let removed = self.oauth_handoffs.write().await.remove(handoff_id);
-        removed.map(|state| {
-            if let Some(handle) = state.poll_task {
-                handle.abort();
-            }
-            (state.provider, state.app_verifier)
-        })
+        self.oauth_handoffs
+            .write()
+            .await
+            .remove(handoff_id)
+            .map(|state| {
+                state.cancelled.store(true, Ordering::Relaxed);
+                (state.provider, state.app_verifier)
+            })
     }
 
     pub fn pty(&self) -> &PtyService {

--- a/crates/local-deployment/src/lib.rs
+++ b/crates/local-deployment/src/lib.rs
@@ -463,10 +463,10 @@ impl LocalDeployment {
     ) {
         let mut handoffs = self.oauth_handoffs.write().await;
         // Abort any existing poll task for this handoff (e.g. user retried).
-        if let Some(old) = handoffs.remove(&handoff_id) {
-            if let Some(handle) = old.poll_task {
-                handle.abort();
-            }
+        if let Some(old) = handoffs.remove(&handoff_id)
+            && let Some(handle) = old.poll_task
+        {
+            handle.abort();
         }
         handoffs.insert(
             handoff_id,

--- a/crates/local-deployment/src/lib.rs
+++ b/crates/local-deployment/src/lib.rs
@@ -462,11 +462,13 @@ impl LocalDeployment {
         poll_task: Option<tokio::task::JoinHandle<()>>,
     ) {
         let mut handoffs = self.oauth_handoffs.write().await;
-        // Abort any existing poll task for this handoff (e.g. user retried).
-        if let Some(old) = handoffs.remove(&handoff_id)
-            && let Some(handle) = old.poll_task
-        {
-            handle.abort();
+        // Abort all existing poll tasks — a new handoff_init means the user
+        // retried, and each retry generates a fresh handoff_id, so we can't
+        // look up the old entry by the new ID.
+        for (_, old) in handoffs.drain() {
+            if let Some(handle) = old.poll_task {
+                handle.abort();
+            }
         }
         handoffs.insert(
             handoff_id,

--- a/crates/remote/src/auth/handoff.rs
+++ b/crates/remote/src/auth/handoff.rs
@@ -387,9 +387,17 @@ impl OAuthHandoffService {
             Some(AuthorizationStatus::Error) => Ok(PollResult::Error(
                 record.error_code.unwrap_or_else(|| "unknown".to_string()),
             )),
-            Some(AuthorizationStatus::Redeemed) => Err(HandoffError::Authorization(
-                OAuthHandoffError::AlreadyRedeemed,
-            )),
+            Some(AuthorizationStatus::Redeemed) => {
+                // The handoff was already redeemed (likely by this same poll flow
+                // whose HTTP response was lost). Re-verify and re-generate tokens
+                // so the caller can still complete login.
+                let provided_challenge = hash_sha256_hex(app_verifier);
+                if provided_challenge != record.app_challenge {
+                    return Err(HandoffError::Failed("invalid_app_verifier".into()));
+                }
+                let result = self.complete_authorized_handoff(&record, &repo).await?;
+                Ok(PollResult::Complete(result))
+            }
             _ => Err(HandoffError::Failed("invalid_state".into())),
         }
     }

--- a/crates/remote/src/auth/handoff.rs
+++ b/crates/remote/src/auth/handoff.rs
@@ -98,6 +98,13 @@ pub struct RedeemResponse {
     pub email: String,
 }
 
+#[derive(Debug, Clone)]
+pub enum PollResult {
+    Pending,
+    Complete(RedeemResponse),
+    Error(String),
+}
+
 pub struct OAuthHandoffService {
     pool: PgPool,
     providers: Arc<ProviderRegistry>,
@@ -332,18 +339,67 @@ impl OAuthHandoffService {
 
         let expected_code_hash = record
             .app_code_hash
+            .clone()
             .ok_or_else(|| HandoffError::Failed("missing_app_code".into()))?;
         let provided_hash = hash_sha256_hex(app_code);
         if provided_hash != expected_code_hash {
             return Err(HandoffError::Failed("invalid_app_code".into()));
         }
 
-        let expected_challenge = record.app_challenge;
+        let expected_challenge = record.app_challenge.clone();
         let provided_challenge = hash_sha256_hex(app_verifier);
         if provided_challenge != expected_challenge {
             return Err(HandoffError::Failed("invalid_app_verifier".into()));
         }
 
+        self.complete_authorized_handoff(&record, &repo).await
+    }
+
+    /// Poll a handoff for completion (desktop flow).
+    ///
+    /// Returns `Ok(PollResult::Pending)` while the user hasn't finished OAuth,
+    /// `Ok(PollResult::Complete(..))` once tokens are ready, or an error.
+    pub async fn poll(
+        &self,
+        handoff_id: Uuid,
+        app_verifier: &str,
+    ) -> Result<PollResult, HandoffError> {
+        let repo = OAuthHandoffRepository::new(&self.pool);
+        let record = repo.get(handoff_id).await?;
+
+        if is_expired(&record) {
+            repo.set_status(record.id, AuthorizationStatus::Expired, Some("expired"))
+                .await?;
+            return Err(HandoffError::Expired);
+        }
+
+        match record.status() {
+            Some(AuthorizationStatus::Pending) => Ok(PollResult::Pending),
+            Some(AuthorizationStatus::Authorized) => {
+                let provided_challenge = hash_sha256_hex(app_verifier);
+                if provided_challenge != record.app_challenge {
+                    return Err(HandoffError::Failed("invalid_app_verifier".into()));
+                }
+
+                let result = self.complete_authorized_handoff(&record, &repo).await?;
+                Ok(PollResult::Complete(result))
+            }
+            Some(AuthorizationStatus::Error) => Ok(PollResult::Error(
+                record.error_code.unwrap_or_else(|| "unknown".to_string()),
+            )),
+            Some(AuthorizationStatus::Redeemed) => Err(HandoffError::Authorization(
+                OAuthHandoffError::AlreadyRedeemed,
+            )),
+            _ => Err(HandoffError::Failed("invalid_state".into())),
+        }
+    }
+
+    /// Shared logic for generating tokens and marking a handoff as redeemed.
+    async fn complete_authorized_handoff(
+        &self,
+        record: &OAuthHandoff,
+        repo: &OAuthHandoffRepository<'_>,
+    ) -> Result<RedeemResponse, HandoffError> {
         let session_id = record
             .session_id
             .ok_or_else(|| HandoffError::Failed("missing_session".into()))?;

--- a/crates/remote/src/auth/mod.rs
+++ b/crates/remote/src/auth/mod.rs
@@ -5,7 +5,7 @@ mod middleware;
 mod oauth_token_validator;
 mod provider;
 
-pub(crate) use handoff::{CallbackResult, HandoffError, OAuthHandoffService};
+pub(crate) use handoff::{CallbackResult, HandoffError, OAuthHandoffService, PollResult};
 pub(crate) use jwt::{JwtError, JwtService};
 pub(crate) use local::{LocalAuthError, auth_methods_response, is_local_provider, login};
 pub(crate) use middleware::{RequestContext, require_session};

--- a/crates/remote/src/routes/oauth.rs
+++ b/crates/remote/src/routes/oauth.rs
@@ -1,8 +1,9 @@
 use std::borrow::Cow;
 
 use api_types::{
-    AuthMethodsResponse, HandoffInitRequest, HandoffInitResponse, HandoffRedeemRequest,
-    HandoffRedeemResponse, LocalLoginRequest, LocalLoginResponse, ProfileResponse, ProviderProfile,
+    AuthMethodsResponse, HandoffInitRequest, HandoffInitResponse, HandoffPollRequest,
+    HandoffPollResponse, HandoffRedeemRequest, HandoffRedeemResponse, LocalLoginRequest,
+    LocalLoginResponse, ProfileResponse, ProviderProfile,
 };
 use axum::{
     Json, Router,
@@ -20,8 +21,8 @@ use crate::{
     AppState,
     audit::{self, AuditAction, AuditEvent},
     auth::{
-        CallbackResult, HandoffError, LocalAuthError, RequestContext, auth_methods_response,
-        login as local_login_flow,
+        CallbackResult, HandoffError, LocalAuthError, PollResult, RequestContext,
+        auth_methods_response, login as local_login_flow,
     },
     db::{oauth::OAuthHandoffError, oauth_accounts::OAuthAccountRepository},
 };
@@ -32,6 +33,8 @@ pub(super) fn public_router() -> Router<AppState> {
         .route("/auth/local/login", post(local_login))
         .route("/oauth/web/init", post(web_init))
         .route("/oauth/web/redeem", post(web_redeem))
+        .route("/oauth/web/poll", post(web_poll))
+        .route("/oauth/web/callback-success", get(callback_success))
         .route("/oauth/{provider}/start", get(authorize_start))
         .route("/oauth/{provider}/callback", get(authorize_callback))
 }
@@ -109,6 +112,115 @@ async fn web_redeem(
         }
         Err(error) => redeem_error_response(error),
     }
+}
+
+async fn web_poll(
+    State(state): State<AppState>,
+    Json(payload): Json<HandoffPollRequest>,
+) -> Response {
+    let handoff = state.handoff();
+    match handoff
+        .poll(payload.handoff_id, &payload.app_verifier)
+        .await
+    {
+        Ok(PollResult::Pending) => {
+            (StatusCode::OK, Json(HandoffPollResponse::Pending)).into_response()
+        }
+        Ok(PollResult::Complete(result)) => {
+            if let Some(analytics) = state.analytics() {
+                analytics.track(
+                    result.user_id,
+                    "$identify",
+                    serde_json::json!({ "email": result.email }),
+                );
+            }
+
+            audit::emit(
+                AuditEvent::system(AuditAction::AuthLogin)
+                    .user(result.user_id, None)
+                    .resource("auth_session", None)
+                    .http("POST", "/v1/oauth/web/poll", 200)
+                    .description("User logged in via OAuth (desktop poll)"),
+            );
+
+            (
+                StatusCode::OK,
+                Json(HandoffPollResponse::Complete {
+                    access_token: result.access_token,
+                    refresh_token: result.refresh_token,
+                }),
+            )
+                .into_response()
+        }
+        Ok(PollResult::Error(error)) => {
+            (StatusCode::OK, Json(HandoffPollResponse::Error { error })).into_response()
+        }
+        Err(error) => redeem_error_response(error),
+    }
+}
+
+async fn callback_success() -> Response {
+    let body = r#"<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Authentication Complete</title>
+    <style>
+      @import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600&display=swap');
+      *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+      body {
+        font-family: 'IBM Plex Sans', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+        background: #f2f2f2;
+        color: #333;
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+      .container {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 24px;
+        padding: 24px;
+      }
+      .checkmark {
+        width: 48px;
+        height: 48px;
+        color: #22c55e;
+      }
+      .content {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 4px;
+      }
+      .title {
+        font-size: 13px;
+        font-weight: 500;
+        color: #0d0d0d;
+      }
+      .subtitle {
+        font-size: 12px;
+        color: #636363;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <svg class="checkmark" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+      </svg>
+      <div class="content">
+        <p class="title">Authentication complete</p>
+        <p class="subtitle">You can close this tab and return to the app.</p>
+      </div>
+    </div>
+  </body>
+</html>"#;
+
+    axum::response::Html(body).into_response()
 }
 
 async fn local_login(

--- a/crates/server/src/routes/oauth.rs
+++ b/crates/server/src/routes/oauth.rs
@@ -473,9 +473,8 @@ async fn poll_for_login(deployment: DeploymentImpl, handoff_id: Uuid, app_verifi
                 access_token,
                 refresh_token,
             }) => {
-                // Clean up the stored handoff.
-                deployment.take_oauth_handoff(&handoff_id).await;
-
+                // Finalize login BEFORE cleaning up the handoff entry,
+                // because take_oauth_handoff aborts this task's own JoinHandle.
                 if let Err(e) = finalize_login(
                     &deployment,
                     Credentials {
@@ -488,6 +487,7 @@ async fn poll_for_login(deployment: DeploymentImpl, handoff_id: Uuid, app_verifi
                 {
                     tracing::error!(?e, "failed to finalize login from desktop poll");
                 }
+                deployment.take_oauth_handoff(&handoff_id).await;
                 return;
             }
             Ok(HandoffPollResponse::Error { error }) => {

--- a/crates/server/src/routes/oauth.rs
+++ b/crates/server/src/routes/oauth.rs
@@ -487,9 +487,14 @@ async fn poll_for_login(deployment: DeploymentImpl, handoff_id: Uuid, app_verifi
                 deployment.take_oauth_handoff(&handoff_id).await;
                 return;
             }
-            Err(e) => {
+            Err(e) if e.is_transient() => {
                 tracing::debug!(?e, "desktop handoff poll request failed, retrying");
                 continue;
+            }
+            Err(e) => {
+                tracing::warn!(?e, "desktop handoff poll hit permanent error");
+                deployment.take_oauth_handoff(&handoff_id).await;
+                return;
             }
         }
     }

--- a/crates/server/src/routes/oauth.rs
+++ b/crates/server/src/routes/oauth.rs
@@ -1,6 +1,6 @@
 use api_types::{
-    AuthMethodsResponse, HandoffInitRequest, HandoffRedeemRequest, LocalLoginRequest,
-    ProfileResponse, StatusResponse,
+    AuthMethodsResponse, HandoffInitRequest, HandoffPollRequest, HandoffPollResponse,
+    HandoffRedeemRequest, LocalLoginRequest, ProfileResponse, StatusResponse,
 };
 use axum::{
     Router,
@@ -103,6 +103,8 @@ async fn auth_methods(
 struct HandoffInitPayload {
     provider: String,
     return_to: String,
+    #[serde(default)]
+    desktop: bool,
 }
 
 #[derive(Debug, Serialize)]
@@ -120,17 +122,42 @@ async fn handoff_init(
     let app_verifier = generate_secret();
     let app_challenge = hash_sha256_hex(&app_verifier);
 
+    // For desktop, redirect the browser to a remote-hosted success page
+    // instead of back to localhost.
+    let return_to = if payload.desktop {
+        let api_base = deployment
+            .remote_info()
+            .get_api_base()
+            .ok_or_else(|| ApiError::BadRequest("Remote API not configured".to_string()))?;
+        format!(
+            "{}/v1/oauth/web/callback-success",
+            api_base.trim_end_matches('/')
+        )
+    } else {
+        payload.return_to.clone()
+    };
+
     let request = HandoffInitRequest {
         provider: payload.provider.clone(),
-        return_to: payload.return_to.clone(),
+        return_to,
         app_challenge,
     };
 
     let response = client.handoff_init(&request).await?;
 
     deployment
-        .store_oauth_handoff(response.handoff_id, payload.provider, app_verifier)
+        .store_oauth_handoff(response.handoff_id, payload.provider, app_verifier.clone())
         .await;
+
+    // For desktop, spawn a background task that polls the remote server
+    // until the OAuth flow completes, then finalizes login automatically.
+    if payload.desktop {
+        let handoff_id = response.handoff_id;
+        let deployment_clone = deployment.clone();
+        tokio::spawn(async move {
+            poll_for_login(deployment_clone, handoff_id, app_verifier).await;
+        });
+    }
 
     Ok(ResponseJson(ApiResponse::success(
         HandoffInitResponseBody {
@@ -147,10 +174,6 @@ struct HandoffCompleteQuery {
     app_code: Option<String>,
     #[serde(default)]
     error: Option<String>,
-    /// When set to "desktop", the callback page will not auto-close so the user
-    /// can see the success message (e.g. when opened from the Tauri desktop app).
-    #[serde(default)]
-    source: Option<String>,
 }
 
 async fn handoff_complete(
@@ -205,11 +228,9 @@ async fn handoff_complete(
     )
     .await?;
 
-    let is_desktop = query.source.as_deref() == Some("desktop");
-    Ok(close_window_response(
-        format!("Signed in with {provider}. You can return to the app."),
-        is_desktop,
-    ))
+    Ok(close_window_response(format!(
+        "Signed in with {provider}. You can return to the app."
+    )))
 }
 
 async fn local_login(
@@ -422,6 +443,61 @@ async fn finalize_login(
     Ok(profile)
 }
 
+/// Background task that polls the remote server for OAuth completion (desktop flow).
+async fn poll_for_login(deployment: DeploymentImpl, handoff_id: Uuid, app_verifier: String) {
+    let client = match deployment.remote_client() {
+        Ok(c) => c,
+        Err(_) => return,
+    };
+
+    let request = HandoffPollRequest {
+        handoff_id,
+        app_verifier,
+    };
+
+    // Poll every 2 seconds for up to 5 minutes.
+    for _ in 0..150 {
+        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+
+        match client.handoff_poll(&request).await {
+            Ok(HandoffPollResponse::Pending) => continue,
+            Ok(HandoffPollResponse::Complete {
+                access_token,
+                refresh_token,
+            }) => {
+                // Clean up the stored handoff.
+                deployment.take_oauth_handoff(&handoff_id).await;
+
+                if let Err(e) = finalize_login(
+                    &deployment,
+                    Credentials {
+                        access_token: Some(access_token),
+                        refresh_token,
+                        expires_at: None,
+                    },
+                )
+                .await
+                {
+                    tracing::error!(?e, "failed to finalize login from desktop poll");
+                }
+                return;
+            }
+            Ok(HandoffPollResponse::Error { error }) => {
+                tracing::warn!(%error, "desktop handoff poll returned error");
+                deployment.take_oauth_handoff(&handoff_id).await;
+                return;
+            }
+            Err(e) => {
+                tracing::debug!(?e, "desktop handoff poll request failed, retrying");
+                continue;
+            }
+        }
+    }
+
+    tracing::warn!("desktop handoff poll timed out");
+    deployment.take_oauth_handoff(&handoff_id).await;
+}
+
 fn hash_sha256_hex(input: &str) -> String {
     let mut output = String::with_capacity(64);
     let digest = Sha256::digest(input.as_bytes());
@@ -460,17 +536,7 @@ fn simple_html_response(status: StatusCode, message: String) -> Response<String>
         .unwrap()
 }
 
-fn close_window_response(message: String, skip_auto_close: bool) -> Response<String> {
-    let script = if skip_auto_close {
-        "" // Desktop app: leave the tab open so the user sees the message
-    } else {
-        "<script>\
-           window.addEventListener('load', () => {\
-             try { window.close(); } catch (err) {}\
-             setTimeout(() => { window.close(); }, 150);\
-           });\
-         </script>"
-    };
+fn close_window_response(message: String) -> Response<String> {
     let body = format!(
         r#"<!doctype html>
 <html>
@@ -478,7 +544,12 @@ fn close_window_response(message: String, skip_auto_close: bool) -> Response<Str
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Authentication Complete</title>
-    {script}
+    <script>
+      window.addEventListener('load', () => {{
+        try {{ window.close(); }} catch (err) {{}}
+        setTimeout(() => {{ window.close(); }}, 150);
+      }});
+    </script>
     {AUTH_PAGE_STYLES}
   </head>
   <body>

--- a/crates/server/src/routes/oauth.rs
+++ b/crates/server/src/routes/oauth.rs
@@ -145,19 +145,27 @@ async fn handoff_init(
 
     let response = client.handoff_init(&request).await?;
 
-    deployment
-        .store_oauth_handoff(response.handoff_id, payload.provider, app_verifier.clone())
-        .await;
-
     // For desktop, spawn a background task that polls the remote server
     // until the OAuth flow completes, then finalizes login automatically.
-    if payload.desktop {
+    let poll_task = if payload.desktop {
         let handoff_id = response.handoff_id;
         let deployment_clone = deployment.clone();
-        tokio::spawn(async move {
-            poll_for_login(deployment_clone, handoff_id, app_verifier).await;
-        });
-    }
+        let verifier = app_verifier.clone();
+        Some(tokio::spawn(async move {
+            poll_for_login(deployment_clone, handoff_id, verifier).await;
+        }))
+    } else {
+        None
+    };
+
+    deployment
+        .store_oauth_handoff(
+            response.handoff_id,
+            payload.provider,
+            app_verifier,
+            poll_task,
+        )
+        .await;
 
     Ok(ResponseJson(ApiResponse::success(
         HandoffInitResponseBody {

--- a/crates/server/src/routes/oauth.rs
+++ b/crates/server/src/routes/oauth.rs
@@ -145,27 +145,19 @@ async fn handoff_init(
 
     let response = client.handoff_init(&request).await?;
 
+    let cancelled = deployment
+        .store_oauth_handoff(response.handoff_id, payload.provider, app_verifier.clone())
+        .await;
+
     // For desktop, spawn a background task that polls the remote server
     // until the OAuth flow completes, then finalizes login automatically.
-    let poll_task = if payload.desktop {
+    if payload.desktop {
         let handoff_id = response.handoff_id;
         let deployment_clone = deployment.clone();
-        let verifier = app_verifier.clone();
-        Some(tokio::spawn(async move {
-            poll_for_login(deployment_clone, handoff_id, verifier).await;
-        }))
-    } else {
-        None
-    };
-
-    deployment
-        .store_oauth_handoff(
-            response.handoff_id,
-            payload.provider,
-            app_verifier,
-            poll_task,
-        )
-        .await;
+        tokio::spawn(async move {
+            poll_for_login(deployment_clone, handoff_id, app_verifier, cancelled).await;
+        });
+    }
 
     Ok(ResponseJson(ApiResponse::success(
         HandoffInitResponseBody {
@@ -452,7 +444,17 @@ async fn finalize_login(
 }
 
 /// Background task that polls the remote server for OAuth completion (desktop flow).
-async fn poll_for_login(deployment: DeploymentImpl, handoff_id: Uuid, app_verifier: String) {
+///
+/// Uses a cooperative `cancelled` flag instead of `JoinHandle::abort()` so that
+/// `finalize_login` is never interrupted mid-execution by a concurrent retry.
+async fn poll_for_login(
+    deployment: DeploymentImpl,
+    handoff_id: Uuid,
+    app_verifier: String,
+    cancelled: std::sync::Arc<std::sync::atomic::AtomicBool>,
+) {
+    use std::sync::atomic::Ordering;
+
     let client = match deployment.remote_client() {
         Ok(c) => c,
         Err(_) => return,
@@ -467,14 +469,17 @@ async fn poll_for_login(deployment: DeploymentImpl, handoff_id: Uuid, app_verifi
     for _ in 0..150 {
         tokio::time::sleep(std::time::Duration::from_secs(2)).await;
 
+        if cancelled.load(Ordering::Relaxed) {
+            tracing::debug!(%handoff_id, "desktop login poll cancelled");
+            return;
+        }
+
         match client.handoff_poll(&request).await {
             Ok(HandoffPollResponse::Pending) => continue,
             Ok(HandoffPollResponse::Complete {
                 access_token,
                 refresh_token,
             }) => {
-                // Finalize login BEFORE cleaning up the handoff entry,
-                // because take_oauth_handoff aborts this task's own JoinHandle.
                 if let Err(e) = finalize_login(
                     &deployment,
                     Credentials {

--- a/crates/services/src/services/remote_client.rs
+++ b/crates/services/src/services/remote_client.rs
@@ -60,12 +60,16 @@ impl RemoteClientError {
     }
 
     /// Returns true if the error is transient and should be retried.
-    fn should_retry(&self) -> bool {
+    pub fn is_transient(&self) -> bool {
         match self {
             Self::Transport(_) | Self::Timeout => true,
             Self::Http { status, .. } => (500..=599).contains(status),
             _ => false,
         }
+    }
+
+    fn should_retry(&self) -> bool {
+        self.is_transient()
     }
 
     fn is_definitive_auth_failure(&self) -> bool {

--- a/crates/services/src/services/remote_client.rs
+++ b/crates/services/src/services/remote_client.rs
@@ -8,15 +8,16 @@ use api_types::{
     CreateIssueRequest, CreateIssueTagRequest, CreateOrganizationRequest,
     CreateOrganizationResponse, CreateWorkspaceRequest, DeleteResponse, DeleteWorkspaceRequest,
     GetInvitationResponse, GetOrganizationResponse, HandoffInitRequest, HandoffInitResponse,
-    HandoffRedeemRequest, HandoffRedeemResponse, Issue, IssueAssignee, IssueRelationship, IssueTag,
-    ListAttachmentsResponse, ListInvitationsResponse, ListIssueAssigneesResponse,
-    ListIssueRelationshipsResponse, ListIssueTagsResponse, ListIssuesResponse, ListMembersResponse,
-    ListOrganizationsResponse, ListProjectStatusesResponse, ListProjectsResponse,
-    ListPullRequestsResponse, ListTagsResponse, LocalLoginRequest, LocalLoginResponse,
-    MutationResponse, Organization, ProfileResponse, PullRequest, RevokeInvitationRequest,
-    SearchIssuesRequest, Tag, TokenRefreshRequest, TokenRefreshResponse, UpdateIssueRequest,
-    UpdateMemberRoleRequest, UpdateMemberRoleResponse, UpdateOrganizationRequest,
-    UpdatePullRequestApiRequest, UpdateWorkspaceRequest, UpsertPullRequestRequest, Workspace,
+    HandoffPollRequest, HandoffPollResponse, HandoffRedeemRequest, HandoffRedeemResponse, Issue,
+    IssueAssignee, IssueRelationship, IssueTag, ListAttachmentsResponse, ListInvitationsResponse,
+    ListIssueAssigneesResponse, ListIssueRelationshipsResponse, ListIssueTagsResponse,
+    ListIssuesResponse, ListMembersResponse, ListOrganizationsResponse,
+    ListProjectStatusesResponse, ListProjectsResponse, ListPullRequestsResponse, ListTagsResponse,
+    LocalLoginRequest, LocalLoginResponse, MutationResponse, Organization, ProfileResponse,
+    PullRequest, RevokeInvitationRequest, SearchIssuesRequest, Tag, TokenRefreshRequest,
+    TokenRefreshResponse, UpdateIssueRequest, UpdateMemberRoleRequest, UpdateMemberRoleResponse,
+    UpdateOrganizationRequest, UpdatePullRequestApiRequest, UpdateWorkspaceRequest,
+    UpsertPullRequestRequest, Workspace,
 };
 use backon::{ExponentialBuilder, Retryable};
 use chrono::Duration as ChronoDuration;
@@ -303,6 +304,16 @@ impl RemoteClient {
         request: &HandoffRedeemRequest,
     ) -> Result<HandoffRedeemResponse, RemoteClientError> {
         self.post_public("/v1/oauth/web/redeem", Some(request))
+            .await
+            .map_err(|e| self.map_api_error(e))
+    }
+
+    /// Polls for handoff completion (desktop flow).
+    pub async fn handoff_poll(
+        &self,
+        request: &HandoffPollRequest,
+    ) -> Result<HandoffPollResponse, RemoteClientError> {
+        self.post_public("/v1/oauth/web/poll", Some(request))
             .await
             .map_err(|e| self.map_api_error(e))
     }

--- a/packages/web-core/src/shared/dialogs/global/OAuthDialog.tsx
+++ b/packages/web-core/src/shared/dialogs/global/OAuthDialog.tsx
@@ -151,14 +151,13 @@ const OAuthDialogImpl = create<OAuthDialogProps>(({ initialProvider }) => {
     (provider: OAuthProvider) => {
       setState({ type: 'waiting', provider });
 
-      // Get the current window location as return_to.
-      // When running inside Tauri the OAuth flow opens in the system browser,
-      // so we tag the callback URL so the server knows not to auto-close the tab.
+      // For desktop (Tauri), the backend overrides returnTo to a remote-hosted
+      // success page and polls for completion. For web, the browser is redirected
+      // back to localhost after OAuth.
       const isTauri = '__TAURI_INTERNALS__' in window;
-      const returnTo = `${window.location.origin}/api/auth/handoff/complete${isTauri ? '?source=desktop' : ''}`;
+      const returnTo = `${window.location.origin}/api/auth/handoff/complete`;
 
-      // Initialize handoff flow
-      initHandoff.mutate({ provider, returnTo });
+      initHandoff.mutate({ provider, returnTo, desktop: isTauri || undefined });
     },
     [initHandoff]
   );

--- a/packages/web-core/src/shared/hooks/auth/useAuthMutations.ts
+++ b/packages/web-core/src/shared/hooks/auth/useAuthMutations.ts
@@ -12,10 +12,12 @@ export function useAuthMutations(options?: UseAuthMutationsOptions) {
     mutationFn: ({
       provider,
       returnTo,
+      desktop,
     }: {
       provider: string;
       returnTo: string;
-    }) => oauthApi.handoffInit(provider, returnTo),
+      desktop?: boolean;
+    }) => oauthApi.handoffInit(provider, returnTo, desktop),
     onSuccess: (data) => {
       options?.onInitSuccess?.(data);
     },

--- a/packages/web-core/src/shared/lib/api.ts
+++ b/packages/web-core/src/shared/lib/api.ts
@@ -1255,11 +1255,12 @@ export const oauthApi = {
 
   handoffInit: async (
     provider: string,
-    returnTo: string
+    returnTo: string,
+    desktop?: boolean
   ): Promise<{ handoff_id: string; authorize_url: string }> => {
     const response = await makeRequest('/api/auth/handoff/init', {
       method: 'POST',
-      body: JSON.stringify({ provider, return_to: returnTo }),
+      body: JSON.stringify({ provider, return_to: returnTo, desktop }),
     });
     return handleApiResponse<{ handoff_id: string; authorize_url: string }>(
       response


### PR DESCRIPTION
## Summary

Refactors the OAuth login flow for the Tauri desktop app to use a polling-based approach instead of redirecting the browser back to localhost.

**Problem:** When a desktop user signs in via OAuth, the system browser opens to the remote server, completes authentication, then gets redirected back to `http://localhost:PORT/api/auth/handoff/complete` — showing a localhost page in the user's browser. This is a poor UX and can fail if the port isn't accessible.

**Solution:** The local backend now detects desktop mode, redirects the browser to a remote-hosted success page instead of localhost, and polls the remote server in the background until the OAuth handoff completes.

## Changes

### New remote endpoints
- `POST /v1/oauth/web/poll` — polling endpoint that returns `pending`, `complete` (with tokens), or `error`
- `GET /v1/oauth/web/callback-success` — static HTML success page shown in the browser after OAuth

### Remote handoff service (`crates/remote/src/auth/handoff.rs`)
- Added `poll()` method that checks handoff status and verifies `app_verifier` when authorized
- Extracted `complete_authorized_handoff()` helper from `redeem()` to share token generation logic
- Added `PollResult` enum (Pending / Complete / Error)

### API types (`crates/api-types/src/oauth.rs`)
- Added `HandoffPollRequest` and `HandoffPollResponse` types

### RemoteClient (`crates/services/src/services/remote_client.rs`)
- Added `handoff_poll()` method

### Local backend (`crates/server/src/routes/oauth.rs`)
- Added `desktop: bool` flag to `HandoffInitPayload`
- When desktop: overrides `return_to` to the remote success page URL
- Spawns background `poll_for_login` task that polls every 2s for up to 5 minutes
- On poll success, calls existing `finalize_login()` to save credentials and sync
- Removed `source=desktop` query param from `handoff_complete` (no longer needed)
- Simplified `close_window_response` (always auto-closes, desktop never hits this path)

### Frontend
- `OAuthDialog.tsx`: passes `desktop: true` when running in Tauri
- `useAuthMutations.ts` / `api.ts`: added `desktop` parameter to handoff init

### Also included (from earlier commits)
- Tauri dev port fix: reads `FRONTEND_PORT` env var instead of hardcoding port 3000
- Remote version bump to 0.1.26

## Flow (desktop)

1. Frontend detects Tauri, sends `desktop: true` to handoff init
2. Local backend overrides `return_to` → remote success page, spawns poll task
3. User completes OAuth in system browser → lands on remote success page ("you can close this tab")
4. Poll task detects authorization, redeems tokens via `app_verifier`, calls `finalize_login`
5. Frontend's existing status polling detects `logged_in: true`, closes dialog

## Test plan

- [x] Desktop (Tauri): sign in via OAuth — browser should show remote success page, NOT localhost
- [x] Desktop: app should detect login automatically within a few seconds
- [x] Web (browser): sign in via OAuth — popup flow should still work as before
- [x] Verify `poll_for_login` logs appear in local backend output
- [x] Verify remote server logs show `POST /v1/oauth/web/poll` requests

This PR was written using [Vibe Kanban](https://vibekanban.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OAuth authentication flows across local backend, remote API, and shared types; mistakes could cause login failures or token issuance loops, but changes are scoped to the handoff path with verifier checks and timeouts.
> 
> **Overview**
> Implements a **polling-based OAuth completion flow for the desktop (Tauri) app** to avoid redirecting the system browser back to localhost.
> 
> Adds shared `HandoffPollRequest`/`HandoffPollResponse` types and a new remote `POST /v1/oauth/web/poll` endpoint (plus a remote-hosted `/v1/oauth/web/callback-success` page). The remote handoff service gains `poll()` with shared token-generation logic extracted into `complete_authorized_handoff()`.
> 
> On the local backend, `/api/auth/handoff/init` now accepts a `desktop` flag; when set it overrides `return_to` to the remote success page and spawns a background poll task to call `finalize_login` once tokens are ready, with cooperative cancellation for retries. The web frontend now passes `desktop: true` when running under Tauri, and the remote client adds `handoff_poll()` plus an `is_transient()` helper for retry handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 18474864b8a471a75ba3a19842785dcc76ce0865. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->