### PR TITLE
feat: cli arguments for server host and port and prevent env leaks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4691,6 +4691,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "url",
  "utils",
  "uuid",
 ]
@@ -7885,6 +7886,7 @@ dependencies = [
  "axum",
  "base64 0.22.1",
  "chrono",
+ "clap",
  "db",
  "deployment",
  "desktop-bridge",

--- a/crates/mcp/Cargo.toml
+++ b/crates/mcp/Cargo.toml
@@ -29,4 +29,5 @@ sentry = { version = "0.46.2", default-features = false, features = ["anyhow", "
 reqwest = { workspace = true }
 rustls = { workspace = true }
 regex = "1"
+url = "2.5"
 thiserror = { workspace = true }

--- a/crates/mcp/src/bin/vibe_kanban_mcp.rs
+++ b/crates/mcp/src/bin/vibe_kanban_mcp.rs
@@ -18,6 +18,9 @@ enum McpLaunchMode {
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct LaunchConfig {
     mode: McpLaunchMode,
+    port: Option<u16>,
+    host: Option<String>,
+    backend_url: Option<String>,
 }
 
 fn main() -> anyhow::Result<()> {
@@ -31,8 +34,8 @@ fn main() -> anyhow::Result<()> {
             let version = env!("CARGO_PKG_VERSION");
             init_process_logging("vibe-kanban-mcp", version);
 
-            let base_url = resolve_base_url("vibe-kanban-mcp").await?;
-            let LaunchConfig { mode } = launch_config;
+            let base_url = resolve_base_url("vibe-kanban-mcp", &launch_config).await?;
+            let LaunchConfig { mode, .. } = launch_config;
 
             let server = match mode {
                 McpLaunchMode::Global => McpServer::new_global(&base_url),
@@ -58,6 +61,9 @@ where
     I: Iterator<Item = String>,
 {
     let mut mode = None;
+    let mut port = None;
+    let mut host = None;
+    let mut backend_url = None;
 
     while let Some(arg) = args.next() {
         match arg.as_str() {
@@ -66,13 +72,38 @@ where
                     anyhow::anyhow!("Missing value for --mode. Expected 'global' or 'orchestrator'")
                 })?);
             }
+            "--port" => {
+                let value = args
+                    .next()
+                    .ok_or_else(|| anyhow::anyhow!("Missing value for --port"))?;
+                port = Some(
+                    value
+                        .trim()
+                        .parse::<u16>()
+                        .map_err(|e| anyhow::anyhow!("Invalid port '{}': {}", value, e))?,
+                );
+            }
+            "--host" => {
+                host = Some(
+                    args.next()
+                        .ok_or_else(|| anyhow::anyhow!("Missing value for --host"))?,
+                );
+            }
+            "--backend-url" => {
+                backend_url = Some(
+                    args.next()
+                        .ok_or_else(|| anyhow::anyhow!("Missing value for --backend-url"))?,
+                );
+            }
             "-h" | "--help" => {
-                println!("Usage: vibe-kanban-mcp --mode <global|orchestrator>");
+                println!(
+                    "Usage: vibe-kanban-mcp [--mode <global|orchestrator>] [--port <PORT>] [--host <HOST>] [--backend-url <URL>]"
+                );
                 std::process::exit(0);
             }
             _ => {
                 return Err(anyhow::anyhow!(
-                    "Unknown argument '{arg}'. Usage: vibe-kanban-mcp --mode <global|orchestrator>"
+                    "Unknown argument '{arg}'. Usage: vibe-kanban-mcp [--mode <global|orchestrator>] [--port <PORT>] [--host <HOST>] [--backend-url <URL>]"
                 ));
             }
         }
@@ -94,38 +125,56 @@ where
         }
     };
 
-    Ok(LaunchConfig { mode })
+    Ok(LaunchConfig {
+        mode,
+        port,
+        host,
+        backend_url,
+    })
 }
 
-async fn resolve_base_url(log_prefix: &str) -> anyhow::Result<String> {
-    if let Ok(url) = std::env::var("VIBE_BACKEND_URL") {
+async fn resolve_base_url(log_prefix: &str, config: &LaunchConfig) -> anyhow::Result<String> {
+    if let Some(url) = &config.backend_url {
         tracing::info!(
-            "[{}] Using backend URL from VIBE_BACKEND_URL: {}",
+            "[{}] Using backend URL from --backend-url: {}",
             log_prefix,
             url
         );
+        return Ok(url.clone());
+    }
+
+    let host_override = config.host.clone().or_else(|| std::env::var(HOST_ENV).ok());
+    let port_override = config
+        .port
+        .or_else(|| std::env::var(PORT_ENV).ok().and_then(|s| s.parse().ok()));
+
+    if let Some(mut base) = std::env::var("VIBE_BACKEND_URL")
+        .ok()
+        .and_then(|u| url::Url::parse(&u).ok())
+    {
+        if let Some(h) = &host_override {
+            let _ = base.set_host(Some(h));
+        }
+        if let Some(p) = port_override {
+            let _ = base.set_port(Some(p));
+        }
+        let url = base.as_str().trim_end_matches('/').to_string();
+        tracing::info!("[{}] Using backend URL: {}", log_prefix, url);
         return Ok(url);
     }
 
-    let host = std::env::var(HOST_ENV)
-        .or_else(|_| std::env::var("HOST"))
-        .unwrap_or_else(|_| "127.0.0.1".to_string());
+    let host = host_override
+        .or_else(|| std::env::var("HOST").ok())
+        .unwrap_or_else(|| "127.0.0.1".to_string());
 
-    let port = match std::env::var(PORT_ENV)
-        .or_else(|_| std::env::var("BACKEND_PORT"))
-        .or_else(|_| std::env::var("PORT"))
-    {
-        Ok(port_str) => {
-            tracing::info!("[{}] Using port from environment: {}", log_prefix, port_str);
-            port_str
-                .parse::<u16>()
-                .map_err(|error| anyhow::anyhow!("Invalid port value '{}': {}", port_str, error))?
-        }
-        Err(_) => {
-            let port = read_port_file("vibe-kanban").await?;
-            tracing::info!("[{}] Using port from port file: {}", log_prefix, port);
-            port
-        }
+    let port = if let Some(p) = port_override {
+        p
+    } else if let Ok(port_str) = std::env::var("BACKEND_PORT").or_else(|_| std::env::var("PORT")) {
+        port_str
+            .parse::<u16>()
+            .map_err(|error| anyhow::anyhow!("Invalid port value '{}': {}", port_str, error))?
+    } else {
+        read_port_file("vibe-kanban").await?
     };
 
     let url = format!("http://{}:{}", host, port);
@@ -170,7 +219,10 @@ mod tests {
         assert_eq!(
             config,
             LaunchConfig {
-                mode: McpLaunchMode::Orchestrator
+                mode: McpLaunchMode::Orchestrator,
+                port: None,
+                host: None,
+                backend_url: None,
             }
         );
     }

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -52,6 +52,7 @@ reqwest = { workspace = true }
 rustls = { workspace = true }
 aws-lc-sys = { workspace = true }
 aws-lc-rs = { workspace = true }
+clap = { version = "4", features = ["derive"] }
 strip-ansi-escapes = "0.2.1"
 thiserror = { workspace = true }
 os_info = "3.12.0"

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -1,5 +1,6 @@
 use anyhow::{self, Error as AnyhowError};
 use axum::Router;
+use clap::Parser;
 use deployment::{Deployment, DeploymentError};
 use server::{
     DeploymentImpl, middleware::origin::validate_origin, routes, runtime::relay_registration,
@@ -29,8 +30,78 @@ pub enum VibeKanbanError {
     Other(#[from] AnyhowError),
 }
 
-#[tokio::main]
-async fn main() -> Result<(), VibeKanbanError> {
+#[derive(Parser, Debug)]
+#[command(name = "vibe-kanban", about = "Run the Vibe Kanban server")]
+struct Cli {
+    /// Port to bind the backend server to. Overrides BACKEND_PORT/PORT env vars.
+    #[arg(long, value_name = "PORT", value_parser = parse_port)]
+    port: Option<u16>,
+
+    /// Host interface to bind to. Overrides HOST env var.
+    #[arg(long, value_name = "HOST")]
+    host: Option<String>,
+
+    /// Port for the preview proxy server. Overrides PREVIEW_PROXY_PORT env var.
+    #[arg(long, value_name = "PORT", value_parser = parse_port)]
+    preview_proxy_port: Option<u16>,
+}
+
+/// CLI env vars to strip from the process so they don't leak to child processes
+/// (coding agents, dev servers). Stripped after parsing, before the tokio runtime starts.
+const CLI_ENV_VARS: &[&str] = &[
+    "PORT",
+    "BACKEND_PORT",
+    "HOST",
+    "FRONTEND_PORT",
+    "PREVIEW_PROXY_PORT",
+];
+
+fn main() -> Result<(), VibeKanbanError> {
+    let cli = Cli::parse();
+
+    let port = cli
+        .port
+        .or_else(|| read_port_from_env("BACKEND_PORT"))
+        .or_else(|| read_port_from_env("PORT"))
+        .unwrap_or(0);
+
+    let host = cli
+        .host
+        .or_else(|| std::env::var("HOST").ok().map(|s| s.trim().to_string()))
+        .unwrap_or_else(|| "127.0.0.1".to_string());
+
+    let proxy_port = cli
+        .preview_proxy_port
+        .or_else(|| read_port_from_env("PREVIEW_PROXY_PORT"))
+        .unwrap_or(0);
+
+    for var in CLI_ENV_VARS {
+        unsafe { std::env::remove_var(var) };
+    }
+
+    let main_listener = std::net::TcpListener::bind(format!("{host}:{port}"))?;
+    let proxy_listener = std::net::TcpListener::bind(format!("{host}:{proxy_port}"))?;
+    main_listener.set_nonblocking(true)?;
+    proxy_listener.set_nonblocking(true)?;
+
+    unsafe {
+        std::env::set_var(
+            "VIBE_BACKEND_URL",
+            format!("http://{}:{}", host, main_listener.local_addr()?.port()),
+        );
+    }
+
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .expect("Failed to build tokio runtime")
+        .block_on(async_main(main_listener, proxy_listener))
+}
+
+async fn async_main(
+    main_std_listener: std::net::TcpListener,
+    proxy_std_listener: std::net::TcpListener,
+) -> Result<(), VibeKanbanError> {
     // Install rustls crypto provider before any TLS operations
     rustls::crypto::aws_lc_rs::default_provider()
         .install_default()
@@ -93,31 +164,11 @@ async fn main() -> Result<(), VibeKanbanError> {
     tokio::spawn(async move {
         executors::executors::utils::preload_global_executor_options_cache().await;
     });
-    let port = std::env::var("BACKEND_PORT")
-        .or_else(|_| std::env::var("PORT"))
-        .ok()
-        .and_then(|s| {
-            // Remove any ANSI codes, then turn into String
-            let cleaned =
-                String::from_utf8(strip(s.as_bytes())).expect("UTF-8 after stripping ANSI");
-            cleaned.trim().parse::<u16>().ok()
-        })
-        .unwrap_or_else(|| {
-            tracing::info!("No PORT environment variable set, using port 0 for auto-assignment");
-            0
-        }); // Use 0 to find free port if no specific port provided
 
-    let proxy_port = std::env::var("PREVIEW_PROXY_PORT")
-        .ok()
-        .and_then(|s| s.trim().parse::<u16>().ok())
-        .unwrap_or(0);
-
-    let host = std::env::var("HOST").unwrap_or_else(|_| "127.0.0.1".to_string());
-
-    let main_listener = tokio::net::TcpListener::bind(format!("{host}:{port}")).await?;
+    let main_listener = tokio::net::TcpListener::from_std(main_std_listener)?;
     let actual_main_port = main_listener.local_addr()?.port();
 
-    let proxy_listener = tokio::net::TcpListener::bind(format!("{host}:{proxy_port}")).await?;
+    let proxy_listener = tokio::net::TcpListener::from_std(proxy_std_listener)?;
     let actual_proxy_port = proxy_listener.local_addr()?.port();
 
     if let Err(e) = write_port_file_with_proxy(actual_main_port, Some(actual_proxy_port)).await {
@@ -239,4 +290,25 @@ pub async fn perform_cleanup_actions(deployment: &DeploymentImpl) {
         .kill_all_running_processes()
         .await
         .expect("Failed to cleanly kill running execution processes");
+}
+
+fn parse_port(value: &str) -> Result<u16, String> {
+    let cleaned =
+        String::from_utf8(strip(value.as_bytes())).map_err(|_| "value is not valid UTF-8")?;
+    let trimmed = cleaned.trim();
+    trimmed
+        .parse::<u16>()
+        .map_err(|err| format!("invalid port '{trimmed}': {err}"))
+}
+
+fn read_port_from_env(name: &str) -> Option<u16> {
+    std::env::var(name)
+        .ok()
+        .and_then(|value| match parse_port(&value) {
+            Ok(port) => Some(port),
+            Err(err) => {
+                eprintln!("Ignoring invalid {name} value '{value}': {err}");
+                None
+            }
+        })
 }

--- a/npx-cli/src/cli.ts
+++ b/npx-cli/src/cli.ts
@@ -241,7 +241,10 @@ async function runReview(args: string[]): Promise<void> {
   });
 }
 
-async function runMain(desktopMode: boolean): Promise<void> {
+async function runMain(
+  desktopMode: boolean,
+  args: string[],
+): Promise<void> {
   checkForUpdates();
 
   const modeLabel = LOCAL_DEV_MODE ? " (local dev)" : "";
@@ -274,7 +277,14 @@ async function runMain(desktopMode: boolean): Promise<void> {
   // Browser mode (default — headless server + opens browser)
   console.log(`Starting vibe-kanban v${CLI_VERSION}${modeLabel}...`);
   await extractAndRun("vibe-kanban", (bin) => {
-    execSync(`"${bin}"`, { stdio: "inherit" });
+    const proc = spawn(bin, args, { stdio: "inherit" });
+    proc.on("exit", (code) => process.exit(code ?? 1));
+    proc.on("error", (e) => {
+      console.error("vibe-kanban error:", e.message);
+      process.exit(1);
+    });
+    process.on("SIGINT", () => proc.kill("SIGINT"));
+    process.on("SIGTERM", () => proc.kill("SIGTERM"));
   });
 }
 
@@ -314,7 +324,10 @@ async function main(): Promise<void> {
     .option("--desktop", "Launch the desktop app instead of browser mode")
     .allowUnknownOptions()
     .action((_args: string[], options: RootOptions) => {
-      runOrExit(runMain(Boolean(options.desktop)));
+      const serverArgs = process.argv
+        .slice(2)
+        .filter((arg) => arg !== "--desktop");
+      runOrExit(runMain(Boolean(options.desktop), serverArgs));
     });
 
   cli


### PR DESCRIPTION
Prevent HOST and PORT environment variables from leaking to child processes and add enable using cli arguments as an alternative.

Fixes https://github.com/BloopAI/vibe-kanban/issues/979

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes server startup/binding and environment propagation, which can affect how the backend is reached and how child processes are launched. Risk is moderate due to new CLI parsing and listener setup paths, but scoped to bootstrap code.
> 
> **Overview**
> Adds first-class CLI flags to control networking for local runs: `vibe-kanban` now accepts `--host`, `--port`, and `--preview-proxy-port`, binds via pre-created std `TcpListener`s, and sets `VIBE_BACKEND_URL` based on the chosen/assigned port.
> 
> To prevent accidental configuration bleed into spawned tools, the server now strips common port/host env vars (`PORT`, `BACKEND_PORT`, `HOST`, etc.) after parsing. The MCP binary similarly adds `--host`/`--port`/`--backend-url` overrides and can rewrite `VIBE_BACKEND_URL` via URL parsing.
> 
> Updates the `npx` launcher to forward unknown args to the `vibe-kanban` binary (instead of `execSync`) and adds basic signal forwarding; dependencies are updated to include `clap` and `url` where needed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8d28b4bd840e6fcfa7a7cf0d812873341f4db659. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->