### PR TITLE
feat: add workspace action menu to kanban board cards

### DIFF
--- a/crates/git-host/src/lib.rs
+++ b/crates/git-host/src/lib.rs
@@ -7,6 +7,7 @@ pub mod github;
 use std::path::Path;
 
 use async_trait::async_trait;
+pub use db::models::merge::PullRequestInfo;
 use detection::detect_provider_from_url;
 use enum_dispatch::enum_dispatch;
 pub use types::{

--- a/packages/ui/src/components/IssueWorkspaceCard.tsx
+++ b/packages/ui/src/components/IssueWorkspaceCard.tsx
@@ -4,6 +4,7 @@ import {
   GitPullRequestIcon,
   DotsThreeIcon,
   LinkBreakIcon,
+  ArchiveIcon,
   TrashIcon,
   PlayIcon,
   HandIcon,
@@ -49,6 +50,7 @@ export interface IssueWorkspaceCardProps {
   workspace: WorkspaceWithStats;
   onClick?: () => void;
   onUnlink?: () => void;
+  onArchive?: () => void;
   onDelete?: () => void;
   showOwner?: boolean;
   showStatusBadge?: boolean;
@@ -111,6 +113,7 @@ export function IssueWorkspaceCard({
   workspace,
   onClick,
   onUnlink,
+  onArchive,
   onDelete,
   showOwner = true,
   showStatusBadge = true,
@@ -165,7 +168,7 @@ export function IssueWorkspaceCard({
               className="h-5 w-5 text-[10px] border-2 border-panel"
             />
           )}
-          {(onUnlink || onDelete) && (
+          {(onUnlink || onArchive || onDelete) && (
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <button
@@ -189,6 +192,19 @@ export function IssueWorkspaceCard({
                   >
                     <LinkBreakIcon className="size-icon-xs" />
                     {t('workspaces.unlinkFromIssue')}
+                  </DropdownMenuItem>
+                )}
+                {onArchive && (
+                  <DropdownMenuItem
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onArchive();
+                    }}
+                  >
+                    <ArchiveIcon className="size-icon-xs" />
+                    {workspace.archived
+                      ? t('workspaces.unarchive', 'Unarchive')
+                      : t('workspaces.archive', 'Archive')}
                   </DropdownMenuItem>
                 )}
                 {onDelete && (

--- a/packages/web-core/src/features/kanban/ui/KanbanContainer.tsx
+++ b/packages/web-core/src/features/kanban/ui/KanbanContainer.tsx
@@ -60,6 +60,7 @@ import { resolveRelationshipsForIssue } from '@/shared/lib/resolveRelationships'
 import { KanbanFilterBar } from '@vibe/ui/components/KanbanFilterBar';
 import { ViewNavTabs } from '@vibe/ui/components/ViewNavTabs';
 import { IssueListView } from '@vibe/ui/components/IssueListView';
+import { useWorkspaceActions } from '@/shared/hooks/useWorkspaceActions';
 import { CommandBarDialog } from '@/shared/dialogs/command-bar/CommandBarDialog';
 import { KanbanFiltersDialog } from '@/shared/dialogs/kanban/KanbanFiltersDialog';
 import {
@@ -644,6 +645,29 @@ export function KanbanContainer() {
     userId,
   ]);
 
+  // Workspace action handlers (shared with issue sidebar)
+  const findWorkspaceInKanban = useCallback(
+    (localWorkspaceId: string) => {
+      for (const workspaces of workspacesByIssueId.values()) {
+        const found = workspaces.find(
+          (ws) => ws.localWorkspaceId === localWorkspaceId
+        );
+        if (found) return found;
+      }
+      return undefined;
+    },
+    [workspacesByIssueId]
+  );
+
+  const {
+    unlinkWorkspace: handleUnlinkWorkspace,
+    archiveWorkspace: handleArchiveWorkspace,
+    deleteWorkspace: handleDeleteWorkspace,
+  } = useWorkspaceActions({
+    localWorkspacesById,
+    findWorkspace: findWorkspaceInKanban,
+  });
+
   // Calculate sort_order based on column index and issue position
   // Formula: 1000 * [COLUMN_INDEX] + [ISSUE_INDEX] (both 1-based)
   const calculateSortOrder = useCallback(
@@ -1105,6 +1129,34 @@ export function KanbanContainer() {
                                             openIssueWorkspace(
                                               issue.id,
                                               workspace.localWorkspaceId!
+                                            )
+                                        : undefined
+                                    }
+                                    onUnlink={
+                                      workspace.localWorkspaceId
+                                        ? () =>
+                                            handleUnlinkWorkspace(
+                                              workspace.localWorkspaceId!
+                                            )
+                                        : undefined
+                                    }
+                                    onArchive={
+                                      workspace.localWorkspaceId &&
+                                      workspace.isOwnedByCurrentUser
+                                        ? () =>
+                                            handleArchiveWorkspace(
+                                              workspace.localWorkspaceId!
+                                            )
+                                        : undefined
+                                    }
+                                    onDelete={
+                                      workspace.localWorkspaceId &&
+                                      workspace.isOwnedByCurrentUser
+                                        ? () =>
+                                            handleDeleteWorkspace(
+                                              workspace.localWorkspaceId!,
+                                              issuesById.get(issue.id)
+                                                ?.simple_id
                                             )
                                         : undefined
                                     }

--- a/packages/web-core/src/pages/kanban/IssueWorkspacesSectionContainer.tsx
+++ b/packages/web-core/src/pages/kanban/IssueWorkspacesSectionContainer.tsx
@@ -131,7 +131,7 @@ export function IssueWorkspacesSectionContainer({
 
   const handleDeleteWorkspace = useCallback(
     (localWorkspaceId: string) =>
-      deleteWorkspace(localWorkspaceId, getIssue(issueId)?.simple_id),
+      deleteWorkspace(localWorkspaceId, getIssue(issueId)?.simple_id, true),
     [deleteWorkspace, getIssue, issueId]
   );
 

--- a/packages/web-core/src/pages/kanban/IssueWorkspacesSectionContainer.tsx
+++ b/packages/web-core/src/pages/kanban/IssueWorkspacesSectionContainer.tsx
@@ -9,7 +9,7 @@ import { useUserContext } from '@/shared/hooks/useUserContext';
 import { useWorkspaceContext } from '@/shared/hooks/useWorkspaceContext';
 import { useAppNavigation } from '@/shared/hooks/useAppNavigation';
 import { useProjectWorkspaceCreateDraft } from '@/shared/hooks/useProjectWorkspaceCreateDraft';
-import { workspacesApi } from '@/shared/lib/api';
+import { useWorkspaceActions } from '@/shared/hooks/useWorkspaceActions';
 import { getWorkspaceDefaults } from '@/shared/lib/workspaceDefaults';
 import {
   buildLinkedIssueCreateState,
@@ -18,7 +18,6 @@ import {
   buildWorkspaceCreatePrompt,
 } from '@/shared/lib/workspaceCreateState';
 import { ConfirmDialog } from '@vibe/ui/components/ConfirmDialog';
-import { DeleteWorkspaceDialog } from '@vibe/ui/components/DeleteWorkspaceDialog';
 import type { WorkspaceWithStats } from '@vibe/ui/components/IssueWorkspaceCard';
 import { IssueWorkspacesSection } from '@vibe/ui/components/IssueWorkspacesSection';
 import type { SectionAction } from '@vibe/ui/components/CollapsibleSectionHeader';
@@ -116,6 +115,26 @@ export function IssueWorkspacesSectionContainer({
     localWorkspacesById,
   ]);
 
+  const findWorkspace = useCallback(
+    (localWorkspaceId: string) =>
+      workspacesWithStats.find(
+        (ws) => ws.localWorkspaceId === localWorkspaceId
+      ),
+    [workspacesWithStats]
+  );
+
+  const {
+    unlinkWorkspace: handleUnlinkWorkspace,
+    archiveWorkspace: handleArchiveWorkspace,
+    deleteWorkspace,
+  } = useWorkspaceActions({ localWorkspacesById, findWorkspace });
+
+  const handleDeleteWorkspace = useCallback(
+    (localWorkspaceId: string) =>
+      deleteWorkspace(localWorkspaceId, getIssue(issueId)?.simple_id),
+    [deleteWorkspace, getIssue, issueId]
+  );
+
   const isLoading = projectLoading || orgLoading;
   const shouldAnimateCreateButton = useMemo(() => {
     if (issues.length !== 1) {
@@ -203,87 +222,6 @@ export function IssueWorkspacesSectionContainer({
       }
     },
     [projectId, issueId, appNavigation]
-  );
-
-  // Handle unlinking a workspace from the issue
-  const handleUnlinkWorkspace = useCallback(
-    async (localWorkspaceId: string) => {
-      const result = await ConfirmDialog.show({
-        title: t('workspaces.unlinkFromIssue'),
-        message: t('workspaces.unlinkConfirmMessage'),
-        confirmText: t('workspaces.unlink'),
-        variant: 'destructive',
-      });
-
-      if (result === 'confirmed') {
-        try {
-          await workspacesApi.unlinkFromIssue(localWorkspaceId);
-        } catch (error) {
-          ConfirmDialog.show({
-            title: t('common:error'),
-            message:
-              error instanceof Error
-                ? error.message
-                : t('workspaces.unlinkError'),
-            confirmText: t('common:ok'),
-            showCancelButton: false,
-          });
-        }
-      }
-    },
-    [t]
-  );
-
-  // Handle deleting a workspace (unlinks first, then deletes local)
-  const handleDeleteWorkspace = useCallback(
-    async (localWorkspaceId: string) => {
-      const localWorkspace = localWorkspacesById.get(localWorkspaceId);
-      if (!localWorkspace) {
-        ConfirmDialog.show({
-          title: t('common:error'),
-          message: t('workspaces.deleteError'),
-          confirmText: t('common:ok'),
-          showCancelButton: false,
-        });
-        return;
-      }
-
-      const result = await DeleteWorkspaceDialog.show({
-        branchName: localWorkspace.branch,
-        hasOpenPR:
-          workspacesWithStats
-            .find(
-              (workspace) => workspace.localWorkspaceId === localWorkspaceId
-            )
-            ?.prs.some((pr) => pr.status === 'open') ?? false,
-        isLinkedToIssue: true,
-        linkedIssueSimpleId: getIssue(issueId)?.simple_id,
-      });
-
-      if (result.action !== 'confirmed') {
-        return;
-      }
-
-      try {
-        // Delete local workspace first
-        await workspacesApi.delete(localWorkspaceId, result.deleteBranches);
-        // Unlink from remote after successful deletion
-        if (result.unlinkFromIssue) {
-          await workspacesApi.unlinkFromIssue(localWorkspaceId);
-        }
-      } catch (error) {
-        ConfirmDialog.show({
-          title: t('common:error'),
-          message:
-            error instanceof Error
-              ? error.message
-              : t('workspaces.deleteError'),
-          confirmText: t('common:ok'),
-          showCancelButton: false,
-        });
-      }
-    },
-    [localWorkspacesById, workspacesWithStats, t, issueId, getIssue]
   );
 
   // Actions for the section header

--- a/packages/web-core/src/shared/hooks/useWorkspaceActions.ts
+++ b/packages/web-core/src/shared/hooks/useWorkspaceActions.ts
@@ -83,7 +83,11 @@ export function useWorkspaceActions({
   );
 
   const deleteWorkspace = useCallback(
-    async (localWorkspaceId: string, linkedIssueSimpleId?: string | null) => {
+    async (
+      localWorkspaceId: string,
+      linkedIssueSimpleId?: string | null,
+      isLinkedToIssue?: boolean
+    ) => {
       const localWorkspace = localWorkspacesById.get(localWorkspaceId);
       if (!localWorkspace) {
         ConfirmDialog.show({
@@ -101,7 +105,7 @@ export function useWorkspaceActions({
           findWorkspace(localWorkspaceId)?.prs.some(
             (pr) => pr.status === 'open'
           ) ?? false,
-        isLinkedToIssue: linkedIssueSimpleId != null,
+        isLinkedToIssue: isLinkedToIssue ?? linkedIssueSimpleId != null,
         linkedIssueSimpleId: linkedIssueSimpleId ?? undefined,
       });
 

--- a/packages/web-core/src/shared/hooks/useWorkspaceActions.ts
+++ b/packages/web-core/src/shared/hooks/useWorkspaceActions.ts
@@ -1,0 +1,133 @@
+import { useCallback } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
+import { workspacesApi } from '@/shared/lib/api';
+import { workspaceKeys } from '@/shared/hooks/useWorkspaces';
+import { workspaceSummaryKeys } from '@/shared/hooks/workspaceSummaryKeys';
+import { ConfirmDialog } from '@vibe/ui/components/ConfirmDialog';
+import { DeleteWorkspaceDialog } from '@vibe/ui/components/DeleteWorkspaceDialog';
+import type { WorkspaceWithStats } from '@vibe/ui/components/IssueWorkspaceCard';
+
+interface LocalWorkspace {
+  branch: string;
+}
+
+interface UseWorkspaceActionsOptions {
+  localWorkspacesById: Map<string, LocalWorkspace>;
+  findWorkspace: (localWorkspaceId: string) => WorkspaceWithStats | undefined;
+}
+
+export function useWorkspaceActions({
+  localWorkspacesById,
+  findWorkspace,
+}: UseWorkspaceActionsOptions) {
+  const { t } = useTranslation('common');
+  const queryClient = useQueryClient();
+
+  const unlinkWorkspace = useCallback(
+    async (localWorkspaceId: string) => {
+      const result = await ConfirmDialog.show({
+        title: t('workspaces.unlinkFromIssue'),
+        message: t('workspaces.unlinkConfirmMessage'),
+        confirmText: t('workspaces.unlink'),
+        variant: 'destructive',
+      });
+
+      if (result === 'confirmed') {
+        try {
+          await workspacesApi.unlinkFromIssue(localWorkspaceId);
+        } catch (error) {
+          ConfirmDialog.show({
+            title: t('common:error'),
+            message:
+              error instanceof Error
+                ? error.message
+                : t('workspaces.unlinkError'),
+            confirmText: t('common:ok'),
+            showCancelButton: false,
+          });
+        }
+      }
+    },
+    [t]
+  );
+
+  const archiveWorkspace = useCallback(
+    async (localWorkspaceId: string) => {
+      const isCurrentlyArchived =
+        findWorkspace(localWorkspaceId)?.archived ?? false;
+
+      try {
+        await workspacesApi.update(localWorkspaceId, {
+          archived: !isCurrentlyArchived,
+        });
+        queryClient.invalidateQueries({
+          queryKey: workspaceKeys.all,
+        });
+        queryClient.invalidateQueries({
+          queryKey: workspaceSummaryKeys.all,
+        });
+      } catch (error) {
+        ConfirmDialog.show({
+          title: t('common:error'),
+          message:
+            error instanceof Error
+              ? error.message
+              : t('workspaces.archiveError', 'Failed to update workspace'),
+          confirmText: t('common:ok'),
+          showCancelButton: false,
+        });
+      }
+    },
+    [findWorkspace, queryClient, t]
+  );
+
+  const deleteWorkspace = useCallback(
+    async (localWorkspaceId: string, linkedIssueSimpleId?: string | null) => {
+      const localWorkspace = localWorkspacesById.get(localWorkspaceId);
+      if (!localWorkspace) {
+        ConfirmDialog.show({
+          title: t('common:error'),
+          message: t('workspaces.deleteError'),
+          confirmText: t('common:ok'),
+          showCancelButton: false,
+        });
+        return;
+      }
+
+      const result = await DeleteWorkspaceDialog.show({
+        branchName: localWorkspace.branch,
+        hasOpenPR:
+          findWorkspace(localWorkspaceId)?.prs.some(
+            (pr) => pr.status === 'open'
+          ) ?? false,
+        isLinkedToIssue: linkedIssueSimpleId != null,
+        linkedIssueSimpleId: linkedIssueSimpleId ?? undefined,
+      });
+
+      if (result.action !== 'confirmed') {
+        return;
+      }
+
+      try {
+        await workspacesApi.delete(localWorkspaceId, result.deleteBranches);
+        if (result.unlinkFromIssue) {
+          await workspacesApi.unlinkFromIssue(localWorkspaceId);
+        }
+      } catch (error) {
+        ConfirmDialog.show({
+          title: t('common:error'),
+          message:
+            error instanceof Error
+              ? error.message
+              : t('workspaces.deleteError'),
+          confirmText: t('common:ok'),
+          showCancelButton: false,
+        });
+      }
+    },
+    [localWorkspacesById, findWorkspace, t]
+  );
+
+  return { unlinkWorkspace, archiveWorkspace, deleteWorkspace };
+}


### PR DESCRIPTION
Extract useWorkspaceActions hook from IssueWorkspacesSectionContainer to share unlink/archive/delete logic, then wire up the same "..." dropdown on workspace cards in the kanban view.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new mutation wiring (unlink/archive/delete) in the kanban UI and centralizes logic into a shared hook, so mistakes could cause unintended workspace state changes or stale UI if cache invalidation is wrong.
> 
> **Overview**
> Adds a workspace “more” dropdown to kanban workspace cards, enabling **unlink**, **archive/unarchive**, and **delete** actions (archive/delete gated to workspaces owned by the current user).
> 
> Extracts the existing unlink/archive/delete flows into a new shared `useWorkspaceActions` hook (including PR-aware delete confirmation and query invalidation after archiving) and updates the issue sidebar container and kanban view to use it. Also re-exports `PullRequestInfo` from `crates/git-host` for downstream use.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1932641141cae73af692d66dd4a43b0678de9ac0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->