### PR TITLE
Add npx command normalization to fix command not found

### DIFF
--- a/crates/executors/src/executors/claude.rs
+++ b/crates/executors/src/executors/claude.rs
@@ -176,10 +176,9 @@ impl ClaudeCode {
             );
         }
 
-        let mut builder = CommandBuilder::new(ensure_npx_delimiter(base_command(
-            self.claude_code_router.unwrap_or(false),
-        )))
-        .params(["-p"]);
+        let mut builder =
+            CommandBuilder::new(base_command(self.claude_code_router.unwrap_or(false)))
+                .params(["-p"]);
 
         let plan = self.plan.unwrap_or(false);
         let approvals = self.approvals.unwrap_or(false);

--- a/crates/executors/src/executors/claude.rs
+++ b/crates/executors/src/executors/claude.rs
@@ -66,6 +66,29 @@ fn base_command(claude_code_router: bool) -> &'static str {
     }
 }
 
+fn ensure_npx_delimiter(base: &str) -> String {
+    let mut tokens = base.split_whitespace();
+    let is_npx = tokens.next() == Some("npx");
+    if !is_npx {
+        return base.to_string();
+    }
+
+    if base.split_whitespace().any(|token| token == "--") {
+        return base.to_string();
+    }
+
+    format!("{base} --")
+}
+
+fn normalize_npx_base_command(builder: CommandBuilder) -> CommandBuilder {
+    let normalized_base = ensure_npx_delimiter(&builder.base);
+    if normalized_base == builder.base {
+        return builder;
+    }
+
+    builder.override_base(normalized_base)
+}
+
 fn normalize_claude_stderr_logs(
     msg_store: Arc<MsgStore>,
     entry_index_provider: EntryIndexProvider,
@@ -153,9 +176,10 @@ impl ClaudeCode {
             );
         }
 
-        let mut builder =
-            CommandBuilder::new(base_command(self.claude_code_router.unwrap_or(false)))
-                .params(["-p"]);
+        let mut builder = CommandBuilder::new(ensure_npx_delimiter(base_command(
+            self.claude_code_router.unwrap_or(false),
+        )))
+        .params(["-p"]);
 
         let plan = self.plan.unwrap_or(false);
         let approvals = self.approvals.unwrap_or(false);
@@ -192,7 +216,8 @@ impl ClaudeCode {
             "--replay-user-messages",
         ]);
 
-        apply_overrides(builder, &self.cmd)
+        let builder = apply_overrides(builder, &self.cmd)?;
+        Ok(normalize_npx_base_command(builder))
     }
 
     pub fn permission_mode(&self) -> PermissionMode {
@@ -3274,5 +3299,29 @@ mod tests {
         let control_request_json = r#"{"type":"control_request","request_id":"f559d907-b139-475b-addd-79c05591eb99","request":{"subtype":"can_use_tool","tool_name":"Bash","input":{"command":"./gradlew :web:testApi","timeout":300000,"description":"Run API tests"},"permission_suggestions":[{"type":"addRules","rules":[{"toolName":"Bash","ruleContent":"./gradlew :web:testApi:"}],"behavior":"allow","destination":"localSettings"}],"tool_use_id":"toolu_014PR3WXsJfiftSCbjcjEbeM"}}"#;
         let parsed: ClaudeJson = serde_json::from_str(control_request_json).unwrap();
         assert!(matches!(parsed, ClaudeJson::ControlRequest { .. }));
+    }
+
+    #[tokio::test]
+    async fn test_build_command_builder_normalizes_npx_override() {
+        let executor = ClaudeCode {
+            append_prompt: AppendPrompt::default(),
+            claude_code_router: Some(false),
+            plan: None,
+            approvals: None,
+            model: None,
+            effort: None,
+            agent: None,
+            dangerously_skip_permissions: None,
+            disable_api_key: None,
+            cmd: CmdOverrides {
+                base_command_override: Some("npx -y @anthropic-ai/claude-code@2.1.62".to_string()),
+                additional_params: None,
+                env: None,
+            },
+            approvals_service: None,
+        };
+
+        let builder = executor.build_command_builder().await.unwrap();
+        assert_eq!(builder.base, "npx -y @anthropic-ai/claude-code@2.1.62 --");
     }
 }

--- a/crates/executors/src/executors/claude/slash_commands.rs
+++ b/crates/executors/src/executors/claude/slash_commands.rs
@@ -15,8 +15,7 @@ use tokio::{
 use workspace_utils::command_ext::GroupSpawnNoWindowExt;
 
 use super::{
-    ClaudeCode, ClaudeJson, ClaudePlugin, base_command, ensure_npx_delimiter,
-    normalize_npx_base_command,
+    ClaudeCode, ClaudeJson, ClaudePlugin, base_command, normalize_npx_base_command,
 };
 use crate::{
     command::{CommandBuildError, CommandBuilder, apply_overrides},
@@ -197,10 +196,9 @@ impl ClaudeCode {
     async fn build_slash_commands_discovery_command_builder(
         &self,
     ) -> Result<CommandBuilder, CommandBuildError> {
-        let mut builder = CommandBuilder::new(ensure_npx_delimiter(base_command(
-            self.claude_code_router.unwrap_or(false),
-        )))
-        .params(["-p"]);
+        let mut builder =
+            CommandBuilder::new(base_command(self.claude_code_router.unwrap_or(false)))
+                .params(["-p"]);
 
         builder = builder.extend_params([
             "--verbose",

--- a/crates/executors/src/executors/claude/slash_commands.rs
+++ b/crates/executors/src/executors/claude/slash_commands.rs
@@ -14,7 +14,10 @@ use tokio::{
 };
 use workspace_utils::command_ext::GroupSpawnNoWindowExt;
 
-use super::{ClaudeCode, ClaudeJson, ClaudePlugin, base_command};
+use super::{
+    ClaudeCode, ClaudeJson, ClaudePlugin, base_command, ensure_npx_delimiter,
+    normalize_npx_base_command,
+};
 use crate::{
     command::{CommandBuildError, CommandBuilder, apply_overrides},
     env::{ExecutionEnv, RepoContext},
@@ -194,9 +197,10 @@ impl ClaudeCode {
     async fn build_slash_commands_discovery_command_builder(
         &self,
     ) -> Result<CommandBuilder, CommandBuildError> {
-        let mut builder =
-            CommandBuilder::new(base_command(self.claude_code_router.unwrap_or(false)))
-                .params(["-p"]);
+        let mut builder = CommandBuilder::new(ensure_npx_delimiter(base_command(
+            self.claude_code_router.unwrap_or(false),
+        )))
+        .params(["-p"]);
 
         builder = builder.extend_params([
             "--verbose",
@@ -207,7 +211,8 @@ impl ClaudeCode {
             "/",
         ]);
 
-        apply_overrides(builder, &self.cmd)
+        let builder = apply_overrides(builder, &self.cmd)?;
+        Ok(normalize_npx_base_command(builder))
     }
 
     async fn discover_available_command_and_plugins(
@@ -365,5 +370,42 @@ impl ClaudeCode {
         } else {
             raw.to_case(Case::Title)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::command::CmdOverrides;
+
+    use std::sync::Arc;
+
+    use super::super::{AppendPrompt, ExecutorApprovalService};
+    use super::*;
+
+    #[tokio::test]
+    async fn test_discovery_builder_normalizes_npx_override() {
+        let executor = ClaudeCode {
+            append_prompt: AppendPrompt::default(),
+            claude_code_router: Some(false),
+            plan: None,
+            approvals: None,
+            model: None,
+            effort: None,
+            agent: None,
+            dangerously_skip_permissions: None,
+            disable_api_key: None,
+            cmd: CmdOverrides {
+                base_command_override: Some("npx -y @anthropic-ai/claude-code@2.1.62".to_string()),
+                additional_params: None,
+                env: None,
+            },
+            approvals_service: None::<Arc<dyn ExecutorApprovalService>>,
+        };
+
+        let builder = executor
+            .build_slash_commands_discovery_command_builder()
+            .await
+            .unwrap();
+        assert_eq!(builder.base, "npx -y @anthropic-ai/claude-code@2.1.62 --");
     }
 }


### PR DESCRIPTION
## Summary
- remove the redundant pre-override `npx` delimiter normalization in the Claude executor command builder
- remove the same redundant normalization in slash command discovery
- keep post-override normalization so custom `npx` base-command overrides still receive `--` when needed

## Files Changed
- `crates/executors/src/executors/claude.rs`
- `crates/executors/src/executors/claude/slash_commands.rs`

## Verification
- `cargo test -p executors test_build_command_builder_normalizes_npx_override`
- `cargo test -p executors test_discovery_builder_normalizes_npx_override`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Claude executor command construction; incorrect normalization could change how arguments are passed to `npx` and break spawning or slash-command discovery for some configurations.
> 
> **Overview**
> Ensures custom Claude `base_command_override` values that start with `npx` are **post-override normalized** to include the `--` delimiter when missing, preventing downstream args from being interpreted as `npx` options.
> 
> Updates both the main Claude command builder and the slash-command discovery builder to apply this normalization after `apply_overrides`, and adds targeted async tests asserting an `npx` override becomes `... --`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5113860f6535399341b7e6f3fc1a5fbc68633bbb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->