### PR TITLE
chore(i18n): add locale contributor workflow

### DIFF
--- a/docs/designs/russian-localization-upstream.md
+++ b/docs/designs/russian-localization-upstream.md
@@ -1,0 +1,56 @@
+# Russian Localization Upstream Plan
+
+Status: active
+Date: 2026-03-29
+Branch: feat/i18n-foundation-ru
+
+## Goal
+
+Add Russian as a first-class Vibe Kanban locale and upstream it in a way that maintainers can review and extend easily.
+
+## Why This Is Split Into Two PRs
+
+One large "add Russian + invent the locale workflow" PR is harder to review and easier to reject on process grounds.
+
+Two smaller PRs keep the review clean:
+
+1. PR 1 adds localization infrastructure for future contributors.
+2. PR 2 adds the Russian locale using that infrastructure.
+
+## PR 1: Localization Infrastructure
+
+Scope:
+
+- Add a documented workflow for introducing a new locale.
+- Add a locale scaffold script that copies the English namespace files into a new locale directory.
+- Add a QA helper that reports untranslated or unchanged strings compared to English.
+- Keep the change small. No new runtime abstractions. No CI policy changes.
+
+Out of scope:
+
+- Adding Russian translations.
+- Refactoring the existing i18n system.
+- Translating docs or README.
+
+## PR 2: Add Russian Locale
+
+Scope:
+
+- Add `RU` to the config enum and generated shared types.
+- Register `ru` in the frontend language map and i18n resources.
+- Add `packages/web-core/src/i18n/locales/ru/*.json`.
+- Verify language selection, browser detection, and key consistency.
+
+Out of scope:
+
+- Rewriting existing copy.
+- Bulk cleanup of unrelated hardcoded strings.
+- Translating the marketing site or documentation.
+
+## Acceptance Bar
+
+Both PRs should be independently reviewable and green on existing checks.
+
+PR 1 should make the next locale cheaper to add.
+
+PR 2 should feel like a complete product locale, not a partial translation dump.

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -1,0 +1,82 @@
+# Internationalization Workflow
+
+Vibe Kanban already ships multiple first-class locales. This document describes the lowest-friction way to add another one without missing type, config, or QA steps.
+
+## Locale layout
+
+Frontend locale files live in:
+
+`packages/web-core/src/i18n/locales/<i18n-code>/`
+
+Each locale currently mirrors the English namespaces:
+
+- `common.json`
+- `settings.json`
+- `projects.json`
+- `tasks.json`
+- `organization.json`
+
+English is the source locale:
+
+`packages/web-core/src/i18n/locales/en/`
+
+## Add a new locale
+
+1. Scaffold the locale files from English:
+
+```bash
+node scripts/create-locale.mjs --ui RU --code ru --name "Русский"
+```
+
+2. Register the language in the config enum:
+
+`crates/services/src/services/config/versions/v6.rs`
+
+3. Regenerate shared types:
+
+```bash
+pnpm run generate-types
+```
+
+4. Register the language mapping and endonym:
+
+`packages/web-core/src/i18n/languages.ts`
+
+5. Register the locale resources:
+
+`packages/web-core/src/i18n/config.ts`
+
+6. Translate the new locale JSON files.
+
+## QA checklist
+
+Run the existing i18n checks:
+
+```bash
+./scripts/check-i18n.sh
+node scripts/check-unused-i18n-keys.mjs
+```
+
+Run the unchanged-string helper for the new locale:
+
+```bash
+node scripts/check-locale-translation.mjs ru
+```
+
+Use `--fail-on-identical` if you want the command to exit non-zero when the locale still contains English strings:
+
+```bash
+node scripts/check-locale-translation.mjs ru --fail-on-identical
+```
+
+## Review expectations
+
+For upstream locale PRs, aim for:
+
+- full namespace coverage
+- no missing keys
+- no accidental English leftovers in user-facing strings
+- working language selection in Settings
+- sensible browser-language detection
+
+Keep locale workflow changes separate from large translation changes when possible. It makes review much easier.

--- a/package.json
+++ b/package.json
@@ -38,6 +38,8 @@
     "remote:generate-types:check": "cargo run --manifest-path crates/remote/Cargo.toml --bin remote-generate-types -- --check",
     "prepare-db": "node scripts/prepare-db.js",
     "prepare-db:check": "node scripts/prepare-db.js --check",
+    "locale:new": "node scripts/create-locale.mjs",
+    "locale:check": "node scripts/check-locale-translation.mjs",
     "build:bippy-bundle": "node scripts/build-bippy-bundle.mjs",
     "build:npx": "bash ./local-build.sh",
     "build:npx-cli": "cd npx-cli && npm ci && npm run build",

--- a/scripts/check-locale-translation.mjs
+++ b/scripts/check-locale-translation.mjs
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+const LOCALES_DIR = path.join(ROOT, 'packages/web-core/src/i18n/locales');
+const SOURCE_DIR = path.join(LOCALES_DIR, 'en');
+const namespaceFiles = ['common.json', 'settings.json', 'projects.json', 'tasks.json', 'organization.json'];
+
+function usage() {
+  console.log(`Usage:
+  node scripts/check-locale-translation.mjs <locale-code> [--fail-on-identical]
+`);
+}
+
+function flattenStrings(value, prefix = '') {
+  if (typeof value === 'string') {
+    return [[prefix, value]];
+  }
+
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return [];
+  }
+
+  return Object.entries(value).flatMap(([key, child]) =>
+    flattenStrings(child, prefix ? `${prefix}.${key}` : key),
+  );
+}
+
+function isProbablySafeToMatch(value) {
+  if (!/[A-Za-z]/.test(value)) return false;
+  if (/^https?:\/\//.test(value)) return false;
+  if (/^[A-Z0-9 _./:+-]+$/.test(value)) return false;
+  if (/^\{\{.+\}\}$/.test(value)) return false;
+  return true;
+}
+
+const args = process.argv.slice(2);
+const localeCode = args[0];
+const failOnIdentical = args.includes('--fail-on-identical');
+
+if (!localeCode || localeCode.startsWith('-')) {
+  usage();
+  process.exit(1);
+}
+
+if (localeCode === 'en') {
+  console.error('Pass a translated locale code, not en.');
+  process.exit(1);
+}
+
+const targetDir = path.join(LOCALES_DIR, localeCode);
+if (!fs.existsSync(targetDir)) {
+  console.error(`Locale directory not found: ${targetDir}`);
+  process.exit(1);
+}
+
+let identicalCount = 0;
+let reported = 0;
+const REPORT_LIMIT = 100;
+
+for (const file of namespaceFiles) {
+  const sourcePath = path.join(SOURCE_DIR, file);
+  const targetPath = path.join(targetDir, file);
+
+  if (!fs.existsSync(targetPath)) {
+    console.error(`Missing locale file: ${targetPath}`);
+    process.exit(1);
+  }
+
+  const source = JSON.parse(fs.readFileSync(sourcePath, 'utf8'));
+  const target = JSON.parse(fs.readFileSync(targetPath, 'utf8'));
+
+  const sourceEntries = new Map(flattenStrings(source));
+  const targetEntries = new Map(flattenStrings(target));
+
+  for (const [key, englishValue] of sourceEntries.entries()) {
+    const translatedValue = targetEntries.get(key);
+    if (translatedValue !== englishValue) continue;
+    if (!isProbablySafeToMatch(englishValue)) continue;
+
+    identicalCount += 1;
+    if (reported < REPORT_LIMIT) {
+      console.log(`${file}:${key}`);
+      console.log(`  en = ${JSON.stringify(englishValue)}`);
+      console.log(`  ${localeCode} = ${JSON.stringify(translatedValue)}`);
+      reported += 1;
+    }
+  }
+}
+
+if (identicalCount === 0) {
+  console.log(`No unchanged strings found for locale '${localeCode}'.`);
+  process.exit(0);
+}
+
+if (identicalCount > REPORT_LIMIT) {
+  console.log(`... ${identicalCount - REPORT_LIMIT} more unchanged strings omitted`);
+}
+
+console.log(`Found ${identicalCount} unchanged strings in locale '${localeCode}'.`);
+process.exit(failOnIdentical ? 1 : 0);

--- a/scripts/create-locale.mjs
+++ b/scripts/create-locale.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+const EN_LOCALES_DIR = path.join(
+  ROOT,
+  'packages/web-core/src/i18n/locales/en',
+);
+const TARGET_ROOT = path.join(ROOT, 'packages/web-core/src/i18n/locales');
+
+function printUsage() {
+  console.log(`Usage:
+  node scripts/create-locale.mjs --ui RU --code ru --name "Русский"
+
+Required flags:
+  --ui     UI enum value to add later (e.g. RU, DE, IT)
+  --code   i18next locale code (e.g. ru, de, it)
+  --name   Native display name / endonym
+`);
+}
+
+function parseArgs(argv) {
+  const result = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (!arg.startsWith('--')) continue;
+    result[arg.slice(2)] = argv[i + 1];
+    i += 1;
+  }
+  return result;
+}
+
+function ensureDir(dir) {
+  fs.mkdirSync(dir, { recursive: true });
+}
+
+const args = parseArgs(process.argv.slice(2));
+const ui = args.ui;
+const code = args.code;
+const name = args.name;
+
+if (!ui || !code || !name) {
+  printUsage();
+  process.exit(1);
+}
+
+if (!fs.existsSync(EN_LOCALES_DIR)) {
+  console.error(`English locale directory not found: ${EN_LOCALES_DIR}`);
+  process.exit(1);
+}
+
+const targetDir = path.join(TARGET_ROOT, code);
+if (fs.existsSync(targetDir)) {
+  console.error(`Locale directory already exists: ${targetDir}`);
+  process.exit(1);
+}
+
+ensureDir(targetDir);
+
+const namespaceFiles = fs
+  .readdirSync(EN_LOCALES_DIR)
+  .filter((file) => file.endsWith('.json'))
+  .sort();
+
+for (const file of namespaceFiles) {
+  const source = path.join(EN_LOCALES_DIR, file);
+  const target = path.join(targetDir, file);
+  fs.copyFileSync(source, target);
+}
+
+console.log(`Scaffolded locale '${code}' in ${targetDir}`);
+console.log('');
+console.log('Next steps:');
+console.log(
+  `1. Add UiLanguage::${ui[0]}${ui.slice(1).toLowerCase()} in crates/services/src/services/config/versions/v6.rs`,
+);
+console.log('2. Run: pnpm run generate-types');
+console.log(
+  `3. Register ${ui} -> ${code} and the endonym "${name}" in packages/web-core/src/i18n/languages.ts`,
+);
+console.log(
+  `4. Register locale resources for "${code}" in packages/web-core/src/i18n/config.ts`,
+);
+console.log(`5. Translate files under packages/web-core/src/i18n/locales/${code}/`);
+console.log(`6. Run: node scripts/check-locale-translation.mjs ${code}`);

--- a/scripts/create-locale.mjs
+++ b/scripts/create-locale.mjs
@@ -38,6 +38,14 @@ function ensureDir(dir) {
   fs.mkdirSync(dir, { recursive: true });
 }
 
+function toRustUiLanguageVariant(ui) {
+  return ui
+    .split('_')
+    .filter(Boolean)
+    .map((segment) => segment[0] + segment.slice(1).toLowerCase())
+    .join('');
+}
+
 const args = parseArgs(process.argv.slice(2));
 const ui = args.ui;
 const code = args.code;
@@ -76,7 +84,7 @@ console.log(`Scaffolded locale '${code}' in ${targetDir}`);
 console.log('');
 console.log('Next steps:');
 console.log(
-  `1. Add UiLanguage::${ui[0]}${ui.slice(1).toLowerCase()} in crates/services/src/services/config/versions/v6.rs`,
+  `1. Add UiLanguage::${toRustUiLanguageVariant(ui)} in crates/services/src/services/config/versions/v6.rs`,
 );
 console.log('2. Run: pnpm run generate-types');
 console.log(


### PR DESCRIPTION
## Summary
- document the locale contribution workflow in the repo
- add a scaffold script for new locales
- add a helper to report unchanged translation strings

## Validation
- node scripts/create-locale.mjs
- node scripts/check-locale-translation.mjs fr
- node scripts/check-unused-i18n-keys.mjs
- ./scripts/check-i18n.sh

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds documentation and developer tooling scripts only; no runtime i18n behavior or CI enforcement changes.
> 
> **Overview**
> Adds repo documentation for contributing new locales (`docs/i18n.md`) and a design note describing the two-PR plan for upstreaming Russian (`docs/designs/russian-localization-upstream.md`).
> 
> Introduces two Node scripts: `scripts/create-locale.mjs` to scaffold a new locale directory by copying English JSON namespaces, and `scripts/check-locale-translation.mjs` to report strings that are still identical to English (optionally failing via `--fail-on-identical`).
> 
> Exposes both utilities via `package.json` scripts (`locale:new`, `locale:check`) to standardize the workflow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6eb3f77d7e429cfc353084890a229d6d639da832. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->