### PR TITLE
fix: copy patches/ directory in Dockerfile fe-builder stage

### DIFF
--- a/crates/remote/Dockerfile
+++ b/crates/remote/Dockerfile
@@ -19,6 +19,7 @@ COPY packages/local-web/package.json packages/local-web/package.json
 COPY packages/remote-web/package.json packages/remote-web/package.json
 COPY packages/ui/package.json packages/ui/package.json
 COPY packages/web-core/package.json packages/web-core/package.json
+COPY patches/ patches/
 
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
     pnpm install --frozen-lockfile


### PR DESCRIPTION
Fixes #3300

## Summary
- Add `COPY patches/ patches/` before `pnpm install` in the `fe-builder` stage of `crates/remote/Dockerfile`
- Without this, pnpm fails with `ENOENT` when trying to apply `@pierre__diffs@1.1.4.patch` during `pnpm install --frozen-lockfile`

## Test plan
- [ ] Run `docker compose --env-file ../../.env.remote -f docker-compose.prod.yml up -d --build` from `crates/remote/` and verify the build succeeds

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change limited to the frontend Docker build context; primary impact is on image build reproducibility and avoiding `pnpm install` failures when patch files are required.
> 
> **Overview**
> Fixes the `crates/remote/Dockerfile` frontend build by copying the `patches/` directory into the `fe-builder` stage *before* running `pnpm install --frozen-lockfile`, ensuring pnpm can apply workspace patch files during image builds.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a39e53b764e28f3fb31052960bfe211d9928d8c3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->