### PR TITLE
feat: add Pi coding agent executor via pi-acp ACP adapter

### DIFF
--- a/crates/executors/default_profiles.json
+++ b/crates/executors/default_profiles.json
@@ -63,6 +63,11 @@
           "autonomy": "skip-permissions-unsafe"
         }
       }
+    },
+    "PI": {
+      "DEFAULT": {
+        "PI": {}
+      }
     }
   }
 }

--- a/crates/executors/src/executors/mod.rs
+++ b/crates/executors/src/executors/mod.rs
@@ -23,7 +23,7 @@ use crate::{
     env::ExecutionEnv,
     executors::{
         amp::Amp, claude::ClaudeCode, codex::Codex, copilot::Copilot, cursor::CursorAgent,
-        droid::Droid, gemini::Gemini, opencode::Opencode, qwen::QwenCode,
+        droid::Droid, gemini::Gemini, opencode::Opencode, pi::Pi, qwen::QwenCode,
     },
     logs::utils::patch,
     mcp_config::McpConfig,
@@ -39,6 +39,7 @@ pub mod cursor;
 pub mod droid;
 pub mod gemini;
 pub mod opencode;
+pub mod pi;
 #[cfg(feature = "qa-mode")]
 pub mod qa_mock;
 pub mod qwen;
@@ -119,6 +120,7 @@ pub enum CodingAgent {
     QwenCode,
     Copilot,
     Droid,
+    Pi,
     #[cfg(feature = "qa-mode")]
     QaMock(QaMockExecutor),
 }
@@ -193,7 +195,7 @@ impl CodingAgent {
                 vec![BaseAgentCapability::SessionFork]
             }
             Self::CursorAgent(_) => vec![BaseAgentCapability::SetupHelper],
-            Self::Amp(_) | Self::Copilot(_) | Self::Droid(_) => vec![],
+            Self::Amp(_) | Self::Copilot(_) | Self::Droid(_) | Self::Pi(_) => vec![],
             #[cfg(feature = "qa-mode")]
             Self::QaMock(_) => vec![], // QA mock doesn't need special capabilities
         }

--- a/crates/executors/src/executors/pi.rs
+++ b/crates/executors/src/executors/pi.rs
@@ -1,0 +1,162 @@
+use std::{path::Path, sync::Arc};
+
+use async_trait::async_trait;
+use derivative::Derivative;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use ts_rs::TS;
+use workspace_utils::msg_store::MsgStore;
+
+pub use super::acp::AcpAgentHarness;
+use crate::{
+    approvals::ExecutorApprovalService,
+    command::{CmdOverrides, CommandBuildError, CommandBuilder, apply_overrides},
+    env::ExecutionEnv,
+    executor_discovery::ExecutorDiscoveredOptions,
+    executors::{
+        AppendPrompt, AvailabilityInfo, BaseCodingAgent, ExecutorError, SpawnedChild,
+        StandardCodingAgentExecutor,
+    },
+    logs::utils::patch,
+    model_selector::{ModelSelectorConfig, PermissionPolicy},
+    profile::ExecutorConfig,
+};
+
+#[derive(Derivative, Clone, Serialize, Deserialize, TS, JsonSchema)]
+#[derivative(Debug, PartialEq)]
+pub struct Pi {
+    #[serde(default)]
+    pub append_prompt: AppendPrompt,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    #[serde(flatten)]
+    pub cmd: CmdOverrides,
+    #[serde(skip)]
+    #[ts(skip)]
+    #[derivative(Debug = "ignore", PartialEq = "ignore")]
+    pub approvals: Option<Arc<dyn ExecutorApprovalService>>,
+}
+
+impl Pi {
+    fn build_command_builder(&self) -> Result<CommandBuilder, CommandBuildError> {
+        // pi-acp is the ACP adapter for the pi coding agent
+        // https://github.com/svkozak/pi-acp
+        let builder = CommandBuilder::new("npx -y pi-acp");
+
+        apply_overrides(builder, &self.cmd)
+    }
+}
+
+#[async_trait]
+impl StandardCodingAgentExecutor for Pi {
+    fn apply_overrides(&mut self, executor_config: &ExecutorConfig) {
+        if let Some(model_id) = &executor_config.model_id {
+            self.model = Some(model_id.clone());
+        }
+    }
+
+    fn use_approvals(&mut self, approvals: Arc<dyn ExecutorApprovalService>) {
+        self.approvals = Some(approvals);
+    }
+
+    async fn spawn(
+        &self,
+        current_dir: &Path,
+        prompt: &str,
+        env: &ExecutionEnv,
+    ) -> Result<SpawnedChild, ExecutorError> {
+        let harness = AcpAgentHarness::with_session_namespace("pi_sessions");
+        let combined_prompt = self.append_prompt.combine_prompt(prompt);
+        let pi_command = self.build_command_builder()?.build_initial()?;
+        harness
+            .spawn_with_command(
+                current_dir,
+                combined_prompt,
+                pi_command,
+                env,
+                &self.cmd,
+                self.approvals.clone(),
+            )
+            .await
+    }
+
+    async fn spawn_follow_up(
+        &self,
+        current_dir: &Path,
+        prompt: &str,
+        session_id: &str,
+        _reset_to_message_id: Option<&str>,
+        env: &ExecutionEnv,
+    ) -> Result<SpawnedChild, ExecutorError> {
+        let harness = AcpAgentHarness::with_session_namespace("pi_sessions");
+        let combined_prompt = self.append_prompt.combine_prompt(prompt);
+        let pi_command = self.build_command_builder()?.build_follow_up(&[])?;
+        harness
+            .spawn_follow_up_with_command(
+                current_dir,
+                combined_prompt,
+                session_id,
+                pi_command,
+                env,
+                &self.cmd,
+                self.approvals.clone(),
+            )
+            .await
+    }
+
+    fn normalize_logs(
+        &self,
+        msg_store: Arc<MsgStore>,
+        worktree_path: &Path,
+    ) -> Vec<tokio::task::JoinHandle<()>> {
+        crate::executors::acp::normalize_logs(msg_store, worktree_path)
+    }
+
+    fn default_mcp_config_path(&self) -> Option<std::path::PathBuf> {
+        // pi stores its settings at ~/.pi/agent/settings.json
+        dirs::home_dir().map(|home| home.join(".pi").join("agent").join("settings.json"))
+    }
+
+    fn get_availability_info(&self) -> AvailabilityInfo {
+        // Check if pi is installed by looking for its config directory
+        let pi_dir_found = dirs::home_dir()
+            .map(|home| home.join(".pi").join("agent").is_dir())
+            .unwrap_or(false);
+
+        if pi_dir_found {
+            AvailabilityInfo::InstallationFound
+        } else {
+            AvailabilityInfo::NotFound
+        }
+    }
+
+    fn get_preset_options(&self) -> ExecutorConfig {
+        ExecutorConfig {
+            executor: BaseCodingAgent::Pi,
+            variant: None,
+            model_id: self.model.clone(),
+            agent_id: None,
+            reasoning_id: None,
+            permission_policy: Some(PermissionPolicy::Auto),
+        }
+    }
+
+    async fn discover_options(
+        &self,
+        _workdir: Option<&std::path::Path>,
+        _repo_path: Option<&std::path::Path>,
+    ) -> Result<futures::stream::BoxStream<'static, json_patch::Patch>, ExecutorError> {
+        // pi supports multiple providers/models via its own configuration
+        // Users configure models in pi's settings, not through vibe-kanban
+        let options = ExecutorDiscoveredOptions {
+            model_selector: ModelSelectorConfig {
+                permissions: vec![PermissionPolicy::Auto, PermissionPolicy::Supervised],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        Ok(Box::pin(futures::stream::once(async move {
+            patch::executor_discovered_options(options)
+        })))
+    }
+}

--- a/crates/executors/src/mcp_config.rs
+++ b/crates/executors/src/mcp_config.rs
@@ -403,6 +403,7 @@ impl CodingAgent {
             CodingAgent::Codex(_) => Codex,
             CodingAgent::Opencode(_) => Opencode,
             CodingAgent::Copilot(..) => Copilot,
+            CodingAgent::Pi(_) => Passthrough,
             #[cfg(feature = "qa-mode")]
             CodingAgent::QaMock(_) => Passthrough, // QA mock doesn't need MCP
         };

--- a/packages/public/agents/pi-dark.svg
+++ b/packages/public/agents/pi-dark.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
+  <rect width="24" height="24" rx="6" fill="#1a1a2e"/>
+  <text x="12" y="17.5" text-anchor="middle" font-family="serif" font-size="16" font-weight="bold" fill="#e0e0e0">π</text>
+</svg>

--- a/packages/public/agents/pi-light.svg
+++ b/packages/public/agents/pi-light.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
+  <rect width="24" height="24" rx="6" fill="#f0f0f5"/>
+  <text x="12" y="17.5" text-anchor="middle" font-family="serif" font-size="16" font-weight="bold" fill="#1a1a2e">π</text>
+</svg>

--- a/packages/web-core/src/shared/components/AgentIcon.tsx
+++ b/packages/web-core/src/shared/components/AgentIcon.tsx
@@ -29,6 +29,8 @@ export function getAgentName(
       return 'Copilot';
     case BaseCodingAgent.DROID:
       return 'Droid';
+    case BaseCodingAgent.PI:
+      return 'Pi';
   }
 }
 
@@ -72,6 +74,9 @@ export function AgentIcon({ agent, className = 'h-4 w-4' }: AgentIconProps) {
       break;
     case BaseCodingAgent.DROID:
       iconPath = `/agents/droid${suffix}.svg`;
+      break;
+    case BaseCodingAgent.PI:
+      iconPath = `/agents/pi${suffix}.svg`;
       break;
     default:
       return null;

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -587,7 +587,7 @@ working_dir: string | null, };
 
 export type ScriptRequestLanguage = "Bash";
 
-export enum BaseCodingAgent { CLAUDE_CODE = "CLAUDE_CODE", AMP = "AMP", GEMINI = "GEMINI", CODEX = "CODEX", OPENCODE = "OPENCODE", CURSOR_AGENT = "CURSOR_AGENT", QWEN_CODE = "QWEN_CODE", COPILOT = "COPILOT", DROID = "DROID" }
+export enum BaseCodingAgent { CLAUDE_CODE = "CLAUDE_CODE", AMP = "AMP", GEMINI = "GEMINI", CODEX = "CODEX", OPENCODE = "OPENCODE", CURSOR_AGENT = "CURSOR_AGENT", QWEN_CODE = "QWEN_CODE", COPILOT = "COPILOT", DROID = "DROID", PI = "PI" }
 
 export type CodingAgent = { "CLAUDE_CODE": ClaudeCode } | { "AMP": Amp } | { "GEMINI": Gemini } | { "CODEX": Codex } | { "OPENCODE": Opencode } | { "CURSOR_AGENT": CursorAgent } | { "QWEN_CODE": QwenCode } | { "COPILOT": Copilot } | { "DROID": Droid };
 


### PR DESCRIPTION
## Summary

Adds [Pi](https://github.com/badlogic/pi-mono) as a new coding agent executor, using the [pi-acp](https://github.com/svkozak/pi-acp) ACP adapter.

## Implementation

Following the established ACP-based executor pattern (same as Gemini, Qwen, Copilot):

### Rust Backend
- **`crates/executors/src/executors/pi.rs`** — Pi executor struct implementing `StandardCodingAgentExecutor` via `AcpAgentHarness`
- Command: `npx -y pi-acp` (ACP JSON-RPC 2.0 over stdio)
- Session namespace: `pi_sessions`
- Availability detection: checks for `~/.pi/agent/` directory
- MCP config path: `~/.pi/agent/settings.json`

### Registration
- `CodingAgent` enum: added `Pi` variant
- `capabilities()`: empty (like Amp/Copilot/Droid — no SessionFork or ContextUsage via ACP yet)
- `preconfigured_mcp()`: Passthrough adapter
- `default_profiles.json`: added PI profile

### Frontend
- `BaseCodingAgent` TypeScript enum: added `PI`
- `AgentIcon.tsx`: Pi name + icon paths
- SVG icons: `pi-dark.svg`, `pi-light.svg`

## Build Verification

```
cargo check  # ✅ full project passes
```

## References
- pi-acp: https://github.com/svkozak/pi-acp (⭐147, v0.0.24)
- pi: https://github.com/badlogic/pi-mono
- Related: PR #1917 (previous Pi integration attempt, different approach)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new ACP-based executor that spawns an external `npx` command and introduces new availability/MCP config paths, so failures or unexpected behavior will surface at runtime on user machines. Risk is moderated by being additive and largely isolated behind the existing executor interface.
> 
> **Overview**
> Adds **Pi** as a new coding agent option end-to-end.
> 
> Backend registers a `Pi` executor implementing `StandardCodingAgentExecutor`, spawning via `npx -y pi-acp`, providing install detection and a default MCP config path, and wiring `Pi` into `CodingAgent`/capabilities plus MCP preconfiguration as passthrough.
> 
> Config/UI updates add a default `PI` profile, extend the shared `BaseCodingAgent` enum, and add Pi light/dark icons and `AgentIcon` mapping for display.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 58e3ac489231f2cc0f53543990cc2fed4b46da2e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->