### PR TITLE
Emit git-style diff headers in concatenate_diff_hunks to prevent parser crashes (Vibe Kanban)

### DIFF
--- a/crates/utils/src/diff.rs
+++ b/crates/utils/src/diff.rs
@@ -190,11 +190,16 @@ fn fix_hunk_headers(hunks: Vec<String>) -> Vec<String> {
     new_hunks
 }
 
-/// Creates a full unified diff with the file path in the header,
+/// Creates a full unified diff with the file path in the header.
+///
+/// Outputs git-diff format (`diff --git` prefix) so that downstream parsers
+/// (e.g. @pierre/diffs) split on `^diff --git` boundaries instead of
+/// `^---\s+\S`, which collides with deleted lines starting with `-- `.
 pub fn concatenate_diff_hunks(file_path: &str, hunks: &[String]) -> String {
     let mut unified_diff = String::new();
 
-    let header = format!("--- a/{file_path}\n+++ b/{file_path}\n");
+    let header =
+        format!("diff --git a/{file_path} b/{file_path}\n--- a/{file_path}\n+++ b/{file_path}\n");
 
     unified_diff.push_str(&header);
 


### PR DESCRIPTION
## What changed
- Updated `concatenate_diff_hunks` in `crates/utils/src/diff.rs` to prepend a `diff --git a/<path> b/<path>` header before the existing `---` / `+++` unified diff file headers.
- Expanded the function documentation to explicitly describe the git-diff output format and parser behavior expectations.
- Kept the rest of the hunk concatenation behavior unchanged; this is a focused formatting fix in diff output construction.

## Why this was changed
- The previous output began directly with `---` / `+++`, which can be ambiguous for downstream parsers that segment diffs using patterns that may collide with diff content.
- In particular, parser boundaries could be confused by deleted lines that start with `-- `, leading to PatchDiff parsing failures/crashes.
- Emitting the `diff --git` prefix aligns output with standard git-diff structure and gives downstream tools a reliable file boundary marker.

## Important implementation details
- The header is now built as:
  - `diff --git a/{file_path} b/{file_path}`
  - `--- a/{file_path}`
  - `+++ b/{file_path}`
- This preserves compatibility with unified diff consumers while improving robustness for tools (e.g. `@pierre/diffs`) that prefer `^diff --git` as the split boundary.

- [x] tested

This PR was written using [Vibe Kanban](https://vibekanban.com)
