### PR TITLE
fix: use portable worker bundle to fix diff tab in prod builds (#3307)

### DIFF
--- a/packages/web-core/src/pages/workspaces/ChangesPanelContainer.tsx
+++ b/packages/web-core/src/pages/workspaces/ChangesPanelContainer.tsx
@@ -12,8 +12,10 @@ import {
   WorkerPoolContextProvider,
 } from '@pierre/diffs/react';
 import type { DiffLineAnnotation, AnnotationSide } from '@pierre/diffs';
-const WorkerUrl = new URL('@pierre/diffs/worker/worker.js', import.meta.url)
-  .href;
+const WorkerUrl = new URL(
+  '@pierre/diffs/worker/worker-portable.js',
+  import.meta.url
+).href;
 import { sortDiffs } from '@/shared/lib/fileTreeUtils';
 import { useChangesView } from '@/shared/hooks/useChangesView';
 import { useScrollSyncStateMachine } from '@/shared/hooks/useScrollSyncStateMachine';


### PR DESCRIPTION
## Summary

- Fix diff tab showing empty page in production builds while working fine in dev
- Switch `@pierre/diffs` worker from `worker.js` to `worker-portable.js` (pre-bundled variant)

## Root Cause

The `worker.js` entry from `@pierre/diffs` contains bare module specifiers (`shiki/core`, `shiki/engine/javascript`, etc.) that browsers cannot resolve inside ES module workers. Vite's dev server transparently resolves these, but in production builds the worker is emitted as a static asset without bundling its dependencies — causing the worker to error on load.

When workers fail to initialize, Pierre's `WorkerPoolManager.isWorkingPool()` still returns `true` (the `workersFailed` flag is never set because the init Promise hangs). This means `renderDiff()` always takes the worker code path, `getPlainDiffAST()` returns `undefined`, and the shadow roots remain empty — producing a blank diff tab.

## Fix

One-line change in `ChangesPanelContainer.tsx`: use `worker-portable.js` instead of `worker.js`. The portable variant is a fully self-contained bundle (~490KB) with zero bare imports, so it works correctly as a browser module worker in production builds.

## Test plan

- [x] Verify `pnpm run build` produces a worker asset with 0 bare import statements
- [ ] Verify diff tab loads correctly in a production build
- [ ] Verify diff tab still works in dev


🤖 Generated with [Claude Code](https://claude.com/claude-code)