### PR TITLE
fix: prevent stale loadedInitialEntries guard from blocking conversation history load

### DIFF
--- a/packages/web-core/src/features/workspace-chat/model/hooks/useConversationHistory.ts
+++ b/packages/web-core/src/features/workspace-chat/model/hooks/useConversationHistory.ts
@@ -400,16 +400,15 @@ export const useConversationHistory = ({
       if (executionProcesses.current.length === 0) {
         if (emittedEmptyInitialRef.current) return;
         emittedEmptyInitialRef.current = true;
-        loadedInitialEntries.current = true;
         emitEntries(displayedExecutionProcesses.current, 'initial', false);
         return;
       }
 
       emittedEmptyInitialRef.current = false;
-      loadedInitialEntries.current = true;
 
       const allInitialEntries = await loadHistoricEntries(MIN_INITIAL_ENTRIES);
       if (cancelled) return;
+      loadedInitialEntries.current = true;
       mergeIntoDisplayed((state) => {
         Object.assign(state, allInitialEntries);
       });


### PR DESCRIPTION
## Summary

Fixes conversation history not loading when switching between workspaces. The user would see "Send a message to start the conversation" instead of actual history, requiring a page reload to fix.

## Root Cause

Commit `06a6ae18b` migrated `ExecutionProcessesProvider` from React Context to a Zustand store. This introduced an async timing gap: the store is updated via `useEffect` in the parent, but children's effects run first (React's bottom-up ordering). During workspace switches, `useConversationHistory`'s load effect would read stale store data and prematurely set `loadedInitialEntries = true`, permanently blocking the history load when correct data arrived later.

Two specific paths were affected:

1. **Empty branch**: `selectedSessionId` transitions through `undefined` between switches, causing `isLoading = false` with 0 processes. The empty branch treated this as a genuinely empty session and set `loadedInitialEntries = true`.

2. **Loading branch**: When stale wrong-session processes were still in the store, the flag was set *before* the async `loadHistoricEntries()` call. If the effect was cancelled (by new data arriving) and re-ran, the flag blocked re-entry.

## Fix

- **Remove** `loadedInitialEntries = true` from the empty-initial branch — transient empty states shouldn't lock out future loads
- **Move** `loadedInitialEntries = true` in the loading branch from before `await loadHistoricEntries()` to after the `if (cancelled) return` check — only mark as loaded after a successful, non-cancelled load completes

## Test plan

- [x] Switch between workspaces with existing conversation history — history loads immediately
- [x] Switch workspaces multiple times in succession — no infinite spinner
- [x] Fresh workspace with no history — empty state displays correctly
- [x] `pnpm run check` passes
- [x] `pnpm run format` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)