### PR TITLE
fix(server): return 404 instead of 500 when container path has no matching workspace

### DIFF
--- a/crates/server/src/routes/containers.rs
+++ b/crates/server/src/routes/containers.rs
@@ -6,7 +6,7 @@ use axum::{
 };
 use db::models::{
     requests::ContainerQuery,
-    workspace::{Workspace, WorkspaceContext},
+    workspace::{Workspace, WorkspaceContext, WorkspaceError},
 };
 use deployment::Deployment;
 use serde::Serialize;
@@ -27,7 +27,12 @@ async fn get_container_info(
     let info =
         Workspace::resolve_container_ref_by_prefix(&deployment.db().pool, &query.container_ref)
             .await
-            .map_err(ApiError::Database)?;
+            .map_err(|e| match e {
+                sqlx::Error::RowNotFound => {
+                    ApiError::Workspace(WorkspaceError::WorkspaceNotFound)
+                }
+                e => ApiError::Database(e),
+            })?;
 
     Ok(ResponseJson(ApiResponse::success(ContainerInfo {
         attempt_id: info.workspace_id,
@@ -41,7 +46,12 @@ async fn get_context(
     let info =
         Workspace::resolve_container_ref_by_prefix(&deployment.db().pool, &payload.container_ref)
             .await
-            .map_err(ApiError::Database)?;
+            .map_err(|e| match e {
+                sqlx::Error::RowNotFound => {
+                    ApiError::Workspace(WorkspaceError::WorkspaceNotFound)
+                }
+                e => ApiError::Database(e),
+            })?;
 
     let ctx = Workspace::load_context(&deployment.db().pool, info.workspace_id).await?;
     Ok(ResponseJson(ApiResponse::success(ctx)))


### PR DESCRIPTION
## Context

The `/containers/info` and `/containers/attempt-context` endpoints call `Workspace::resolve_container_ref_by_prefix`, which returns `sqlx::Error::RowNotFound` when no workspace's `container_ref` matches the given path.

Previously, this was propagated via `.map_err(ApiError::Database)`, causing the error to be caught by the `ApiError::Database(_)` arm and returned as a 500 Internal Server Error, logged at `ERROR` level. This is expected behaviour when a client (e.g. the VSCode extension) probes a path that does not belong to any Vibe Kanban workspace, so a 404 is the semantically correct response.

## Changes

- In `crates/server/src/routes/containers.rs`, replace `.map_err(ApiError::Database)` with a match that maps `sqlx::Error::RowNotFound` → `ApiError::Workspace(WorkspaceError::WorkspaceNotFound)` (404) in both `get_container_info` and `get_context`
- Actual database errors still propagate as 500
- Add `WorkspaceError` to imports

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small change limited to error mapping on two read-only container routes, only affecting the response status for missing rows while preserving 500s for real DB failures.
> 
> **Overview**
> Updates `/containers/info` and `/containers/attempt-context` to treat `sqlx::Error::RowNotFound` from `Workspace::resolve_container_ref_by_prefix` as `WorkspaceError::WorkspaceNotFound`, returning a **404** instead of a **500** when a container path doesn’t match any workspace.
> 
> All other SQLx errors continue to map to `ApiError::Database` (500), and `WorkspaceError` is added to the route imports.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d5ac712d2f2e15d4a1cfcca1ffc34d90cb92cb42. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->