### PR TITLE
feat: allow creating workspaces with an empty repository list

### DIFF
--- a/crates/local-deployment/src/container.rs
+++ b/crates/local-deployment/src/container.rs
@@ -163,11 +163,6 @@ impl LocalContainerService {
     ) -> Result<(Vec<Repo>, Vec<RepoWorkspaceInput>), ContainerError> {
         let workspace_repos =
             WorkspaceRepo::find_by_workspace_id(&self.db.pool, workspace_id).await?;
-        if workspace_repos.is_empty() {
-            return Err(ContainerError::Other(anyhow!(
-                "Workspace has no repositories configured"
-            )));
-        }
 
         let repositories =
             WorkspaceRepo::find_repos_for_workspace(&self.db.pool, workspace_id).await?;

--- a/crates/mcp/src/task_server/tools/task_attempts.rs
+++ b/crates/mcp/src/task_server/tools/task_attempts.rs
@@ -103,10 +103,6 @@ impl McpServer {
             issue_id,
         }): Parameters<StartWorkspaceRequest>,
     ) -> Result<CallToolResult, ErrorData> {
-        if repositories.is_empty() {
-            return Self::err("At least one repository must be specified.", None::<&str>);
-        }
-
         let executor_trimmed = executor.trim();
         if executor_trimmed.is_empty() {
             return Self::err("Executor must not be empty.", None::<&str>);

--- a/crates/server/src/routes/workspaces/create.rs
+++ b/crates/server/src/routes/workspaces/create.rs
@@ -228,12 +228,6 @@ pub async fn create_and_start_workspace(
         )
     })?;
 
-    if repos.is_empty() {
-        return Err(ApiError::BadRequest(
-            "At least one repository is required".to_string(),
-        ));
-    }
-
     let mut managed_workspace = deployment
         .workspace_manager()
         .load_managed_workspace(create_workspace_record(&deployment, name).await?)

--- a/crates/services/src/services/container.rs
+++ b/crates/services/src/services/container.rs
@@ -1141,11 +1141,6 @@ pub trait ContainerService {
         // Capture current HEAD per repository as the "before" commit for this execution
         let repositories =
             WorkspaceRepo::find_repos_for_workspace(&self.db().pool, workspace.id).await?;
-        if repositories.is_empty() {
-            return Err(ContainerError::Other(anyhow!(
-                "Workspace has no repositories configured"
-            )));
-        }
 
         let workspace_root = workspace
             .container_ref

--- a/crates/workspace-manager/src/workspace_manager.rs
+++ b/crates/workspace-manager/src/workspace_manager.rs
@@ -294,10 +294,6 @@ impl WorkspaceManager {
         repos: &[RepoWorkspaceInput],
         branch_name: &str,
     ) -> Result<WorktreeContainer, WorkspaceError> {
-        if repos.is_empty() {
-            return Err(WorkspaceError::NoRepositories);
-        }
-
         info!(
             "Creating workspace at {} with {} repositories",
             workspace_dir.display(),
@@ -377,7 +373,10 @@ impl WorkspaceManager {
         branch_name: &str,
     ) -> Result<(), WorkspaceError> {
         if repos.is_empty() {
-            return Err(WorkspaceError::NoRepositories);
+            if !workspace_dir.exists() {
+                tokio::fs::create_dir_all(workspace_dir).await?;
+            }
+            return Ok(());
         }
 
         // Try legacy migration first (single repo projects only)

--- a/packages/web-core/src/shared/components/CreateChatBoxContainer.tsx
+++ b/packages/web-core/src/shared/components/CreateChatBoxContainer.tsx
@@ -77,8 +77,8 @@ export function CreateChatBoxContainer({
     hasResolvedInitialRepoDefaults,
   ]);
 
-  const showRepoPickerStep = !hasSelectedRepos || isSelectingRepos;
-  const showChatStep = hasSelectedRepos && !isSelectingRepos;
+  const showRepoPickerStep = isSelectingRepos;
+  const showChatStep = !isSelectingRepos;
 
   // Attachment handling - insert markdown and track attachment IDs
   const handleInsertMarkdown = useCallback(
@@ -109,7 +109,7 @@ export function CreateChatBoxContainer({
 
   const { getRootProps, getInputProps, isDragActive } = useDropzone({
     onDrop,
-    disabled: createWorkspace.isPending || !hasSelectedRepos,
+    disabled: createWorkspace.isPending,
     noClick: true,
     noKeyboard: true,
   });
@@ -137,9 +137,10 @@ export function CreateChatBoxContainer({
 
   const repoId = repos.length === 1 ? repos[0]?.id : undefined;
   const repoSummaryLabel = useMemo(() => {
+    if (repos.length === 0) return 'No repositories';
     if (repos.length === 1) {
       const repo = repos[0];
-      if (!repo) return '0 repositories selected';
+      if (!repo) return 'No repositories';
       const selectedBranch = targetBranches[repo.id];
       const branch = selectedBranch
         ? truncateBranchLabel(selectedBranch)
@@ -167,7 +168,6 @@ export function CreateChatBoxContainer({
 
   // Determine if we can submit
   const canSubmit =
-    hasSelectedRepos &&
     hasSelectedBranchesForAllRepos &&
     message.trim().length > 0 &&
     effectiveExecutor !== null;
@@ -282,15 +282,13 @@ export function CreateChatBoxContainer({
 
   // Determine error to display
   const displayError =
-    hasAttemptedSubmit && repos.length === 0
-      ? 'Add at least one repository to create a workspace'
-      : hasAttemptedSubmit && !hasSelectedBranchesForAllRepos
-        ? 'Select a branch for every repository before creating a workspace'
-        : createWorkspace.error
-          ? createWorkspace.error instanceof Error
-            ? createWorkspace.error.message
-            : 'Failed to create workspace'
-          : null;
+    hasAttemptedSubmit && !hasSelectedBranchesForAllRepos
+      ? 'Select a branch for every repository before creating a workspace'
+      : createWorkspace.error
+        ? createWorkspace.error instanceof Error
+          ? createWorkspace.error.message
+          : 'Failed to create workspace'
+        : null;
 
   // Wait for initial value to be applied before rendering
   // This ensures the editor mounts with content ready, so autoFocus works correctly
@@ -308,7 +306,10 @@ export function CreateChatBoxContainer({
                 {t('createMode.headings.repoStep')}
               </h2>
               <CreateModeRepoPickerBar
-                onContinueToPrompt={() => setIsSelectingRepos(false)}
+                onContinueToPrompt={() => {
+                  setIsSelectingRepos(false);
+                  setHasInitializedStep(true);
+                }}
               />
             </>
           )}
@@ -360,7 +361,7 @@ export function CreateChatBoxContainer({
                   }
                   onSend={handleSubmit}
                   isSending={createWorkspace.isPending}
-                  disabled={!hasSelectedRepos}
+                  disabled={false}
                   executor={{
                     selected: effectiveExecutor,
                     options: executorOptions,

--- a/packages/web-core/src/shared/components/CreateModeRepoPickerBar.tsx
+++ b/packages/web-core/src/shared/components/CreateModeRepoPickerBar.tsx
@@ -353,7 +353,7 @@ export function CreateModeRepoPickerBar({
               variant="default"
               value="Continue"
               onClick={onContinueToPrompt}
-              disabled={isBusy || repos.length === 0}
+              disabled={isBusy}
             />
           </div>
         </div>


### PR DESCRIPTION
## Context

Users may want to create workspaces without any repositories, using the shell's working directory as the workspace `pwd`. Previously, empty repo lists were rejected at multiple validation layers.

When `hasResolvedInitialRepoDefaults` resolved after the user had already clicked "Continue" with no repos, the initialisation `useEffect` would fire (since `hasInitializedStep` was still `false`) and reset `isSelectingRepos` back to `true`, yanking the user from the chat step back to the repo picker. This was previously invisible because `showChatStep` required `hasSelectedRepos`.

## Changes

- Backend — remove empty-repos validation from:
  - `create_and_start_workspace` API route
  - `start_workspace` MCP tool
  - `start_execution` in the services container
  - `workspace_repo_inputs` in the local container
- `WorkspaceManager`:
  - `create_workspace` now creates the workspace directory even with no repos
  - `ensure_workspace_exists` returns early (after ensuring the directory exists) when repos are empty
- Frontend:
  - `CreateModeRepoPickerBar` — allow "Continue" with no repos selected
  - `CreateChatBoxContainer` — allow submission with no repos, remove the "at least one repository" error, show `No repositories` in the repo summary label
  - `CreateChatBoxContainer` — set `hasInitializedStep` to `true` when the user explicitly clicks "Continue", preventing the late-resolving effect from resetting the step

Contributes to #3061

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Enables workspace creation/execution flows to proceed with an empty repo list, which changes assumptions in container/worktree and UI flows and could expose edge cases around working directories, branch selection, and cleanup.
> 
> **Overview**
> Allows creating and starting workspaces with **zero repositories** by removing empty-repo validation from the API route (`create_and_start_workspace`), MCP tool (`start_workspace`), and container/services layers.
> 
> Updates `WorkspaceManager` to handle empty repo sets by still creating/ensuring the workspace directory (and returning early from `ensure_workspace_exists` when no repos). The web create flow is adjusted to let users continue/submit without selecting repos, removes the “at least one repository” error, and displays a `No repositories` summary label.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9431c1dcd975e237ca1497d2c2e927e9ac56f8e0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->