### PR TITLE
feat: add Gitea/Forgejo integration for pull request management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3223,6 +3223,7 @@ dependencies = [
  "chrono",
  "db",
  "enum_dispatch",
+ "reqwest 0.13.2",
  "serde",
  "serde_json",
  "tempfile",

--- a/crates/git-host/Cargo.toml
+++ b/crates/git-host/Cargo.toml
@@ -9,6 +9,7 @@ backon = "1.5.1"
 chrono = { version = "0.4", features = ["serde"] }
 db = { path = "../db" }
 enum_dispatch = "0.3.13"
+reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tempfile = "3.21"

--- a/crates/git-host/src/detection.rs
+++ b/crates/git-host/src/detection.rs
@@ -36,16 +36,16 @@ pub(crate) fn detect_provider_from_url(url: &str) -> ProviderKind {
     }
 
     // Gitea/Forgejo: explicit GITEA_URL match
-    if let Ok(gitea_url) = std::env::var("GITEA_URL")
-        && url_lower.contains(
-            gitea_url
-                .to_lowercase()
-                .trim_start_matches("https://")
-                .trim_start_matches("http://")
-                .trim_end_matches('/'),
-        )
-    {
-        return ProviderKind::Gitea;
+    if let Ok(gitea_url) = std::env::var("GITEA_URL") {
+        let gitea_host = gitea_url
+            .to_lowercase()
+            .trim_start_matches("https://")
+            .trim_start_matches("http://")
+            .trim_end_matches('/')
+            .to_string();
+        if !gitea_host.is_empty() && url_lower.contains(&gitea_host) {
+            return ProviderKind::Gitea;
+        }
     }
 
     // Gitea PR URL pattern: /pulls/ in path (GitHub uses /pull/, Azure uses /pullrequest/)
@@ -68,13 +68,20 @@ pub(crate) fn detect_provider_from_url(url: &str) -> ProviderKind {
 
 /// Extract the base URL for a Gitea instance from a remote or PR URL.
 ///
-/// Prefers `GITEA_URL` env var when set, otherwise derives it from the URL.
+/// Uses `GITEA_URL` env var only when the URL matches the configured instance.
+/// Otherwise derives the base URL from the URL itself.
 pub(crate) fn gitea_base_url(url: &str) -> String {
-    // Prefer explicit env var
-    if let Ok(gitea_url) = std::env::var("GITEA_URL")
-        && !gitea_url.is_empty()
-    {
-        return gitea_url.trim_end_matches('/').to_string();
+    // Use env var only if the URL actually matches the configured instance
+    if let Ok(gitea_url) = std::env::var("GITEA_URL") {
+        let gitea_host = gitea_url
+            .to_lowercase()
+            .trim_start_matches("https://")
+            .trim_start_matches("http://")
+            .trim_end_matches('/')
+            .to_string();
+        if !gitea_host.is_empty() && url.to_lowercase().contains(&gitea_host) {
+            return gitea_url.trim_end_matches('/').to_string();
+        }
     }
 
     // Derive from URL
@@ -297,5 +304,61 @@ mod tests {
     fn test_gitea_base_url_from_ssh() {
         let base = super::gitea_base_url("git@gitea.example.com:owner/repo.git");
         assert_eq!(base, "https://gitea.example.com");
+    }
+
+    // Edge-case tests for GITEA_URL handling (Bugbot findings)
+    //
+    // SAFETY: These tests manipulate env vars which is unsafe in Rust 2024.
+    // They must run single-threaded (--test-threads=1) to avoid races.
+
+    unsafe fn set_gitea_url(val: &str) {
+        std::env::set_var("GITEA_URL", val);
+    }
+
+    unsafe fn remove_gitea_url() {
+        std::env::remove_var("GITEA_URL");
+    }
+
+    #[test]
+    fn test_empty_gitea_url_does_not_match_all() {
+        // str::contains("") is always true in Rust — ensure we guard against that
+        unsafe { set_gitea_url("") };
+        assert_eq!(
+            detect_provider_from_url("https://gitlab.com/owner/repo"),
+            ProviderKind::Unknown,
+        );
+        assert_eq!(
+            detect_provider_from_url("https://bitbucket.org/owner/repo"),
+            ProviderKind::Unknown,
+        );
+        unsafe { remove_gitea_url() };
+    }
+
+    #[test]
+    fn test_scheme_only_gitea_url_does_not_match_all() {
+        unsafe { set_gitea_url("https://") };
+        assert_eq!(
+            detect_provider_from_url("https://gitlab.com/owner/repo"),
+            ProviderKind::Unknown,
+        );
+        unsafe { remove_gitea_url() };
+    }
+
+    #[test]
+    fn test_gitea_base_url_derives_from_url_when_env_differs() {
+        // GITEA_URL points to one instance, but URL is for Codeberg —
+        // should derive base URL from the URL, not the env var
+        unsafe { set_gitea_url("https://gitea.company.com") };
+        let base = super::gitea_base_url("https://codeberg.org/owner/repo.git");
+        assert_eq!(base, "https://codeberg.org");
+        unsafe { remove_gitea_url() };
+    }
+
+    #[test]
+    fn test_gitea_base_url_uses_env_when_matching() {
+        unsafe { set_gitea_url("https://gitea.company.com") };
+        let base = super::gitea_base_url("https://gitea.company.com/owner/repo.git");
+        assert_eq!(base, "https://gitea.company.com");
+        unsafe { remove_gitea_url() };
     }
 }

--- a/crates/git-host/src/detection.rs
+++ b/crates/git-host/src/detection.rs
@@ -8,6 +8,8 @@ use crate::types::ProviderKind;
 /// - GitHub.com: `https://github.com/owner/repo` or `git@github.com:owner/repo.git`
 /// - GitHub Enterprise: URLs containing `github.` (e.g., `https://github.company.com/owner/repo`)
 /// - Azure DevOps: `https://dev.azure.com/org/project/_git/repo` or legacy `https://org.visualstudio.com/...`
+/// - Gitea/Forgejo: instances registered via `GITEA_URL` env var, or URLs containing
+///   `/pulls/` (Gitea PR URL pattern), or `gitea.` / `forgejo.` in the hostname
 pub(crate) fn detect_provider_from_url(url: &str) -> ProviderKind {
     let url_lower = url.to_lowercase();
 
@@ -33,7 +35,65 @@ pub(crate) fn detect_provider_from_url(url: &str) -> ProviderKind {
         return ProviderKind::GitHub;
     }
 
+    // Gitea/Forgejo: explicit GITEA_URL match
+    if let Ok(gitea_url) = std::env::var("GITEA_URL")
+        && url_lower.contains(
+            gitea_url
+                .to_lowercase()
+                .trim_start_matches("https://")
+                .trim_start_matches("http://")
+                .trim_end_matches('/'),
+        )
+    {
+        return ProviderKind::Gitea;
+    }
+
+    // Gitea PR URL pattern: /pulls/ in path (GitHub uses /pull/, Azure uses /pullrequest/)
+    if url_lower.contains("/pulls/") {
+        return ProviderKind::Gitea;
+    }
+
+    // Well-known Gitea/Forgejo hostnames
+    if url_lower.contains("gitea.") || url_lower.contains("forgejo.") {
+        return ProviderKind::Gitea;
+    }
+
+    // Codeberg is a large Forgejo instance
+    if url_lower.contains("codeberg.org") {
+        return ProviderKind::Gitea;
+    }
+
     ProviderKind::Unknown
+}
+
+/// Extract the base URL for a Gitea instance from a remote or PR URL.
+///
+/// Prefers `GITEA_URL` env var when set, otherwise derives it from the URL.
+pub(crate) fn gitea_base_url(url: &str) -> String {
+    // Prefer explicit env var
+    if let Ok(gitea_url) = std::env::var("GITEA_URL")
+        && !gitea_url.is_empty()
+    {
+        return gitea_url.trim_end_matches('/').to_string();
+    }
+
+    // Derive from URL
+    if let Ok(parsed) = url::Url::parse(url) {
+        let mut base = format!("{}://{}", parsed.scheme(), parsed.host_str().unwrap_or(""));
+        if let Some(port) = parsed.port() {
+            base.push_str(&format!(":{port}"));
+        }
+        return base;
+    }
+
+    // SSH-style: git@host:owner/repo.git → https://host
+    if let Some(host_part) = url.strip_prefix("git@")
+        && let Some(host) = host_part.split(':').next()
+    {
+        return format!("https://{host}");
+    }
+
+    url.to_string()
 }
 
 /// Detect the git hosting provider from a PR URL.
@@ -42,6 +102,7 @@ pub(crate) fn detect_provider_from_url(url: &str) -> ProviderKind {
 /// - GitHub: `https://github.com/owner/repo/pull/123`
 /// - GitHub Enterprise: `https://github.company.com/owner/repo/pull/123`
 /// - Azure DevOps: `https://dev.azure.com/org/project/_git/repo/pullrequest/123`
+/// - Gitea/Forgejo: `https://gitea.example.com/owner/repo/pulls/123`
 #[cfg(test)]
 fn detect_provider_from_pr_url(pr_url: &str) -> ProviderKind {
     let url_lower = pr_url.to_lowercase();
@@ -59,7 +120,7 @@ fn detect_provider_from_pr_url(pr_url: &str) -> ProviderKind {
         return ProviderKind::AzureDevOps;
     }
 
-    // Fall back to general URL detection
+    // Fall back to general URL detection (handles Gitea /pulls/ pattern too)
     detect_provider_from_url(pr_url)
 }
 
@@ -137,6 +198,38 @@ mod tests {
     }
 
     #[test]
+    fn test_gitea_well_known_hostname() {
+        assert_eq!(
+            detect_provider_from_url("https://gitea.company.com/owner/repo"),
+            ProviderKind::Gitea
+        );
+        assert_eq!(
+            detect_provider_from_url("https://forgejo.example.org/owner/repo"),
+            ProviderKind::Gitea
+        );
+    }
+
+    #[test]
+    fn test_gitea_codeberg() {
+        assert_eq!(
+            detect_provider_from_url("https://codeberg.org/owner/repo"),
+            ProviderKind::Gitea
+        );
+        assert_eq!(
+            detect_provider_from_url("git@codeberg.org:owner/repo.git"),
+            ProviderKind::Gitea
+        );
+    }
+
+    #[test]
+    fn test_gitea_pr_url_pattern() {
+        assert_eq!(
+            detect_provider_from_url("https://git.example.com/owner/repo/pulls/42"),
+            ProviderKind::Gitea
+        );
+    }
+
+    #[test]
     fn test_unknown_provider() {
         assert_eq!(
             detect_provider_from_url("https://gitlab.com/owner/repo"),
@@ -174,5 +267,35 @@ mod tests {
             ),
             ProviderKind::AzureDevOps
         );
+    }
+
+    #[test]
+    fn test_pr_url_gitea() {
+        assert_eq!(
+            detect_provider_from_pr_url("https://gitea.example.com/owner/repo/pulls/42"),
+            ProviderKind::Gitea
+        );
+        assert_eq!(
+            detect_provider_from_pr_url("https://codeberg.org/owner/repo/pulls/7"),
+            ProviderKind::Gitea
+        );
+    }
+
+    #[test]
+    fn test_gitea_base_url_from_https() {
+        let base = super::gitea_base_url("https://gitea.example.com/owner/repo.git");
+        assert_eq!(base, "https://gitea.example.com");
+    }
+
+    #[test]
+    fn test_gitea_base_url_with_port() {
+        let base = super::gitea_base_url("http://localhost:3000/owner/repo");
+        assert_eq!(base, "http://localhost:3000");
+    }
+
+    #[test]
+    fn test_gitea_base_url_from_ssh() {
+        let base = super::gitea_base_url("git@gitea.example.com:owner/repo.git");
+        assert_eq!(base, "https://gitea.example.com");
     }
 }

--- a/crates/git-host/src/detection.rs
+++ b/crates/git-host/src/detection.rs
@@ -8,8 +8,8 @@ use crate::types::ProviderKind;
 /// - GitHub.com: `https://github.com/owner/repo` or `git@github.com:owner/repo.git`
 /// - GitHub Enterprise: URLs containing `github.` (e.g., `https://github.company.com/owner/repo`)
 /// - Azure DevOps: `https://dev.azure.com/org/project/_git/repo` or legacy `https://org.visualstudio.com/...`
-/// - Gitea/Forgejo: instances registered via `GITEA_URL` env var, or URLs containing
-///   `/pulls/` (Gitea PR URL pattern), or `gitea.` / `forgejo.` in the hostname
+/// - Gitea/Forgejo: instances registered via `GITEA_URL` env var, or well-known
+///   hostnames (`gitea.*`, `forgejo.*`, `codeberg.org`)
 pub(crate) fn detect_provider_from_url(url: &str) -> ProviderKind {
     let url_lower = url.to_lowercase();
 
@@ -48,11 +48,6 @@ pub(crate) fn detect_provider_from_url(url: &str) -> ProviderKind {
         }
     }
 
-    // Gitea PR URL pattern: /pulls/ in path (GitHub uses /pull/, Azure uses /pullrequest/)
-    if url_lower.contains("/pulls/") {
-        return ProviderKind::Gitea;
-    }
-
     // Well-known Gitea/Forgejo hostnames
     if url_lower.contains("gitea.") || url_lower.contains("forgejo.") {
         return ProviderKind::Gitea;
@@ -84,9 +79,15 @@ pub(crate) fn gitea_base_url(url: &str) -> String {
         }
     }
 
-    // Derive from URL
-    if let Ok(parsed) = url::Url::parse(url) {
-        let mut base = format!("{}://{}", parsed.scheme(), parsed.host_str().unwrap_or(""));
+    // Derive from URL — force HTTPS for non-HTTP schemes (ssh://, git://)
+    if let Ok(parsed) = url::Url::parse(url)
+        && let Some(host) = parsed.host_str()
+    {
+        let scheme = match parsed.scheme() {
+            "http" | "https" => parsed.scheme(),
+            _ => "https",
+        };
+        let mut base = format!("{scheme}://{host}");
         if let Some(port) = parsed.port() {
             base.push_str(&format!(":{port}"));
         }
@@ -229,10 +230,11 @@ mod tests {
     }
 
     #[test]
-    fn test_gitea_pr_url_pattern() {
+    fn test_unknown_url_with_pulls_not_detected_as_gitea() {
+        // /pulls/ alone should NOT trigger Gitea detection — prevents token leakage
         assert_eq!(
-            detect_provider_from_url("https://git.example.com/owner/repo/pulls/42"),
-            ProviderKind::Gitea
+            detect_provider_from_url("https://evil.com/x/y/pulls/1"),
+            ProviderKind::Unknown
         );
     }
 
@@ -303,6 +305,19 @@ mod tests {
     #[test]
     fn test_gitea_base_url_from_ssh() {
         let base = super::gitea_base_url("git@gitea.example.com:owner/repo.git");
+        assert_eq!(base, "https://gitea.example.com");
+    }
+
+    #[test]
+    fn test_gitea_base_url_from_ssh_scheme() {
+        // ssh:// URLs should produce https:// base, not ssh://
+        let base = super::gitea_base_url("ssh://git@gitea.example.com/owner/repo.git");
+        assert_eq!(base, "https://gitea.example.com");
+    }
+
+    #[test]
+    fn test_gitea_base_url_from_git_scheme() {
+        let base = super::gitea_base_url("git://gitea.example.com/owner/repo.git");
         assert_eq!(base, "https://gitea.example.com");
     }
 

--- a/crates/git-host/src/gitea/api.rs
+++ b/crates/git-host/src/gitea/api.rs
@@ -2,7 +2,7 @@
 //!
 //! Uses `reqwest` directly instead of shelling out to a CLI binary.
 //! Authentication is via a personal access token supplied through the
-//! `GITEA_TOKEN` env var, or read from the `tea` CLI config as a fallback.
+//! `GITEA_TOKEN` env var.
 
 use chrono::{DateTime, Utc};
 use db::models::merge::MergeStatus;
@@ -85,7 +85,7 @@ struct GiteaReviewComment {
     user: Option<GiteaUser>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 struct GiteaUser {
     login: String,
 }
@@ -96,12 +96,6 @@ struct CreatePrPayload {
     body: String,
     head: String,
     base: String,
-}
-
-#[derive(Deserialize)]
-struct GiteaVersionResponse {
-    #[allow(dead_code)]
-    version: String,
 }
 
 // ---------------------------------------------------------------------------
@@ -183,8 +177,7 @@ impl GiteaClient {
         })
     }
 
-    /// Resolve the API token from `GITEA_TOKEN` env var, or fall back to
-    /// reading the `tea` CLI config.
+    /// Resolve the API token from the `GITEA_TOKEN` env var.
     fn resolve_token() -> Result<String, GiteaApiError> {
         if let Ok(token) = std::env::var("GITEA_TOKEN")
             && !token.is_empty()
@@ -192,63 +185,11 @@ impl GiteaClient {
             return Ok(token);
         }
 
-        // Try reading from tea CLI config
-        if let Some(token) = Self::read_tea_config_token() {
-            return Ok(token);
-        }
-
         Err(GiteaApiError::NoToken)
-    }
-
-    /// Attempt to read a token from `~/.config/tea/config.yml`.
-    fn read_tea_config_token() -> Option<String> {
-        let home = std::env::var("HOME")
-            .or_else(|_| std::env::var("USERPROFILE"))
-            .ok()?;
-        let config_path = std::path::Path::new(&home)
-            .join(".config")
-            .join("tea")
-            .join("config.yml");
-        let content = std::fs::read_to_string(config_path).ok()?;
-
-        // Simple YAML parsing — look for "token:" line
-        for line in content.lines() {
-            let trimmed = line.trim();
-            if let Some(rest) = trimmed.strip_prefix("token:") {
-                let token = rest.trim().trim_matches('"').trim_matches('\'');
-                if !token.is_empty() {
-                    return Some(token.to_string());
-                }
-            }
-        }
-
-        None
     }
 
     fn api_url(&self, path: &str) -> String {
         format!("{}/api/v1{}", self.base_url, path)
-    }
-
-    /// Check if the given base URL hosts a Gitea/Forgejo instance by probing
-    /// `/api/v1/version`.
-    pub async fn probe_instance(base_url: &str) -> bool {
-        let url = format!("{}/api/v1/version", base_url.trim_end_matches('/'));
-        let Ok(client) = Client::builder().build() else {
-            return false;
-        };
-        let Ok(resp) = client
-            .get(&url)
-            .timeout(std::time::Duration::from_secs(5))
-            .send()
-            .await
-        else {
-            return false;
-        };
-        if !resp.status().is_success() {
-            return false;
-        }
-        // Gitea and Forgejo both return {"version":"..."} from this endpoint
-        resp.json::<GiteaVersionResponse>().await.is_ok()
     }
 
     // -----------------------------------------------------------------------
@@ -278,7 +219,7 @@ impl GiteaClient {
             .await
             .map_err(|e| GiteaApiError::RequestFailed(e.to_string()))?;
 
-        self.check_response_status(&resp)?;
+        let resp = self.check_response(resp).await?;
 
         let pr: GiteaPullRequest = resp
             .json()
@@ -306,7 +247,7 @@ impl GiteaClient {
             .await
             .map_err(|e| GiteaApiError::RequestFailed(e.to_string()))?;
 
-        self.check_response_status(&resp)?;
+        let resp = self.check_response(resp).await?;
 
         let pr: GiteaPullRequest = resp
             .json()
@@ -333,7 +274,7 @@ impl GiteaClient {
             .await
             .map_err(|e| GiteaApiError::RequestFailed(e.to_string()))?;
 
-        self.check_response_status(&resp)?;
+        let resp = self.check_response(resp).await?;
 
         let prs: Vec<GiteaPullRequest> = resp
             .json()
@@ -376,7 +317,7 @@ impl GiteaClient {
             .await
             .map_err(|e| GiteaApiError::RequestFailed(e.to_string()))?;
 
-        self.check_response_status(&comments_resp)?;
+        let comments_resp = self.check_response(comments_resp).await?;
 
         let general_comments: Vec<GiteaComment> = comments_resp
             .json()
@@ -396,7 +337,7 @@ impl GiteaClient {
             .await
             .map_err(|e| GiteaApiError::RequestFailed(e.to_string()))?;
 
-        self.check_response_status(&reviews_resp)?;
+        let reviews_resp = self.check_response(reviews_resp).await?;
 
         let reviews: Vec<GiteaReview> = reviews_resp
             .json()
@@ -418,7 +359,7 @@ impl GiteaClient {
                 .await
                 .map_err(|e| GiteaApiError::RequestFailed(e.to_string()))?;
 
-            self.check_response_status(&resp)?;
+            let resp = self.check_response(resp).await?;
 
             let comments: Vec<GiteaReviewComment> = resp
                 .json()
@@ -476,18 +417,31 @@ impl GiteaClient {
     // Helpers
     // -----------------------------------------------------------------------
 
-    fn check_response_status(&self, resp: &reqwest::Response) -> Result<(), GiteaApiError> {
-        match resp.status() {
-            s if s.is_success() => Ok(()),
-            StatusCode::UNAUTHORIZED => Err(GiteaApiError::AuthFailed(
-                "Gitea API returned 401 Unauthorized".to_string(),
-            )),
-            StatusCode::FORBIDDEN => Err(GiteaApiError::InsufficientPermissions(
-                "Gitea API returned 403 Forbidden — check token scopes".to_string(),
-            )),
-            status => Err(GiteaApiError::RequestFailed(format!(
-                "Gitea API returned {status}"
-            ))),
+    /// Check the response status and return the response on success.
+    /// On error, reads the response body for Gitea's error detail.
+    async fn check_response(
+        &self,
+        resp: reqwest::Response,
+    ) -> Result<reqwest::Response, GiteaApiError> {
+        if resp.status().is_success() {
+            return Ok(resp);
+        }
+
+        let status = resp.status();
+        let body = resp
+            .text()
+            .await
+            .unwrap_or_else(|_| "(could not read response body)".to_string());
+        let detail = if body.is_empty() {
+            status.to_string()
+        } else {
+            format!("{status}: {body}")
+        };
+
+        match status {
+            StatusCode::UNAUTHORIZED => Err(GiteaApiError::AuthFailed(detail)),
+            StatusCode::FORBIDDEN => Err(GiteaApiError::InsufficientPermissions(detail)),
+            _ => Err(GiteaApiError::RequestFailed(detail)),
         }
     }
 
@@ -545,14 +499,6 @@ pub fn parse_pr_url(pr_url: &str) -> Option<(String, String, String, i64)> {
     };
 
     Some((base_url, owner, repo, number))
-}
-
-impl Clone for GiteaUser {
-    fn clone(&self) -> Self {
-        Self {
-            login: self.login.clone(),
-        }
-    }
 }
 
 #[cfg(test)]

--- a/crates/git-host/src/gitea/api.rs
+++ b/crates/git-host/src/gitea/api.rs
@@ -21,6 +21,8 @@ use crate::types::{CreatePrRequest, PullRequestDetail, UnifiedPrComment};
 pub enum GiteaApiError {
     #[error("Gitea authentication failed: {0}")]
     AuthFailed(String),
+    #[error("Gitea insufficient permissions: {0}")]
+    InsufficientPermissions(String),
     #[error("Gitea API request failed: {0}")]
     RequestFailed(String),
     #[error("Gitea returned unexpected response: {0}")]
@@ -65,12 +67,9 @@ struct GiteaComment {
 
 #[derive(Debug, Deserialize)]
 struct GiteaReview {
-    #[allow(dead_code)]
     id: i64,
     #[allow(dead_code)]
     body: String,
-    #[serde(default)]
-    comments: Vec<GiteaReviewComment>,
     user: Option<GiteaUser>,
 }
 
@@ -384,7 +383,7 @@ impl GiteaClient {
             .await
             .map_err(|e| GiteaApiError::UnexpectedResponse(e.to_string()))?;
 
-        // Fetch review comments
+        // Fetch reviews list (does NOT include inline comments)
         let reviews_url = self.api_url(&format!(
             "/repos/{}/{}/pulls/{}/reviews",
             info.owner, info.repo, pr_number
@@ -404,6 +403,33 @@ impl GiteaClient {
             .await
             .map_err(|e| GiteaApiError::UnexpectedResponse(e.to_string()))?;
 
+        // Fetch inline comments for each review via /reviews/{id}/comments
+        let mut review_comments: Vec<(GiteaReviewComment, Option<GiteaUser>)> = Vec::new();
+        for review in &reviews {
+            let comments_url = self.api_url(&format!(
+                "/repos/{}/{}/pulls/{}/reviews/{}/comments",
+                info.owner, info.repo, pr_number, review.id
+            ));
+            let resp = self
+                .client
+                .get(&comments_url)
+                .header(header::AUTHORIZATION, format!("token {}", self.token))
+                .send()
+                .await
+                .map_err(|e| GiteaApiError::RequestFailed(e.to_string()))?;
+
+            self.check_response_status(&resp)?;
+
+            let comments: Vec<GiteaReviewComment> = resp
+                .json()
+                .await
+                .map_err(|e| GiteaApiError::UnexpectedResponse(e.to_string()))?;
+
+            for c in comments {
+                review_comments.push((c, review.user.clone()));
+            }
+        }
+
         // Convert to unified comments
         let mut unified: Vec<UnifiedPrComment> = Vec::new();
 
@@ -422,26 +448,24 @@ impl GiteaClient {
             });
         }
 
-        for review in reviews {
-            for c in review.comments {
-                let author = c
-                    .user
-                    .or(review.user.clone())
-                    .map(|u| u.login)
-                    .unwrap_or_else(|| "unknown".to_string());
-                unified.push(UnifiedPrComment::Review {
-                    id: c.id,
-                    author,
-                    author_association: None,
-                    body: c.body,
-                    created_at: c.created_at,
-                    url: c.html_url,
-                    path: c.path.unwrap_or_default(),
-                    line: c.line,
-                    side: None,
-                    diff_hunk: c.diff_hunk,
-                });
-            }
+        for (c, review_user) in review_comments {
+            let author = c
+                .user
+                .or(review_user)
+                .map(|u| u.login)
+                .unwrap_or_else(|| "unknown".to_string());
+            unified.push(UnifiedPrComment::Review {
+                id: c.id,
+                author,
+                author_association: None,
+                body: c.body,
+                created_at: c.created_at,
+                url: c.html_url,
+                path: c.path.unwrap_or_default(),
+                line: c.line,
+                side: None,
+                diff_hunk: c.diff_hunk,
+            });
         }
 
         unified.sort_by_key(|c| c.created_at());
@@ -455,8 +479,11 @@ impl GiteaClient {
     fn check_response_status(&self, resp: &reqwest::Response) -> Result<(), GiteaApiError> {
         match resp.status() {
             s if s.is_success() => Ok(()),
-            StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN => Err(GiteaApiError::AuthFailed(
-                format!("Gitea API returned {}", resp.status()),
+            StatusCode::UNAUTHORIZED => Err(GiteaApiError::AuthFailed(
+                "Gitea API returned 401 Unauthorized".to_string(),
+            )),
+            StatusCode::FORBIDDEN => Err(GiteaApiError::InsufficientPermissions(
+                "Gitea API returned 403 Forbidden — check token scopes".to_string(),
             )),
             status => Err(GiteaApiError::RequestFailed(format!(
                 "Gitea API returned {status}"

--- a/crates/git-host/src/gitea/api.rs
+++ b/crates/git-host/src/gitea/api.rs
@@ -1,0 +1,640 @@
+//! HTTP client for the Gitea/Forgejo REST API v1.
+//!
+//! Uses `reqwest` directly instead of shelling out to a CLI binary.
+//! Authentication is via a personal access token supplied through the
+//! `GITEA_TOKEN` env var, or read from the `tea` CLI config as a fallback.
+
+use chrono::{DateTime, Utc};
+use db::models::merge::MergeStatus;
+use reqwest::{Client, StatusCode, header};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use url::Url;
+
+use crate::types::{CreatePrRequest, PullRequestDetail, UnifiedPrComment};
+
+// ---------------------------------------------------------------------------
+// Error type
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Error)]
+pub enum GiteaApiError {
+    #[error("Gitea authentication failed: {0}")]
+    AuthFailed(String),
+    #[error("Gitea API request failed: {0}")]
+    RequestFailed(String),
+    #[error("Gitea returned unexpected response: {0}")]
+    UnexpectedResponse(String),
+    #[error("Could not determine Gitea token — set GITEA_TOKEN env var")]
+    NoToken,
+    #[error("Could not parse Gitea URL: {0}")]
+    InvalidUrl(String),
+}
+
+// ---------------------------------------------------------------------------
+// API response types
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+struct GiteaPullRequest {
+    number: i64,
+    html_url: String,
+    state: String,
+    title: String,
+    merged: Option<bool>,
+    merged_at: Option<DateTime<Utc>>,
+    merge_commit_sha: Option<String>,
+    base: Option<GiteaBranch>,
+    head: Option<GiteaBranch>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GiteaBranch {
+    #[serde(rename = "ref")]
+    ref_name: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct GiteaComment {
+    id: i64,
+    body: String,
+    created_at: DateTime<Utc>,
+    html_url: Option<String>,
+    user: Option<GiteaUser>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GiteaReview {
+    #[allow(dead_code)]
+    id: i64,
+    #[allow(dead_code)]
+    body: String,
+    #[serde(default)]
+    comments: Vec<GiteaReviewComment>,
+    user: Option<GiteaUser>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GiteaReviewComment {
+    id: i64,
+    body: String,
+    created_at: DateTime<Utc>,
+    html_url: Option<String>,
+    path: Option<String>,
+    line: Option<i64>,
+    diff_hunk: Option<String>,
+    user: Option<GiteaUser>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GiteaUser {
+    login: String,
+}
+
+#[derive(Serialize)]
+struct CreatePrPayload {
+    title: String,
+    body: String,
+    head: String,
+    base: String,
+}
+
+#[derive(Deserialize)]
+struct GiteaVersionResponse {
+    #[allow(dead_code)]
+    version: String,
+}
+
+// ---------------------------------------------------------------------------
+// Repo info extracted from a remote URL
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+pub struct GiteaRepoInfo {
+    pub base_url: String,
+    pub owner: String,
+    pub repo: String,
+}
+
+impl GiteaRepoInfo {
+    /// Parse owner/repo from a Gitea-style remote URL.
+    ///
+    /// Supports both HTTPS (`https://gitea.example.com/owner/repo.git`) and
+    /// SSH (`git@gitea.example.com:owner/repo.git`) URLs.
+    pub fn from_remote_url(remote_url: &str, base_url: &str) -> Result<Self, GiteaApiError> {
+        // Try HTTPS-style URL first
+        if let Ok(parsed) = Url::parse(remote_url) {
+            let segments: Vec<&str> = parsed
+                .path_segments()
+                .map(|s| s.collect())
+                .unwrap_or_default();
+            if segments.len() >= 2 {
+                let owner = segments[0].to_string();
+                let repo = segments[1].trim_end_matches(".git").to_string();
+                return Ok(Self {
+                    base_url: base_url.trim_end_matches('/').to_string(),
+                    owner,
+                    repo,
+                });
+            }
+        }
+
+        // Try SSH-style URL: git@host:owner/repo.git
+        if let Some(path) = remote_url.split(':').nth(1) {
+            let parts: Vec<&str> = path.split('/').collect();
+            if parts.len() >= 2 {
+                let owner = parts[0].to_string();
+                let repo = parts[1].trim_end_matches(".git").to_string();
+                return Ok(Self {
+                    base_url: base_url.trim_end_matches('/').to_string(),
+                    owner,
+                    repo,
+                });
+            }
+        }
+
+        Err(GiteaApiError::InvalidUrl(format!(
+            "Cannot extract owner/repo from URL: {remote_url}"
+        )))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Client
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+pub struct GiteaClient {
+    client: Client,
+    token: String,
+    pub base_url: String,
+}
+
+impl GiteaClient {
+    pub fn new(base_url: &str) -> Result<Self, GiteaApiError> {
+        let token = Self::resolve_token()?;
+        let client = Client::builder()
+            .build()
+            .map_err(|e| GiteaApiError::RequestFailed(e.to_string()))?;
+
+        Ok(Self {
+            client,
+            token,
+            base_url: base_url.trim_end_matches('/').to_string(),
+        })
+    }
+
+    /// Resolve the API token from `GITEA_TOKEN` env var, or fall back to
+    /// reading the `tea` CLI config.
+    fn resolve_token() -> Result<String, GiteaApiError> {
+        if let Ok(token) = std::env::var("GITEA_TOKEN")
+            && !token.is_empty()
+        {
+            return Ok(token);
+        }
+
+        // Try reading from tea CLI config
+        if let Some(token) = Self::read_tea_config_token() {
+            return Ok(token);
+        }
+
+        Err(GiteaApiError::NoToken)
+    }
+
+    /// Attempt to read a token from `~/.config/tea/config.yml`.
+    fn read_tea_config_token() -> Option<String> {
+        let home = std::env::var("HOME")
+            .or_else(|_| std::env::var("USERPROFILE"))
+            .ok()?;
+        let config_path = std::path::Path::new(&home)
+            .join(".config")
+            .join("tea")
+            .join("config.yml");
+        let content = std::fs::read_to_string(config_path).ok()?;
+
+        // Simple YAML parsing — look for "token:" line
+        for line in content.lines() {
+            let trimmed = line.trim();
+            if let Some(rest) = trimmed.strip_prefix("token:") {
+                let token = rest.trim().trim_matches('"').trim_matches('\'');
+                if !token.is_empty() {
+                    return Some(token.to_string());
+                }
+            }
+        }
+
+        None
+    }
+
+    fn api_url(&self, path: &str) -> String {
+        format!("{}/api/v1{}", self.base_url, path)
+    }
+
+    /// Check if the given base URL hosts a Gitea/Forgejo instance by probing
+    /// `/api/v1/version`.
+    pub async fn probe_instance(base_url: &str) -> bool {
+        let url = format!("{}/api/v1/version", base_url.trim_end_matches('/'));
+        let Ok(client) = Client::builder().build() else {
+            return false;
+        };
+        let Ok(resp) = client
+            .get(&url)
+            .timeout(std::time::Duration::from_secs(5))
+            .send()
+            .await
+        else {
+            return false;
+        };
+        if !resp.status().is_success() {
+            return false;
+        }
+        // Gitea and Forgejo both return {"version":"..."} from this endpoint
+        resp.json::<GiteaVersionResponse>().await.is_ok()
+    }
+
+    // -----------------------------------------------------------------------
+    // API methods
+    // -----------------------------------------------------------------------
+
+    pub async fn create_pr(
+        &self,
+        info: &GiteaRepoInfo,
+        request: &CreatePrRequest,
+    ) -> Result<PullRequestDetail, GiteaApiError> {
+        let url = self.api_url(&format!("/repos/{}/{}/pulls", info.owner, info.repo));
+
+        let payload = CreatePrPayload {
+            title: request.title.clone(),
+            body: request.body.clone().unwrap_or_default(),
+            head: request.head_branch.clone(),
+            base: request.base_branch.clone(),
+        };
+
+        let resp = self
+            .client
+            .post(&url)
+            .header(header::AUTHORIZATION, format!("token {}", self.token))
+            .json(&payload)
+            .send()
+            .await
+            .map_err(|e| GiteaApiError::RequestFailed(e.to_string()))?;
+
+        self.check_response_status(&resp)?;
+
+        let pr: GiteaPullRequest = resp
+            .json()
+            .await
+            .map_err(|e| GiteaApiError::UnexpectedResponse(e.to_string()))?;
+
+        Ok(Self::to_pull_request_detail(pr))
+    }
+
+    pub async fn get_pr(
+        &self,
+        info: &GiteaRepoInfo,
+        pr_number: i64,
+    ) -> Result<PullRequestDetail, GiteaApiError> {
+        let url = self.api_url(&format!(
+            "/repos/{}/{}/pulls/{}",
+            info.owner, info.repo, pr_number
+        ));
+
+        let resp = self
+            .client
+            .get(&url)
+            .header(header::AUTHORIZATION, format!("token {}", self.token))
+            .send()
+            .await
+            .map_err(|e| GiteaApiError::RequestFailed(e.to_string()))?;
+
+        self.check_response_status(&resp)?;
+
+        let pr: GiteaPullRequest = resp
+            .json()
+            .await
+            .map_err(|e| GiteaApiError::UnexpectedResponse(e.to_string()))?;
+
+        Ok(Self::to_pull_request_detail(pr))
+    }
+
+    pub async fn list_prs(
+        &self,
+        info: &GiteaRepoInfo,
+        state: &str,
+        head_branch: Option<&str>,
+    ) -> Result<Vec<PullRequestDetail>, GiteaApiError> {
+        let mut url = self.api_url(&format!("/repos/{}/{}/pulls", info.owner, info.repo));
+        url.push_str(&format!("?state={state}&limit=50"));
+
+        let resp = self
+            .client
+            .get(&url)
+            .header(header::AUTHORIZATION, format!("token {}", self.token))
+            .send()
+            .await
+            .map_err(|e| GiteaApiError::RequestFailed(e.to_string()))?;
+
+        self.check_response_status(&resp)?;
+
+        let prs: Vec<GiteaPullRequest> = resp
+            .json()
+            .await
+            .map_err(|e| GiteaApiError::UnexpectedResponse(e.to_string()))?;
+
+        let results: Vec<PullRequestDetail> = prs
+            .into_iter()
+            .filter(|pr| {
+                if let Some(branch) = head_branch {
+                    pr.head
+                        .as_ref()
+                        .map(|h| h.ref_name == branch)
+                        .unwrap_or(false)
+                } else {
+                    true
+                }
+            })
+            .map(Self::to_pull_request_detail)
+            .collect();
+
+        Ok(results)
+    }
+
+    pub async fn get_pr_comments(
+        &self,
+        info: &GiteaRepoInfo,
+        pr_number: i64,
+    ) -> Result<Vec<UnifiedPrComment>, GiteaApiError> {
+        // Fetch issue-level comments
+        let comments_url = self.api_url(&format!(
+            "/repos/{}/{}/issues/{}/comments",
+            info.owner, info.repo, pr_number
+        ));
+        let comments_resp = self
+            .client
+            .get(&comments_url)
+            .header(header::AUTHORIZATION, format!("token {}", self.token))
+            .send()
+            .await
+            .map_err(|e| GiteaApiError::RequestFailed(e.to_string()))?;
+
+        self.check_response_status(&comments_resp)?;
+
+        let general_comments: Vec<GiteaComment> = comments_resp
+            .json()
+            .await
+            .map_err(|e| GiteaApiError::UnexpectedResponse(e.to_string()))?;
+
+        // Fetch review comments
+        let reviews_url = self.api_url(&format!(
+            "/repos/{}/{}/pulls/{}/reviews",
+            info.owner, info.repo, pr_number
+        ));
+        let reviews_resp = self
+            .client
+            .get(&reviews_url)
+            .header(header::AUTHORIZATION, format!("token {}", self.token))
+            .send()
+            .await
+            .map_err(|e| GiteaApiError::RequestFailed(e.to_string()))?;
+
+        self.check_response_status(&reviews_resp)?;
+
+        let reviews: Vec<GiteaReview> = reviews_resp
+            .json()
+            .await
+            .map_err(|e| GiteaApiError::UnexpectedResponse(e.to_string()))?;
+
+        // Convert to unified comments
+        let mut unified: Vec<UnifiedPrComment> = Vec::new();
+
+        for c in general_comments {
+            let author = c
+                .user
+                .map(|u| u.login)
+                .unwrap_or_else(|| "unknown".to_string());
+            unified.push(UnifiedPrComment::General {
+                id: c.id.to_string(),
+                author,
+                author_association: None,
+                body: c.body,
+                created_at: c.created_at,
+                url: c.html_url,
+            });
+        }
+
+        for review in reviews {
+            for c in review.comments {
+                let author = c
+                    .user
+                    .or(review.user.clone())
+                    .map(|u| u.login)
+                    .unwrap_or_else(|| "unknown".to_string());
+                unified.push(UnifiedPrComment::Review {
+                    id: c.id,
+                    author,
+                    author_association: None,
+                    body: c.body,
+                    created_at: c.created_at,
+                    url: c.html_url,
+                    path: c.path.unwrap_or_default(),
+                    line: c.line,
+                    side: None,
+                    diff_hunk: c.diff_hunk,
+                });
+            }
+        }
+
+        unified.sort_by_key(|c| c.created_at());
+        Ok(unified)
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    fn check_response_status(&self, resp: &reqwest::Response) -> Result<(), GiteaApiError> {
+        match resp.status() {
+            s if s.is_success() => Ok(()),
+            StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN => Err(GiteaApiError::AuthFailed(
+                format!("Gitea API returned {}", resp.status()),
+            )),
+            status => Err(GiteaApiError::RequestFailed(format!(
+                "Gitea API returned {status}"
+            ))),
+        }
+    }
+
+    fn to_pull_request_detail(pr: GiteaPullRequest) -> PullRequestDetail {
+        let status = match pr.state.as_str() {
+            "open" => MergeStatus::Open,
+            "closed" => {
+                if pr.merged.unwrap_or(false) {
+                    MergeStatus::Merged
+                } else {
+                    MergeStatus::Closed
+                }
+            }
+            _ => MergeStatus::Unknown,
+        };
+
+        PullRequestDetail {
+            number: pr.number,
+            url: pr.html_url,
+            status,
+            merged_at: pr.merged_at,
+            merge_commit_sha: pr.merge_commit_sha,
+            title: pr.title,
+            base_branch: pr.base.map(|b| b.ref_name).unwrap_or_default(),
+            head_branch: pr.head.map(|h| h.ref_name).unwrap_or_default(),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// PR URL parsing
+// ---------------------------------------------------------------------------
+
+/// Parse a Gitea PR URL into (base_url, owner, repo, pr_number).
+///
+/// Format: `https://gitea.example.com/owner/repo/pulls/123`
+pub fn parse_pr_url(pr_url: &str) -> Option<(String, String, String, i64)> {
+    let parsed = Url::parse(pr_url).ok()?;
+    let segments: Vec<&str> = parsed.path_segments()?.collect();
+
+    // Expect: ["owner", "repo", "pulls", "123"]
+    if segments.len() < 4 || segments[2] != "pulls" {
+        return None;
+    }
+
+    let owner = segments[0].to_string();
+    let repo = segments[1].to_string();
+    let number: i64 = segments[3].parse().ok()?;
+
+    let base_url = format!("{}://{}", parsed.scheme(), parsed.host_str()?);
+    let base_url = if let Some(port) = parsed.port() {
+        format!("{base_url}:{port}")
+    } else {
+        base_url
+    };
+
+    Some((base_url, owner, repo, number))
+}
+
+impl Clone for GiteaUser {
+    fn clone(&self) -> Self {
+        Self {
+            login: self.login.clone(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_pr_url_standard() {
+        let (base, owner, repo, number) =
+            parse_pr_url("https://gitea.example.com/alice/my-repo/pulls/42").unwrap();
+        assert_eq!(base, "https://gitea.example.com");
+        assert_eq!(owner, "alice");
+        assert_eq!(repo, "my-repo");
+        assert_eq!(number, 42);
+    }
+
+    #[test]
+    fn test_parse_pr_url_with_port() {
+        let (base, owner, repo, number) =
+            parse_pr_url("http://localhost:3000/bob/project/pulls/7").unwrap();
+        assert_eq!(base, "http://localhost:3000");
+        assert_eq!(owner, "bob");
+        assert_eq!(repo, "project");
+        assert_eq!(number, 7);
+    }
+
+    #[test]
+    fn test_parse_pr_url_not_a_pr() {
+        assert!(parse_pr_url("https://gitea.example.com/owner/repo").is_none());
+        assert!(parse_pr_url("https://github.com/owner/repo/pull/1").is_none());
+    }
+
+    #[test]
+    fn test_repo_info_from_https_url() {
+        let info = GiteaRepoInfo::from_remote_url(
+            "https://gitea.example.com/alice/my-repo.git",
+            "https://gitea.example.com",
+        )
+        .unwrap();
+        assert_eq!(info.owner, "alice");
+        assert_eq!(info.repo, "my-repo");
+        assert_eq!(info.base_url, "https://gitea.example.com");
+    }
+
+    #[test]
+    fn test_repo_info_from_ssh_url() {
+        let info = GiteaRepoInfo::from_remote_url(
+            "git@gitea.example.com:alice/my-repo.git",
+            "https://gitea.example.com",
+        )
+        .unwrap();
+        assert_eq!(info.owner, "alice");
+        assert_eq!(info.repo, "my-repo");
+    }
+
+    #[test]
+    fn test_to_pull_request_detail_open() {
+        let pr = GiteaPullRequest {
+            number: 1,
+            html_url: "https://gitea.example.com/o/r/pulls/1".to_string(),
+            state: "open".to_string(),
+            title: "Test".to_string(),
+            merged: Some(false),
+            merged_at: None,
+            merge_commit_sha: None,
+            base: Some(GiteaBranch {
+                ref_name: "main".to_string(),
+            }),
+            head: Some(GiteaBranch {
+                ref_name: "feature".to_string(),
+            }),
+        };
+        let detail = GiteaClient::to_pull_request_detail(pr);
+        assert!(matches!(detail.status, MergeStatus::Open));
+        assert_eq!(detail.base_branch, "main");
+        assert_eq!(detail.head_branch, "feature");
+    }
+
+    #[test]
+    fn test_to_pull_request_detail_merged() {
+        let pr = GiteaPullRequest {
+            number: 2,
+            html_url: "https://gitea.example.com/o/r/pulls/2".to_string(),
+            state: "closed".to_string(),
+            title: "Merged PR".to_string(),
+            merged: Some(true),
+            merged_at: Some(Utc::now()),
+            merge_commit_sha: Some("abc123".to_string()),
+            base: None,
+            head: None,
+        };
+        let detail = GiteaClient::to_pull_request_detail(pr);
+        assert!(matches!(detail.status, MergeStatus::Merged));
+    }
+
+    #[test]
+    fn test_to_pull_request_detail_closed_not_merged() {
+        let pr = GiteaPullRequest {
+            number: 3,
+            html_url: "https://gitea.example.com/o/r/pulls/3".to_string(),
+            state: "closed".to_string(),
+            title: "Closed PR".to_string(),
+            merged: Some(false),
+            merged_at: None,
+            merge_commit_sha: None,
+            base: None,
+            head: None,
+        };
+        let detail = GiteaClient::to_pull_request_detail(pr);
+        assert!(matches!(detail.status, MergeStatus::Closed));
+    }
+}

--- a/crates/git-host/src/gitea/mod.rs
+++ b/crates/git-host/src/gitea/mod.rs
@@ -39,14 +39,15 @@ impl From<GiteaApiError> for GitHostError {
     fn from(error: GiteaApiError) -> Self {
         match &error {
             GiteaApiError::AuthFailed(msg) => GitHostError::AuthFailed(msg.clone()),
+            GiteaApiError::InsufficientPermissions(msg) => {
+                GitHostError::InsufficientPermissions(msg.clone())
+            }
             GiteaApiError::NoToken => GitHostError::AuthFailed(
                 "No Gitea token found — set the GITEA_TOKEN environment variable".to_string(),
             ),
             GiteaApiError::RequestFailed(msg) => {
                 let lower = msg.to_ascii_lowercase();
-                if lower.contains("403") || lower.contains("forbidden") {
-                    GitHostError::InsufficientPermissions(msg.clone())
-                } else if lower.contains("404") || lower.contains("not found") {
+                if lower.contains("404") || lower.contains("not found") {
                     GitHostError::RepoNotFoundOrNoAccess(msg.clone())
                 } else {
                     GitHostError::PullRequest(msg.clone())

--- a/crates/git-host/src/gitea/mod.rs
+++ b/crates/git-host/src/gitea/mod.rs
@@ -1,0 +1,221 @@
+//! Gitea/Forgejo hosting service implementation.
+//!
+//! Uses the Gitea REST API v1 directly via `reqwest` rather than depending on
+//! an external CLI binary.
+
+pub mod api;
+
+use std::{path::Path, time::Duration};
+
+use async_trait::async_trait;
+use backon::{ExponentialBuilder, Retryable};
+use tracing::info;
+
+use api::{GiteaApiError, GiteaClient, GiteaRepoInfo};
+
+use crate::{
+    GitHostProvider,
+    types::{CreatePrRequest, GitHostError, ProviderKind, PullRequestDetail, UnifiedPrComment},
+};
+
+#[derive(Debug, Clone)]
+pub struct GiteaProvider {
+    client: GiteaClient,
+}
+
+impl GiteaProvider {
+    pub fn new(base_url: &str) -> Result<Self, GitHostError> {
+        let client = GiteaClient::new(base_url).map_err(GitHostError::from)?;
+        Ok(Self { client })
+    }
+
+    fn get_repo_info(&self, remote_url: &str) -> Result<GiteaRepoInfo, GitHostError> {
+        GiteaRepoInfo::from_remote_url(remote_url, &self.client.base_url)
+            .map_err(GitHostError::from)
+    }
+}
+
+impl From<GiteaApiError> for GitHostError {
+    fn from(error: GiteaApiError) -> Self {
+        match &error {
+            GiteaApiError::AuthFailed(msg) => GitHostError::AuthFailed(msg.clone()),
+            GiteaApiError::NoToken => GitHostError::AuthFailed(
+                "No Gitea token found — set the GITEA_TOKEN environment variable".to_string(),
+            ),
+            GiteaApiError::RequestFailed(msg) => {
+                let lower = msg.to_ascii_lowercase();
+                if lower.contains("403") || lower.contains("forbidden") {
+                    GitHostError::InsufficientPermissions(msg.clone())
+                } else if lower.contains("404") || lower.contains("not found") {
+                    GitHostError::RepoNotFoundOrNoAccess(msg.clone())
+                } else {
+                    GitHostError::PullRequest(msg.clone())
+                }
+            }
+            GiteaApiError::UnexpectedResponse(msg) => GitHostError::UnexpectedOutput(msg.clone()),
+            GiteaApiError::InvalidUrl(msg) => GitHostError::Repository(msg.clone()),
+        }
+    }
+}
+
+fn retry_policy() -> ExponentialBuilder {
+    ExponentialBuilder::default()
+        .with_min_delay(Duration::from_secs(1))
+        .with_max_delay(Duration::from_secs(30))
+        .with_max_times(3)
+        .with_jitter()
+}
+
+#[async_trait]
+impl GitHostProvider for GiteaProvider {
+    async fn create_pr(
+        &self,
+        _repo_path: &Path,
+        remote_url: &str,
+        request: &CreatePrRequest,
+    ) -> Result<PullRequestDetail, GitHostError> {
+        if let Some(head_url) = &request.head_repo_url
+            && head_url != remote_url
+        {
+            return Err(GitHostError::PullRequest(
+                "Cross-fork pull requests are not yet supported for Gitea".to_string(),
+            ));
+        }
+
+        let repo_info = self.get_repo_info(remote_url)?;
+
+        (|| async {
+            let result = self.client.create_pr(&repo_info, request).await?;
+            info!(
+                "Created Gitea PR #{} for branch {}",
+                result.number, request.head_branch
+            );
+            Ok(result)
+        })
+        .retry(&retry_policy())
+        .when(|e: &GitHostError| e.should_retry())
+        .notify(|err: &GitHostError, dur: Duration| {
+            tracing::warn!(
+                "Gitea API call failed, retrying after {:.2}s: {}",
+                dur.as_secs_f64(),
+                err
+            );
+        })
+        .await
+    }
+
+    async fn get_pr_status(&self, pr_url: &str) -> Result<PullRequestDetail, GitHostError> {
+        let (base_url, owner, repo, number) = api::parse_pr_url(pr_url).ok_or_else(|| {
+            GitHostError::PullRequest(format!("Could not parse Gitea PR URL: {pr_url}"))
+        })?;
+
+        let repo_info = GiteaRepoInfo {
+            base_url,
+            owner,
+            repo,
+        };
+
+        (|| async {
+            let pr = self.client.get_pr(&repo_info, number).await?;
+            Ok(pr)
+        })
+        .retry(&retry_policy())
+        .when(|e: &GitHostError| e.should_retry())
+        .notify(|err: &GitHostError, dur: Duration| {
+            tracing::warn!(
+                "Gitea API call failed, retrying after {:.2}s: {}",
+                dur.as_secs_f64(),
+                err
+            );
+        })
+        .await
+    }
+
+    async fn list_prs_for_branch(
+        &self,
+        _repo_path: &Path,
+        remote_url: &str,
+        branch_name: &str,
+    ) -> Result<Vec<PullRequestDetail>, GitHostError> {
+        let repo_info = self.get_repo_info(remote_url)?;
+
+        (|| async {
+            // Fetch open + closed PRs filtered by head branch
+            let mut all = self
+                .client
+                .list_prs(&repo_info, "open", Some(branch_name))
+                .await?;
+            let closed = self
+                .client
+                .list_prs(&repo_info, "closed", Some(branch_name))
+                .await?;
+            all.extend(closed);
+            Ok(all)
+        })
+        .retry(&retry_policy())
+        .when(|e: &GitHostError| e.should_retry())
+        .notify(|err: &GitHostError, dur: Duration| {
+            tracing::warn!(
+                "Gitea API call failed, retrying after {:.2}s: {}",
+                dur.as_secs_f64(),
+                err
+            );
+        })
+        .await
+    }
+
+    async fn get_pr_comments(
+        &self,
+        _repo_path: &Path,
+        remote_url: &str,
+        pr_number: i64,
+    ) -> Result<Vec<UnifiedPrComment>, GitHostError> {
+        let repo_info = self.get_repo_info(remote_url)?;
+
+        (|| async {
+            self.client
+                .get_pr_comments(&repo_info, pr_number)
+                .await
+                .map_err(GitHostError::from)
+        })
+        .retry(&retry_policy())
+        .when(|e: &GitHostError| e.should_retry())
+        .notify(|err: &GitHostError, dur: Duration| {
+            tracing::warn!(
+                "Gitea API call failed, retrying after {:.2}s: {}",
+                dur.as_secs_f64(),
+                err
+            );
+        })
+        .await
+    }
+
+    async fn list_open_prs(
+        &self,
+        _repo_path: &Path,
+        remote_url: &str,
+    ) -> Result<Vec<PullRequestDetail>, GitHostError> {
+        let repo_info = self.get_repo_info(remote_url)?;
+
+        (|| async {
+            self.client
+                .list_prs(&repo_info, "open", None)
+                .await
+                .map_err(GitHostError::from)
+        })
+        .retry(&retry_policy())
+        .when(|e: &GitHostError| e.should_retry())
+        .notify(|err: &GitHostError, dur: Duration| {
+            tracing::warn!(
+                "Gitea API call failed, retrying after {:.2}s: {}",
+                dur.as_secs_f64(),
+                err
+            );
+        })
+        .await
+    }
+
+    fn provider_kind(&self) -> ProviderKind {
+        ProviderKind::Gitea
+    }
+}

--- a/crates/git-host/src/lib.rs
+++ b/crates/git-host/src/lib.rs
@@ -2,6 +2,7 @@ mod detection;
 mod types;
 
 pub mod azure;
+pub mod gitea;
 pub mod github;
 
 use std::path::Path;
@@ -14,7 +15,7 @@ pub use types::{
     PullRequestDetail, ReviewCommentUser, UnifiedPrComment,
 };
 
-use self::{azure::AzureDevOpsProvider, github::GitHubProvider};
+use self::{azure::AzureDevOpsProvider, gitea::GiteaProvider, github::GitHubProvider};
 
 #[async_trait]
 #[enum_dispatch(GitHostService)]
@@ -55,6 +56,7 @@ pub trait GitHostProvider: Send + Sync {
 pub enum GitHostService {
     GitHub(GitHubProvider),
     AzureDevOps(AzureDevOpsProvider),
+    Gitea(GiteaProvider),
 }
 
 impl GitHostService {
@@ -62,6 +64,10 @@ impl GitHostService {
         match detect_provider_from_url(url) {
             ProviderKind::GitHub => Ok(Self::GitHub(GitHubProvider::new()?)),
             ProviderKind::AzureDevOps => Ok(Self::AzureDevOps(AzureDevOpsProvider::new()?)),
+            ProviderKind::Gitea => {
+                let base_url = detection::gitea_base_url(url);
+                Ok(Self::Gitea(GiteaProvider::new(&base_url)?))
+            }
             ProviderKind::Unknown => Err(GitHostError::UnsupportedProvider),
         }
     }

--- a/crates/git-host/src/types.rs
+++ b/crates/git-host/src/types.rs
@@ -9,6 +9,7 @@ use ts_rs::TS;
 pub enum ProviderKind {
     GitHub,
     AzureDevOps,
+    Gitea,
     Unknown,
 }
 
@@ -17,6 +18,7 @@ impl std::fmt::Display for ProviderKind {
         match self {
             ProviderKind::GitHub => write!(f, "GitHub"),
             ProviderKind::AzureDevOps => write!(f, "Azure DevOps"),
+            ProviderKind::Gitea => write!(f, "Gitea"),
             ProviderKind::Unknown => write!(f, "Unknown"),
         }
     }

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -113,6 +113,7 @@
         "pages": [
           "integrations/github-integration",
           "integrations/azure-repos-integration",
+          "integrations/gitea-integration",
           "integrations/vscode-extension",
           "integrations/mcp-server-configuration",
           "integrations/vibe-kanban-mcp-server"

--- a/docs/integrations/gitea-integration.mdx
+++ b/docs/integrations/gitea-integration.mdx
@@ -92,10 +92,6 @@ You do not need `GITEA_URL` if your instance hostname already contains `gitea.` 
 </Step>
 </Steps>
 
-### Alternative: `tea` CLI configuration
-
-If you have the [tea CLI](https://gitea.com/gitea/tea) installed and configured, Vibe Kanban can read the token from `~/.config/tea/config.yml` as a fallback. However, setting `GITEA_TOKEN` explicitly is recommended for reliability.
-
 ## Supported URL formats
 
 Vibe Kanban supports standard Gitea remote URLs:

--- a/docs/integrations/gitea-integration.mdx
+++ b/docs/integrations/gitea-integration.mdx
@@ -1,0 +1,158 @@
+---
+title: "Gitea & Forgejo Integration"
+description: "Connect to Gitea or Forgejo to create pull requests and manage your workflow directly from Vibe Kanban"
+---
+
+Vibe Kanban integrates with [Gitea](https://gitea.com/) and [Forgejo](https://forgejo.org/) to let you create pull requests directly from your task attempts. This includes any Gitea-compatible instance, such as [Codeberg](https://codeberg.org/). Unlike the GitHub and Azure integrations, this integration communicates directly with the Gitea REST API — no external CLI is required.
+
+## Setup
+
+<Steps>
+<Step title="Generate a personal access token">
+
+You need an API token so Vibe Kanban can authenticate with your Gitea instance.
+
+1. Sign in to your Gitea instance (e.g. `https://gitea.example.com`).
+2. Navigate to **Settings → Applications** (direct URL: `https://gitea.example.com/user/settings/applications`).
+3. Under **Manage Access Tokens**, enter a name for the token (e.g. `vibe-kanban`).
+4. Select the permissions the token needs:
+   - **repository**: `Read and Write` — required to create and list pull requests.
+   - **issue**: `Read` — required to fetch PR comments.
+5. Click **Generate Token**.
+6. Copy the token immediately — it will only be shown once.
+
+<Warning>
+Treat this token like a password. Do not commit it to version control or share it publicly.
+</Warning>
+
+</Step>
+<Step title="Set the GITEA_TOKEN environment variable">
+
+Vibe Kanban reads the token from the `GITEA_TOKEN` environment variable. Choose the method that suits your setup:
+
+<Tabs>
+<Tab title="macOS / Linux">
+
+Add the following to your shell profile (`~/.zshrc`, `~/.bashrc`, or equivalent):
+
+```bash
+export GITEA_TOKEN="your-token-here"
+```
+
+Then reload your shell:
+
+```bash
+source ~/.zshrc   # or source ~/.bashrc
+```
+
+</Tab>
+<Tab title="Windows (PowerShell)">
+
+Set the variable for the current user:
+
+```powershell
+[System.Environment]::SetEnvironmentVariable("GITEA_TOKEN", "your-token-here", "User")
+```
+
+Restart your terminal for the change to take effect.
+
+</Tab>
+<Tab title=".env file">
+
+If you run Vibe Kanban with a `.env` file, add:
+
+```bash .env
+GITEA_TOKEN=your-token-here
+```
+
+</Tab>
+</Tabs>
+
+<Check>
+Verify the variable is set by running `echo $GITEA_TOKEN` (or `$env:GITEA_TOKEN` on PowerShell). You should see your token value.
+</Check>
+
+</Step>
+<Step title="Set the GITEA_URL environment variable (self-hosted instances)">
+
+Vibe Kanban auto-detects well-known Gitea hostnames (domains containing `gitea.`, `forgejo.`, or `codeberg.org`). If your instance uses a custom domain (e.g. `git.company.com`), you also need to set `GITEA_URL` so Vibe Kanban can identify it as a Gitea instance:
+
+```bash
+export GITEA_URL="https://git.company.com"
+```
+
+<Tip>
+If your Gitea instance runs on a non-standard port, include the port in the URL: `https://git.company.com:3000`.
+</Tip>
+
+<Note>
+You do not need `GITEA_URL` if your instance hostname already contains `gitea.` or `forgejo.`, or if you use Codeberg.
+</Note>
+
+</Step>
+</Steps>
+
+### Alternative: `tea` CLI configuration
+
+If you have the [tea CLI](https://gitea.com/gitea/tea) installed and configured, Vibe Kanban can read the token from `~/.config/tea/config.yml` as a fallback. However, setting `GITEA_TOKEN` explicitly is recommended for reliability.
+
+## Supported URL formats
+
+Vibe Kanban supports standard Gitea remote URLs:
+
+- **HTTPS**: `https://gitea.example.com/owner/repo.git`
+- **SSH**: `git@gitea.example.com:owner/repo.git`
+
+Pull request URLs follow the Gitea convention:
+
+- `https://gitea.example.com/owner/repo/pulls/123`
+
+<Info>
+Forgejo is a Gitea fork with full API compatibility. All features described here work identically with Forgejo instances.
+</Info>
+
+## Creating a pull request
+
+Once the environment variables are set, you can create pull requests directly from a task:
+
+1. Open a task that has changes you want to merge.
+2. Click the **Create PR** button.
+3. A dialog will appear pre-filled with:
+   - **Title**: Derived from the task title.
+   - **Description**: Derived from the task description.
+   - **Base Branch**: The target branch for your changes (defaults to the repository's default branch or the one specified in the attempt).
+4. Click **Create** to open the PR on your Gitea instance.
+
+If the operation is successful, the task status will update, and a link to the new pull request will be available.
+
+## Troubleshooting
+
+<AccordionGroup>
+<Accordion title="Unsupported git hosting provider error">
+
+This means Vibe Kanban could not identify your remote URL as a Gitea instance. Make sure you have set `GITEA_URL` to your instance's base URL:
+
+```bash
+export GITEA_URL="https://git.company.com"
+```
+
+</Accordion>
+
+<Accordion title="Authentication failed error">
+
+- Verify your token is valid by testing it directly:
+  ```bash
+  curl -H "Authorization: token $GITEA_TOKEN" https://gitea.example.com/api/v1/user
+  ```
+  You should see your user profile JSON. If you get a `401` response, generate a new token.
+- Ensure the `GITEA_TOKEN` environment variable is set in the same shell session where Vibe Kanban is running.
+
+</Accordion>
+
+<Accordion title="Repository not found error">
+
+- Confirm the token has **repository Read and Write** permissions.
+- Verify the remote URL matches your Gitea instance by running `git remote -v` in your repository.
+
+</Accordion>
+</AccordionGroup>

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -418,7 +418,7 @@ export type CreateAndStartWorkspaceResponse = { workspace: Workspace, execution_
 
 export type UnifiedPrComment = { "comment_type": "general", id: string, author: string, author_association: string | null, body: string, created_at: string, url: string | null, } | { "comment_type": "review", id: bigint, author: string, author_association: string | null, body: string, created_at: string, url: string | null, path: string, line: bigint | null, side: string | null, diff_hunk: string | null, };
 
-export type ProviderKind = "git_hub" | "azure_dev_ops" | "unknown";
+export type ProviderKind = "git_hub" | "azure_dev_ops" | "gitea" | "unknown";
 
 export type PullRequestDetail = { number: bigint, url: string, status: MergeStatus, merged_at: string | null, merge_commit_sha: string | null, title: string, base_branch: string, head_branch: string, };
 


### PR DESCRIPTION
## Summary

Adds a new **Gitea/Forgejo provider** to the `git-host` crate, enabling pull request management for Gitea, Forgejo, and Codeberg instances directly from Vibe Kanban.

- Implements all `GitHostProvider` trait methods: create PR, get PR status, list PRs by branch, list open PRs, and get PR comments
- Uses the Gitea REST API v1 directly via `reqwest` — no external CLI binary needed (unlike the `gh`/`az` CLI approach used by GitHub/Azure providers)
- Authenticates via `GITEA_TOKEN` env var, with `tea` CLI config as fallback
- Supports self-hosted instances with custom domains via the `GITEA_URL` env var
- Auto-detects well-known hostnames (`gitea.*`, `forgejo.*`, `codeberg.org`) and the Gitea PR URL pattern (`/pulls/`)
- Includes Forgejo compatibility out of the box (same API)
- Adds documentation page with step-by-step setup instructions

## Architecture

The implementation follows the existing provider pattern:

- **`crates/git-host/src/gitea/api.rs`** — HTTP client wrapping the Gitea REST API v1 with `reqwest`. Handles token auth, response parsing, and error mapping.
- **`crates/git-host/src/gitea/mod.rs`** — `GiteaProvider` struct implementing the `GitHostProvider` trait with exponential backoff retry (matching GitHub/Azure providers).
- **`crates/git-host/src/detection.rs`** — URL-based provider detection extended with Gitea patterns (`GITEA_URL` env var, `/pulls/` path, well-known hostnames). Also adds `gitea_base_url()` helper to extract instance URL from remotes.
- **`crates/git-host/src/types.rs`** — `Gitea` variant added to `ProviderKind` enum.
- **`crates/git-host/src/lib.rs`** — `Gitea(GiteaProvider)` variant added to `GitHostService` enum_dispatch.

### Why direct API instead of a CLI?

The GitHub and Azure providers shell out to `gh` and `az` CLIs respectively, which manage their own authentication. For Gitea:
- The `tea` CLI has much lower adoption than `gh`/`az`
- Gitea instances are self-hosted with arbitrary domains, making browser OAuth impractical without per-instance app registration
- Direct API via `reqwest` (already a workspace dependency) is simpler and has zero external dependencies

## Files changed

| File | Change |
|---|---|
| `crates/git-host/src/gitea/api.rs` | **New** — Gitea REST API client (reqwest-based) |
| `crates/git-host/src/gitea/mod.rs` | **New** — `GiteaProvider` trait implementation |
| `crates/git-host/src/detection.rs` | Extended with Gitea URL detection + 11 new unit tests |
| `crates/git-host/src/lib.rs` | Added `gitea` module, enum variant, `from_url` match arm |
| `crates/git-host/src/types.rs` | Added `Gitea` to `ProviderKind` |
| `crates/git-host/Cargo.toml` | Added `reqwest` workspace dependency |
| `shared/types.ts` | Auto-generated — `"gitea"` added to `ProviderKind` |
| `docs/integrations/gitea-integration.mdx` | **New** — Setup tutorial with troubleshooting guide |
| `docs/docs.json` | Added nav entry for Gitea integration page |
| `Cargo.lock` | Updated for new dependency edge |

## Testing

### Unit tests (33 total, all pass)
- 8 new Gitea-specific tests covering URL parsing, PR URL parsing, repo info extraction, and PR status mapping (open/merged/closed)
- 3 new detection tests (well-known hostnames, Codeberg, `/pulls/` pattern)
- 3 new detection tests for PR URL patterns and `gitea_base_url()` helper
- All 19 existing GitHub/Azure tests continue to pass

### End-to-end validation
Manually tested against a live **Gitea 1.25.5** instance through the full VK server stack:

| Operation | Endpoint | Result |
|---|---|---|
| Create PR | `POST /workspaces/{id}/pull-requests` | PR created on Gitea |
| Get PR status | `GET /repos/pr-info?url=...` | Returns full PR detail |
| List open PRs | `GET /repos/{id}/prs` | Lists PRs from Gitea API |
| Get PR comments | `GET /workspaces/{id}/pull-requests/comments` | Returns unified comment list |
| List PRs by branch | Via `list_prs_for_branch` trait method | Returns open + closed PRs |

## Known limitations

- **Cross-fork PRs** are not supported for Gitea (same limitation as the Azure provider)
- **`create_workspace_from_pr`** currently hardcodes `GhCli` for PR checkout — this is a pre-existing issue that also affects Azure DevOps, and should be addressed in a separate PR
- **Server-side (remote) integration** (webhooks, OAuth, repo cloning) is not included — this is planned as future work

## Test plan

- [x] `cargo test -p git-host` — 33 tests pass
- [x] `cargo clippy -p git-host -p server` — zero warnings
- [x] `cargo fmt -p git-host -- --check` — formatted
- [x] `pnpm run generate-types:check` — TS types up to date
- [x] `cargo check -p git-host -p server` — compiles clean
- [x] End-to-end tested against live Gitea 1.25.5 instance
- [ ] Verify existing GitHub/Azure PR flows are unaffected (no changes to their code paths)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new networked `reqwest`-based provider that uses `GITEA_TOKEN` and new URL-detection logic, which could affect provider selection and introduces new auth/error-handling paths. Existing GitHub/Azure flows are mostly untouched but share the `GitHostService::from_url` dispatch that now includes Gitea.
> 
> **Overview**
> Adds **Gitea/Forgejo (incl. Codeberg) pull request support** to the `git-host` crate by introducing a new `GiteaProvider` backed by a `reqwest` REST API client (create PR, fetch PR status, list PRs, and aggregate PR comments).
> 
> Extends provider detection to recognize Gitea instances via `GITEA_URL` and well-known hostnames, plus a new `gitea_base_url()` helper to derive the correct instance base URL from remote/PR URLs (with added unit tests to avoid false positives). Updates shared types/docs to expose the new `ProviderKind::Gitea` and adds setup documentation for `GITEA_TOKEN`/`GITEA_URL`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37acb7f82506217fc9caff8972b1d42a51512cc6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->