### PR TITLE
fix: copy packages/remote-web in Dockerfile (pnpm workspace glob)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
 COPY packages/local-web/package.json packages/local-web/package.json
 COPY packages/ui/package.json packages/ui/package.json
 COPY packages/web-core/package.json packages/web-core/package.json
+COPY packages/remote-web/package.json packages/remote-web/package.json
 
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
     pnpm install --frozen-lockfile
@@ -28,6 +29,7 @@ COPY packages/local-web/ packages/local-web/
 COPY packages/public/ packages/public/
 COPY packages/ui/ packages/ui/
 COPY packages/web-core/ packages/web-core/
+COPY packages/remote-web/ packages/remote-web/
 COPY shared/ shared/
 
 RUN pnpm -C packages/local-web build


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk change limited to the Docker build context; main impact is build behavior (pnpm install/cache layers) rather than runtime logic.
> 
> **Overview**
> Fixes the frontend Docker build by copying `packages/remote-web/package.json` before `pnpm install`, and then copying the full `packages/remote-web/` directory into the image.
> 
> This ensures pnpm workspace globs/dependency resolution include `remote-web` and prevents Docker layer caching/install from failing due to a missing workspace package.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 285e1fe7dee04baead61952e59e10f69e874d737. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->