### PR TITLE
Pin npm publish workflow to Node 22.22.1 (Vibe Kanban)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,10 @@ permissions:
   id-token: write  # Required for OIDC trusted publishing
 
 env:
-  NODE_VERSION: 22
+  # Node 22.22.2 regresses `npm install -g npm@...` with
+  # `Cannot find module 'promise-retry'`. Pin a known-good patch until the
+  # upstream Node/npm regression is resolved.
+  NODE_VERSION: 22.22.1
   PNPM_VERSION: 10.13.1
 
 jobs:


### PR DESCRIPTION
## Summary
This PR updates the npm publish workflow to pin the publish job to Node `22.22.1` instead of the floating `22` release line.

## What changed
- Updated `.github/workflows/publish.yml` to set `NODE_VERSION: 22.22.1`
- Added an inline comment documenting the failure mode and why the patch version is pinned
- Preserved the rest of the publish flow, including the existing npm OIDC trusted publishing setup

## Why this was needed
The `Publish to npm` workflow failed while handling the existing `v0.1.42-20260410131124` release. The failure happened before publishing, during the `Upgrade npm for OIDC support` step.

The underlying issue is an upstream regression in Node `22.22.2`: `npm install -g npm@...` can fail with `Cannot find module 'promise-retry'`. Because the workflow used `NODE_VERSION: 22`, GitHub Actions picked up that broken patch release and the release could not be published to npm.

## Important implementation details
- The fix is intentionally narrow and only affects the publish workflow
- Pinning to `22.22.1` keeps the existing publish behavior intact while avoiding the broken Node patch release
- This allows the existing release artifact to be published via the workflow's manual `workflow_dispatch` path without rebuilding the pre-release asset
- The change can be reverted once the upstream Node/npm regression is resolved and the floating Node 22 line is safe again

This PR was written using [Vibe Kanban](https://vibekanban.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that just adjusts the Node patch version used during publishing; main impact is potential workflow behavior differences if the pinned version becomes unavailable.
> 
> **Overview**
> Pins the `publish.yml` GitHub Actions workflow to Node `22.22.1` (with an inline note) to work around a Node `22.22.2` regression that breaks `npm install -g npm@...` during the publish job.
> 
> Also fixes a minor workflow formatting issue by ensuring the file ends with a newline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 281525781e57fb6c1d2966cede594e4eec5d76fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->