### PR TITLE
fix(discovery): persist and prefer canonical backend URL

### DIFF
--- a/crates/mcp/src/bin/vibe_kanban_mcp.rs
+++ b/crates/mcp/src/bin/vibe_kanban_mcp.rs
@@ -2,7 +2,7 @@ use mcp::task_server::McpServer;
 use rmcp::{ServiceExt, transport::stdio};
 use tracing_subscriber::{EnvFilter, prelude::*};
 use utils::{
-    port_file::read_port_file,
+    port_file::{PortInfo, read_port_info},
     sentry::{self as sentry_utils, SentrySource, sentry_layer},
 };
 
@@ -98,7 +98,38 @@ where
 }
 
 async fn resolve_base_url(log_prefix: &str) -> anyhow::Result<String> {
-    if let Ok(url) = std::env::var("VIBE_BACKEND_URL") {
+    let backend_url = std::env::var("VIBE_BACKEND_URL").ok();
+    let host = std::env::var(HOST_ENV)
+        .or_else(|_| std::env::var("HOST"))
+        .unwrap_or_else(|_| "127.0.0.1".to_string());
+
+    let explicit_port =
+        match std::env::var(PORT_ENV)
+            .or_else(|_| std::env::var("BACKEND_PORT"))
+            .or_else(|_| std::env::var("PORT"))
+        {
+            Ok(port_str) => Some(port_str.parse::<u16>().map_err(|error| {
+                anyhow::anyhow!("Invalid port value '{}': {}", port_str, error)
+            })?),
+            Err(_) => None,
+        };
+
+    let port_info = match explicit_port {
+        Some(_) => None,
+        None => Some(read_port_info("vibe-kanban").await?),
+    };
+
+    resolve_base_url_from_sources(log_prefix, backend_url, host, explicit_port, port_info)
+}
+
+fn resolve_base_url_from_sources(
+    log_prefix: &str,
+    backend_url: Option<String>,
+    host: String,
+    explicit_port: Option<u16>,
+    port_info: Option<PortInfo>,
+) -> anyhow::Result<String> {
+    if let Some(url) = backend_url {
         tracing::info!(
             "[{}] Using backend URL from VIBE_BACKEND_URL: {}",
             log_prefix,
@@ -107,28 +138,29 @@ async fn resolve_base_url(log_prefix: &str) -> anyhow::Result<String> {
         return Ok(url);
     }
 
-    let host = std::env::var(HOST_ENV)
-        .or_else(|_| std::env::var("HOST"))
-        .unwrap_or_else(|_| "127.0.0.1".to_string());
+    if let Some(port) = explicit_port {
+        tracing::info!("[{}] Using port from environment: {}", log_prefix, port);
+        let url = format!("http://{}:{}", host, port);
+        tracing::info!("[{}] Using backend URL: {}", log_prefix, url);
+        return Ok(url);
+    }
 
-    let port = match std::env::var(PORT_ENV)
-        .or_else(|_| std::env::var("BACKEND_PORT"))
-        .or_else(|_| std::env::var("PORT"))
-    {
-        Ok(port_str) => {
-            tracing::info!("[{}] Using port from environment: {}", log_prefix, port_str);
-            port_str
-                .parse::<u16>()
-                .map_err(|error| anyhow::anyhow!("Invalid port value '{}': {}", port_str, error))?
-        }
-        Err(_) => {
-            let port = read_port_file("vibe-kanban").await?;
-            tracing::info!("[{}] Using port from port file: {}", log_prefix, port);
-            port
-        }
-    };
+    let port_info = port_info.ok_or_else(|| anyhow::anyhow!("Missing port file information"))?;
+    if let Some(url) = port_info.backend_url {
+        tracing::info!(
+            "[{}] Using canonical backend URL from port file: {}",
+            log_prefix,
+            url
+        );
+        return Ok(url);
+    }
 
-    let url = format!("http://{}:{}", host, port);
+    tracing::info!(
+        "[{}] Using port from port file: {}",
+        log_prefix,
+        port_info.main_port
+    );
+    let url = format!("http://{}:{}", host, port_info.main_port);
     tracing::info!("[{}] Using backend URL: {}", log_prefix, url);
     Ok(url)
 }
@@ -158,7 +190,10 @@ fn init_process_logging(log_prefix: &str, version: &str) {
 
 #[cfg(test)]
 mod tests {
-    use super::{LaunchConfig, McpLaunchMode, resolve_launch_config_from_iter};
+    use super::{
+        LaunchConfig, McpLaunchMode, resolve_base_url_from_sources, resolve_launch_config_from_iter,
+    };
+    use utils::port_file::PortInfo;
 
     #[test]
     fn orchestrator_mode_does_not_require_session_id() {
@@ -193,5 +228,64 @@ mod tests {
                 .to_string()
                 .contains("Unknown argument '--session-id'")
         );
+    }
+
+    #[test]
+    fn vibe_backend_url_has_highest_precedence() {
+        let url = resolve_base_url_from_sources(
+            "test",
+            Some("http://override:9999".to_string()),
+            "legacy-host".to_string(),
+            Some(7777),
+            None,
+        )
+        .expect("base url should resolve");
+
+        assert_eq!(url, "http://override:9999");
+    }
+
+    #[test]
+    fn explicit_env_host_and_port_beat_port_file_url() {
+        let url =
+            resolve_base_url_from_sources("test", None, "env-host".to_string(), Some(7777), None)
+                .expect("base url should resolve");
+
+        assert_eq!(url, "http://env-host:7777");
+    }
+
+    #[test]
+    fn canonical_backend_url_from_port_file_beats_legacy_reconstruction() {
+        let url = resolve_base_url_from_sources(
+            "test",
+            None,
+            "legacy-host".to_string(),
+            None,
+            Some(PortInfo {
+                main_port: 4567,
+                preview_proxy_port: Some(8901),
+                backend_url: Some("http://localhost:4567".to_string()),
+            }),
+        )
+        .expect("base url should resolve");
+
+        assert_eq!(url, "http://localhost:4567");
+    }
+
+    #[test]
+    fn legacy_port_file_still_reconstructs_from_host_and_port() {
+        let url = resolve_base_url_from_sources(
+            "test",
+            None,
+            "legacy-host".to_string(),
+            None,
+            Some(PortInfo {
+                main_port: 4567,
+                preview_proxy_port: Some(8901),
+                backend_url: None,
+            }),
+        )
+        .expect("base url should resolve");
+
+        assert_eq!(url, "http://legacy-host:4567");
     }
 }

--- a/crates/server/src/startup.rs
+++ b/crates/server/src/startup.rs
@@ -8,7 +8,7 @@ use deployment::{Deployment, DeploymentError};
 use services::services::container::ContainerService;
 use tokio_util::sync::CancellationToken;
 use tower_http::validate_request::ValidateRequestHeaderLayer;
-use utils::assets::asset_dir;
+use utils::{assets::asset_dir, port_file::write_port_file_with_proxy_and_backend_url};
 
 use crate::{
     DeploymentImpl, middleware::origin::validate_origin, routes, runtime::relay_registration,
@@ -116,6 +116,17 @@ pub async fn start_with_bind(
     let proxy_port = proxy_listener.local_addr()?.port();
 
     tracing::info!("Server on :{port}, Preview proxy on :{proxy_port}");
+
+    let backend_url = format!("http://localhost:{port}");
+    if let Err(error) = write_port_file_with_proxy_and_backend_url(
+        port,
+        Some(proxy_port),
+        Some(backend_url.clone()),
+    )
+    .await
+    {
+        tracing::warn!("Failed to write discovery port file for {backend_url}: {error}");
+    }
 
     Ok(ServerHandle {
         port,

--- a/crates/utils/src/port_file.rs
+++ b/crates/utils/src/port_file.rs
@@ -3,22 +3,33 @@ use std::{env, path::PathBuf};
 use serde::{Deserialize, Serialize};
 use tokio::fs;
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PortInfo {
     pub main_port: u16,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub preview_proxy_port: Option<u16>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub backend_url: Option<String>,
 }
 
 pub async fn write_port_file_with_proxy(
     main_port: u16,
     preview_proxy_port: Option<u16>,
 ) -> std::io::Result<PathBuf> {
+    write_port_file_with_proxy_and_backend_url(main_port, preview_proxy_port, None).await
+}
+
+pub async fn write_port_file_with_proxy_and_backend_url(
+    main_port: u16,
+    preview_proxy_port: Option<u16>,
+    backend_url: Option<String>,
+) -> std::io::Result<PathBuf> {
     let dir = env::temp_dir().join("vibe-kanban");
     let path = dir.join("vibe-kanban.port");
     let port_info = PortInfo {
         main_port,
         preview_proxy_port,
+        backend_url,
     };
     let content = serde_json::to_string(&port_info)
         .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
@@ -38,8 +49,11 @@ pub async fn read_port_info(app_name: &str) -> std::io::Result<PortInfo> {
     tracing::debug!("Reading port from {:?}", path);
 
     let content = fs::read_to_string(&path).await?;
+    parse_port_info(&content)
+}
 
-    if let Ok(port_info) = serde_json::from_str::<PortInfo>(&content) {
+fn parse_port_info(content: &str) -> std::io::Result<PortInfo> {
+    if let Ok(port_info) = serde_json::from_str::<PortInfo>(content) {
         return Ok(port_info);
     }
 
@@ -51,5 +65,55 @@ pub async fn read_port_info(app_name: &str) -> std::io::Result<PortInfo> {
     Ok(PortInfo {
         main_port: port,
         preview_proxy_port: None,
+        backend_url: None,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{PortInfo, parse_port_info};
+
+    #[test]
+    fn parses_legacy_raw_port_format() {
+        let info = parse_port_info("4567").expect("raw port should parse");
+
+        assert_eq!(
+            info,
+            PortInfo {
+                main_port: 4567,
+                preview_proxy_port: None,
+                backend_url: None,
+            }
+        );
+    }
+
+    #[test]
+    fn parses_legacy_json_without_backend_url() {
+        let info = parse_port_info(r#"{"main_port":4567,"preview_proxy_port":8901}"#)
+            .expect("legacy json should parse");
+
+        assert_eq!(
+            info,
+            PortInfo {
+                main_port: 4567,
+                preview_proxy_port: Some(8901),
+                backend_url: None,
+            }
+        );
+    }
+
+    #[test]
+    fn serializes_and_parses_backend_url_field() {
+        let port_info = PortInfo {
+            main_port: 4567,
+            preview_proxy_port: Some(8901),
+            backend_url: Some("http://localhost:4567".to_string()),
+        };
+
+        let serialized = serde_json::to_string(&port_info).expect("port info should serialize");
+        let reparsed = parse_port_info(&serialized).expect("serialized json should parse");
+
+        assert_eq!(reparsed, port_info);
+        assert!(serialized.contains(r#""backend_url":"http://localhost:4567""#));
+    }
 }


### PR DESCRIPTION
# fix(discovery): persist and prefer canonical backend URL

## What

- add an optional `backend_url` field to `PortInfo` and keep legacy raw-port / JSON discovery parsing intact
- write the canonical backend URL into `vibe-kanban.port` during server startup
- update MCP base URL resolution to prefer `VIBE_BACKEND_URL`, then explicit env host/port, then the discovered canonical backend URL before falling back to legacy host+port reconstruction
- add unit coverage for discovery parsing and base-URL precedence

## Why

Issue #3349 showed MCP could recover a stale or incomplete discovery record and rebuild `http://127.0.0.1:<port>` even when the healthy desktop backend was serving on `http://localhost:<port>` / `::1`.

Persisting the backend's canonical runtime URL lets MCP reuse the same endpoint the server actually bound, avoiding loopback-family mismatches while preserving existing overrides and legacy discovery compatibility.

## How

- extend `crates/utils/src/port_file.rs` with `PortInfo::backend_url`, a `read_port_info` helper, and compatibility tests for legacy formats
- write discovery metadata through `write_port_file_with_proxy_and_backend_url(...)` from `crates/server/src/startup.rs`
- refactor `resolve_base_url` in `crates/mcp/src/bin/vibe_kanban_mcp.rs` into source-precedence logic that prefers the canonical discovered URL when present

## Testing

- `cargo test -p utils --lib`
- `cargo test -p mcp --bin vibe-kanban-mcp`
- `cargo test -p server --lib --no-run`

## Related

- Closes #3349
- Adjacent: #2920, #3205, #3340, #3119, #3238

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes backend discovery/URL resolution between server and MCP; mistakes could break local connectivity if the port file or precedence logic is wrong, but scope is limited and covered by new unit tests.
> 
> **Overview**
> Persists a *canonical* `backend_url` alongside ports in the temp discovery file (`PortInfo`), while keeping backwards-compatible parsing for legacy raw-port and older JSON formats.
> 
> On server startup, writes this canonical URL into the discovery record, and updates MCP base-URL resolution to prefer `VIBE_BACKEND_URL`, then explicit env host/port, then the discovered canonical URL before falling back to reconstructing `http://<host>:<port>`. Adds unit tests covering discovery parsing and URL precedence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9e7babd5d1fb65d6efec07f3d3767ace7d4dd97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->