### PR TITLE
fix(opencode): keep delegated background task sessions alive past parent idle

### DIFF
--- a/crates/executors/src/executors/opencode/sdk.rs
+++ b/crates/executors/src/executors/opencode/sdk.rs
@@ -202,7 +202,9 @@ pub(super) enum ControlEvent {
 
 #[derive(Debug)]
 pub(super) struct SessionActivityState {
-    active_task_calls: HashSet<String>,
+    active_task_calls: HashMap<String, String>,
+    background_sessions: HashSet<String>,
+    idle_sessions: HashSet<String>,
     idle_while_tasks_active: bool,
     last_activity_at: tokio::time::Instant,
 }
@@ -210,7 +212,9 @@ pub(super) struct SessionActivityState {
 impl SessionActivityState {
     fn new() -> Self {
         Self {
-            active_task_calls: HashSet::new(),
+            active_task_calls: HashMap::new(),
+            background_sessions: HashSet::new(),
+            idle_sessions: HashSet::new(),
             idle_while_tasks_active: false,
             last_activity_at: tokio::time::Instant::now(),
         }
@@ -220,16 +224,40 @@ impl SessionActivityState {
         self.last_activity_at = tokio::time::Instant::now();
     }
 
-    fn note_idle(&mut self) {
-        self.last_activity_at = tokio::time::Instant::now();
-        self.idle_while_tasks_active = !self.active_task_calls.is_empty();
+    fn register_background_session(&mut self, session_id: &str) {
+        if session_id.is_empty() {
+            return;
+        }
+        self.mark_activity();
+        self.background_sessions.insert(session_id.to_string());
+        self.idle_sessions.remove(session_id);
     }
 
-    fn update_task_tool(&mut self, call_id: &str, state: &ToolStateUpdate) -> (bool, usize) {
+    fn note_idle(&mut self, session_id: &str, root_session_id: &str) {
         self.mark_activity();
+        self.idle_sessions.insert(session_id.to_string());
+        if session_id == root_session_id
+            && (self.active_task_count() > 0 || self.unfinished_background_session_count() > 0)
+        {
+            self.idle_while_tasks_active = true;
+        }
+    }
+
+    fn update_task_tool(
+        &mut self,
+        owner_session_id: &str,
+        call_id: &str,
+        state: &ToolStateUpdate,
+    ) -> (usize, usize) {
+        self.mark_activity();
+        if let Some(background_session_id) = extract_background_session_id(state) {
+            self.register_background_session(&background_session_id);
+        }
+
         match state {
             ToolStateUpdate::Pending { .. } | ToolStateUpdate::Running { .. } => {
-                self.active_task_calls.insert(call_id.to_string());
+                self.active_task_calls
+                    .insert(call_id.to_string(), owner_session_id.to_string());
             }
             ToolStateUpdate::Completed { .. } | ToolStateUpdate::Error { .. } => {
                 self.active_task_calls.remove(call_id);
@@ -238,13 +266,30 @@ impl SessionActivityState {
         }
 
         (
-            self.idle_while_tasks_active && self.active_task_calls.is_empty(),
-            self.active_task_calls.len(),
+            self.active_task_count(),
+            self.unfinished_background_session_count(),
         )
     }
 
     fn active_task_count(&self) -> usize {
         self.active_task_calls.len()
+    }
+
+    fn unfinished_background_session_count(&self) -> usize {
+        self.background_sessions
+            .iter()
+            .filter(|session_id| !self.idle_sessions.contains(*session_id))
+            .count()
+    }
+
+    fn is_tracked_session(&self, session_id: &str, root_session_id: &str) -> bool {
+        session_id == root_session_id || self.background_sessions.contains(session_id)
+    }
+
+    fn can_complete(&self, root_session_id: &str) -> bool {
+        self.idle_sessions.contains(root_session_id)
+            && self.active_task_count() == 0
+            && self.unfinished_background_session_count() == 0
     }
 
     fn should_delay_completion(&self) -> bool {
@@ -1414,7 +1459,7 @@ async fn process_event_stream(
             continue;
         };
 
-        if !event_matches_session(event_type, &data, ctx.session_id) {
+        if !event_matches_session(&ctx, event_type, &data).await {
             continue;
         }
 
@@ -1445,16 +1490,28 @@ async fn process_event_stream(
                     .and_then(Value::as_str)
                     && status.eq_ignore_ascii_case("idle")
                 {
-                    let (should_delay, active_task_count) = {
-                        let state = ctx.activity_state.lock().await;
-                        (state.should_delay_completion(), state.active_task_count())
+                    let event_session_id =
+                        extract_event_session_id(event_type, &data).unwrap_or(ctx.session_id);
+                    let (should_delay, active_task_count, unfinished_background_sessions, can_complete) = {
+                        let mut state = ctx.activity_state.lock().await;
+                        state.note_idle(event_session_id, ctx.session_id);
+                        (
+                            state.should_delay_completion(),
+                            state.active_task_count(),
+                            state.unfinished_background_session_count(),
+                            state.can_complete(ctx.session_id),
+                        )
                     };
-                    if should_delay {
-                        tracing::info!(
-                            session_id = ctx.session_id,
-                            active_task_count,
-                            "OpenCode session reported idle while task tool calls are still active; delaying completion"
-                        );
+                    if !can_complete {
+                        if should_delay || event_session_id != ctx.session_id {
+                            tracing::info!(
+                                session_id = ctx.session_id,
+                                event_session_id,
+                                active_task_count,
+                                unfinished_background_sessions,
+                                "OpenCode session reported idle but tracked task/subtask work is still active; delaying completion"
+                            );
+                        }
                         continue;
                     }
                     let _ = ctx.control_tx.send(ControlEvent::Idle);
@@ -1462,16 +1519,28 @@ async fn process_event_stream(
                 }
             }
             "session.idle" => {
-                let (should_delay, active_task_count) = {
-                    let state = ctx.activity_state.lock().await;
-                    (state.should_delay_completion(), state.active_task_count())
+                let event_session_id =
+                    extract_event_session_id(event_type, &data).unwrap_or(ctx.session_id);
+                let (should_delay, active_task_count, unfinished_background_sessions, can_complete) = {
+                    let mut state = ctx.activity_state.lock().await;
+                    state.note_idle(event_session_id, ctx.session_id);
+                    (
+                        state.should_delay_completion(),
+                        state.active_task_count(),
+                        state.unfinished_background_session_count(),
+                        state.can_complete(ctx.session_id),
+                    )
                 };
-                if should_delay {
-                    tracing::info!(
-                        session_id = ctx.session_id,
-                        active_task_count,
-                        "OpenCode session emitted session.idle while task tool calls are still active; delaying completion"
-                    );
+                if !can_complete {
+                    if should_delay || event_session_id != ctx.session_id {
+                        tracing::info!(
+                            session_id = ctx.session_id,
+                            event_session_id,
+                            active_task_count,
+                            unfinished_background_sessions,
+                            "OpenCode session emitted idle but tracked task/subtask work is still active; delaying completion"
+                        );
+                    }
                     continue;
                 }
                 let _ = ctx.control_tx.send(ControlEvent::Idle);
@@ -1781,6 +1850,7 @@ async fn update_session_activity_state(
     event_type: &str,
     data: &Value,
 ) -> bool {
+    let event_session_id = extract_event_session_id(event_type, data).unwrap_or(ctx.session_id);
     let mut state = ctx.activity_state.lock().await;
 
     match event_type {
@@ -1790,38 +1860,34 @@ async fn update_session_activity_state(
                 && let Part::Tool(tool) = event.part
                 && tool.tool.eq_ignore_ascii_case("task")
             {
-                let (emit_idle, active_task_count) = state.update_task_tool(&tool.call_id, &tool.state);
+                let background_session_id = extract_background_session_id(&tool.state);
+                let (active_task_count, unfinished_background_sessions) =
+                    state.update_task_tool(event_session_id, &tool.call_id, &tool.state);
+                let emit_idle =
+                    state.should_delay_completion() && state.can_complete(ctx.session_id);
                 tracing::info!(
                     session_id = ctx.session_id,
+                    event_session_id,
                     call_id = %tool.call_id,
                     tool_state = ?tool.state,
+                    ?background_session_id,
                     active_task_count,
+                    unfinished_background_sessions,
                     "OpenCode task tool state update"
                 );
                 return emit_idle;
             }
             state.mark_activity();
         }
-        "session.status" => {
-            if let Some(status) = data
-                .pointer("/properties/status/type")
-                .and_then(Value::as_str)
-                && status.eq_ignore_ascii_case("idle")
-            {
-                state.note_idle();
-            } else {
-                state.mark_activity();
-            }
-        }
-        "session.idle" => state.note_idle(),
+        "session.status" | "session.idle" => {}
         _ => state.mark_activity(),
     }
 
     false
 }
 
-fn event_matches_session(event_type: &str, event: &Value, session_id: &str) -> bool {
-    let extracted = match event_type {
+fn extract_event_session_id<'a>(event_type: &str, event: &'a Value) -> Option<&'a str> {
+    match event_type {
         "message.updated" => event
             .pointer("/properties/info/sessionID")
             .and_then(Value::as_str),
@@ -1848,9 +1914,59 @@ fn event_matches_session(event_type: &str, event: &Value, session_id: &str) -> b
                     .pointer("/properties/part/sessionID")
                     .and_then(Value::as_str)
             }),
-    };
+    }
+}
 
-    extracted == Some(session_id)
+async fn event_matches_session(
+    ctx: &EventStreamContext<'_>,
+    event_type: &str,
+    event: &Value,
+) -> bool {
+    let Some(extracted) = extract_event_session_id(event_type, event) else {
+        return false;
+    };
+    if extracted == ctx.session_id {
+        return true;
+    }
+    let state = ctx.activity_state.lock().await;
+    state.is_tracked_session(extracted, ctx.session_id)
+}
+
+fn extract_background_session_id(state: &ToolStateUpdate) -> Option<String> {
+    let metadata = state.input();
+    let extra_metadata = state.metadata();
+    let run_in_background = metadata
+        .and_then(|v| v.get("run_in_background").and_then(Value::as_bool))
+        .or_else(|| {
+            extra_metadata.and_then(|v| v.get("run_in_background").and_then(Value::as_bool))
+        })
+        .unwrap_or(false);
+    if run_in_background {
+        if let Some(session_id) = extra_metadata
+            .and_then(|v| v.get("sessionId").and_then(Value::as_str))
+            .or_else(|| metadata.and_then(|v| v.get("sessionId").and_then(Value::as_str)))
+        {
+            return Some(session_id.to_string());
+        }
+    }
+    if let Some(background_output) = state.output() {
+        if background_output.contains("Background task launched") {
+            if let Some(session_id) = background_output.lines().find_map(|line| {
+                line.trim()
+                    .strip_prefix("session_id: ")
+                    .map(|value| value.trim().to_string())
+            }) {
+                return Some(session_id);
+            }
+            if let Some(session_id) = extra_metadata
+                .and_then(|v| v.get("sessionId").and_then(Value::as_str))
+                .or_else(|| metadata.and_then(|v| v.get("sessionId").and_then(Value::as_str)))
+            {
+                return Some(session_id.to_string());
+            }
+        }
+    }
+    None
 }
 
 async fn handle_approval_error(

--- a/crates/executors/src/executors/opencode/sdk.rs
+++ b/crates/executors/src/executors/opencode/sdk.rs
@@ -225,7 +225,7 @@ impl SessionActivityState {
         self.idle_while_tasks_active = !self.active_task_calls.is_empty();
     }
 
-    fn update_task_tool(&mut self, call_id: &str, state: &ToolStateUpdate) -> bool {
+    fn update_task_tool(&mut self, call_id: &str, state: &ToolStateUpdate) -> (bool, usize) {
         self.mark_activity();
         match state {
             ToolStateUpdate::Pending { .. } | ToolStateUpdate::Running { .. } => {
@@ -237,7 +237,10 @@ impl SessionActivityState {
             ToolStateUpdate::Unknown => {}
         }
 
-        self.idle_while_tasks_active && self.active_task_calls.is_empty()
+        (
+            self.idle_while_tasks_active && self.active_task_calls.is_empty(),
+            self.active_task_calls.len(),
+        )
     }
 
     fn active_task_count(&self) -> usize {
@@ -1425,7 +1428,7 @@ async fn process_event_stream(
             .await;
 
         if emit_synthetic_idle {
-            tracing::debug!(
+            tracing::info!(
                 session_id = ctx.session_id,
                 "OpenCode session had active task tool calls when parent went idle; synthesizing idle after the last task completed"
             );
@@ -1442,13 +1445,14 @@ async fn process_event_stream(
                     .and_then(Value::as_str)
                     && status.eq_ignore_ascii_case("idle")
                 {
-                    let should_delay = {
+                    let (should_delay, active_task_count) = {
                         let state = ctx.activity_state.lock().await;
-                        state.should_delay_completion()
+                        (state.should_delay_completion(), state.active_task_count())
                     };
                     if should_delay {
-                        tracing::debug!(
+                        tracing::info!(
                             session_id = ctx.session_id,
+                            active_task_count,
                             "OpenCode session reported idle while task tool calls are still active; delaying completion"
                         );
                         continue;
@@ -1458,13 +1462,14 @@ async fn process_event_stream(
                 }
             }
             "session.idle" => {
-                let should_delay = {
+                let (should_delay, active_task_count) = {
                     let state = ctx.activity_state.lock().await;
-                    state.should_delay_completion()
+                    (state.should_delay_completion(), state.active_task_count())
                 };
                 if should_delay {
-                    tracing::debug!(
+                    tracing::info!(
                         session_id = ctx.session_id,
+                        active_task_count,
                         "OpenCode session emitted session.idle while task tool calls are still active; delaying completion"
                     );
                     continue;
@@ -1785,7 +1790,15 @@ async fn update_session_activity_state(
                 && let Part::Tool(tool) = event.part
                 && tool.tool.eq_ignore_ascii_case("task")
             {
-                return state.update_task_tool(&tool.call_id, &tool.state);
+                let (emit_idle, active_task_count) = state.update_task_tool(&tool.call_id, &tool.state);
+                tracing::info!(
+                    session_id = ctx.session_id,
+                    call_id = %tool.call_id,
+                    tool_state = ?tool.state,
+                    active_task_count,
+                    "OpenCode task tool state update"
+                );
+                return emit_idle;
             }
             state.mark_activity();
         }

--- a/crates/executors/src/executors/opencode/sdk.rs
+++ b/crates/executors/src/executors/opencode/sdk.rs
@@ -22,7 +22,10 @@ use workspace_utils::approvals::{ApprovalStatus, QuestionAnswer, QuestionStatus}
 
 use super::{
     slash_commands,
-    types::{OpencodeExecutorEvent, ProviderInfo, ProviderListResponse},
+    types::{
+        MessagePartUpdatedEvent, OpencodeExecutorEvent, Part, ProviderInfo,
+        ProviderListResponse, ToolStateUpdate,
+    },
 };
 use crate::{
     approvals::{ExecutorApprovalError, ExecutorApprovalService},
@@ -197,6 +200,61 @@ pub(super) enum ControlEvent {
     Disconnected,
 }
 
+#[derive(Debug)]
+pub(super) struct SessionActivityState {
+    active_task_calls: HashSet<String>,
+    idle_while_tasks_active: bool,
+    last_activity_at: tokio::time::Instant,
+}
+
+impl SessionActivityState {
+    fn new() -> Self {
+        Self {
+            active_task_calls: HashSet::new(),
+            idle_while_tasks_active: false,
+            last_activity_at: tokio::time::Instant::now(),
+        }
+    }
+
+    fn mark_activity(&mut self) {
+        self.last_activity_at = tokio::time::Instant::now();
+    }
+
+    fn note_idle(&mut self) {
+        self.last_activity_at = tokio::time::Instant::now();
+        self.idle_while_tasks_active = !self.active_task_calls.is_empty();
+    }
+
+    fn update_task_tool(&mut self, call_id: &str, state: &ToolStateUpdate) -> bool {
+        self.mark_activity();
+        match state {
+            ToolStateUpdate::Pending { .. } | ToolStateUpdate::Running { .. } => {
+                self.active_task_calls.insert(call_id.to_string());
+            }
+            ToolStateUpdate::Completed { .. } | ToolStateUpdate::Error { .. } => {
+                self.active_task_calls.remove(call_id);
+            }
+            ToolStateUpdate::Unknown => {}
+        }
+
+        self.idle_while_tasks_active && self.active_task_calls.is_empty()
+    }
+
+    fn active_task_count(&self) -> usize {
+        self.active_task_calls.len()
+    }
+
+    fn should_delay_completion(&self) -> bool {
+        self.idle_while_tasks_active
+    }
+}
+
+pub(super) type SharedSessionActivityState = Arc<AsyncMutex<SessionActivityState>>;
+
+pub(super) fn new_session_activity_state() -> SharedSessionActivityState {
+    Arc::new(AsyncMutex::new(SessionActivityState::new()))
+}
+
 #[derive(Clone)]
 pub(crate) struct PendingApprovals {
     inner: Arc<AsyncMutex<Vec<oneshot::Receiver<()>>>>,
@@ -292,6 +350,7 @@ async fn run_session_inner(
 
     let (control_tx, mut control_rx) = mpsc::unbounded_channel::<ControlEvent>();
     let pending_approvals = PendingApprovals::new();
+    let activity_state = new_session_activity_state();
 
     let event_resp = tokio::select! {
         _ = cancel.cancelled() => return Ok(()),
@@ -308,6 +367,7 @@ async fn run_session_inner(
             auto_approve: config.auto_approve,
             control_tx,
             pending_approvals: pending_approvals.clone(),
+            activity_state: activity_state.clone(),
             models_cache_key: config.models_cache_key.clone(),
             cancel: cancel.clone(),
         },
@@ -328,6 +388,7 @@ async fn run_session_inner(
         prompt_fut,
         &mut control_rx,
         &pending_approvals,
+        activity_state.clone(),
         cancel.clone(),
     )
     .await;
@@ -374,6 +435,7 @@ async fn run_session_inner(
             reminder_fut,
             &mut control_rx,
             &pending_approvals,
+            activity_state.clone(),
             cancel.clone(),
         )
         .await;
@@ -434,6 +496,7 @@ fn build_opencode_client(
 }
 
 const OPENCODE_PROMPT_TIMEOUT: Duration = Duration::from_hours(24 * 7);
+const OPENCODE_TASK_IDLE_QUIET_WINDOW: Duration = Duration::from_secs(5);
 
 fn append_session_error(session_error: &mut Option<String>, message: String) {
     match session_error {
@@ -449,6 +512,7 @@ pub(super) async fn run_request_with_control<F>(
     mut request_fut: F,
     control_rx: &mut mpsc::UnboundedReceiver<ControlEvent>,
     pending_approvals: &PendingApprovals,
+    activity_state: SharedSessionActivityState,
     cancel: CancellationToken,
 ) -> Result<(), ExecutorError>
 where
@@ -503,6 +567,50 @@ where
                     Some(ControlEvent::Disconnected) => return Ok(()),
                 }
             }
+        }
+    }
+
+    loop {
+        let (should_delay_completion, active_task_count, last_activity_at) = {
+            let state = activity_state.lock().await;
+            (
+                state.should_delay_completion(),
+                state.active_task_count(),
+                state.last_activity_at,
+            )
+        };
+
+        if !should_delay_completion {
+            break;
+        }
+
+        let elapsed = last_activity_at.elapsed();
+        if active_task_count == 0 && elapsed >= OPENCODE_TASK_IDLE_QUIET_WINDOW {
+            break;
+        }
+
+        let sleep_for = if active_task_count == 0 {
+            OPENCODE_TASK_IDLE_QUIET_WINDOW
+                .saturating_sub(elapsed)
+                .min(Duration::from_millis(250))
+        } else {
+            Duration::from_millis(250)
+        };
+
+        tokio::select! {
+            _ = cancel.cancelled() => return Ok(()),
+            event = control_rx.recv() => match event {
+                Some(ControlEvent::AuthRequired { message }) => return Err(ExecutorError::AuthRequired(message)),
+                Some(ControlEvent::SessionError { message }) => append_session_error(&mut session_error, message),
+                Some(ControlEvent::Disconnected) if !cancel.is_cancelled() => {
+                    return Err(ExecutorError::Io(io::Error::other(
+                        "OpenCode event stream disconnected while waiting for active task tool calls to finish",
+                    )));
+                }
+                Some(ControlEvent::Disconnected) => return Ok(()),
+                Some(ControlEvent::Idle) | None => {}
+            },
+            _ = tokio::time::sleep(sleep_for) => {}
         }
     }
 
@@ -1117,6 +1225,7 @@ pub(super) struct EventListenerConfig {
     pub auto_approve: bool,
     pub control_tx: mpsc::UnboundedSender<ControlEvent>,
     pub pending_approvals: PendingApprovals,
+    pub activity_state: SharedSessionActivityState,
     pub models_cache_key: String,
     pub cancel: CancellationToken,
 }
@@ -1135,6 +1244,7 @@ pub(super) async fn spawn_event_listener(
         auto_approve,
         control_tx,
         pending_approvals,
+        activity_state,
         models_cache_key,
         cancel,
     } = config;
@@ -1189,6 +1299,7 @@ pub(super) async fn spawn_event_listener(
                 auto_approve,
                 control_tx: &control_tx,
                 pending_approvals: &pending_approvals,
+                activity_state: &activity_state,
                 base_retry_delay: &mut base_retry_delay,
                 last_event_id: &mut last_event_id,
                 models_cache_key: &models_cache_key,
@@ -1246,6 +1357,7 @@ pub(super) struct EventStreamContext<'a> {
     auto_approve: bool,
     control_tx: &'a mpsc::UnboundedSender<ControlEvent>,
     pending_approvals: &'a PendingApprovals,
+    activity_state: &'a SharedSessionActivityState,
     base_retry_delay: &'a mut Duration,
     last_event_id: &'a mut Option<String>,
     /// Cache key for model context windows, derived from config that affects available models.
@@ -1303,12 +1415,22 @@ async fn process_event_stream(
             continue;
         }
 
+        let emit_synthetic_idle = update_session_activity_state(&ctx, event_type, &data).await;
+
         let _ = ctx
             .log_writer
             .log_event(&OpencodeExecutorEvent::SdkEvent {
                 event: data.clone(),
             })
             .await;
+
+        if emit_synthetic_idle {
+            tracing::debug!(
+                session_id = ctx.session_id,
+                "OpenCode session had active task tool calls when parent went idle; synthesizing idle after the last task completed"
+            );
+            let _ = ctx.control_tx.send(ControlEvent::Idle);
+        }
 
         match event_type {
             "message.updated" => {
@@ -1320,11 +1442,33 @@ async fn process_event_stream(
                     .and_then(Value::as_str)
                     && status.eq_ignore_ascii_case("idle")
                 {
+                    let should_delay = {
+                        let state = ctx.activity_state.lock().await;
+                        state.should_delay_completion()
+                    };
+                    if should_delay {
+                        tracing::debug!(
+                            session_id = ctx.session_id,
+                            "OpenCode session reported idle while task tool calls are still active; delaying completion"
+                        );
+                        continue;
+                    }
                     let _ = ctx.control_tx.send(ControlEvent::Idle);
                     return Ok(EventStreamOutcome::Idle);
                 }
             }
             "session.idle" => {
+                let should_delay = {
+                    let state = ctx.activity_state.lock().await;
+                    state.should_delay_completion()
+                };
+                if should_delay {
+                    tracing::debug!(
+                        session_id = ctx.session_id,
+                        "OpenCode session emitted session.idle while task tool calls are still active; delaying completion"
+                    );
+                    continue;
+                }
                 let _ = ctx.control_tx.send(ControlEvent::Idle);
                 return Ok(EventStreamOutcome::Idle);
             }
@@ -1625,6 +1769,42 @@ async fn process_event_stream(
     }
 
     Ok(EventStreamOutcome::Disconnected)
+}
+
+async fn update_session_activity_state(
+    ctx: &EventStreamContext<'_>,
+    event_type: &str,
+    data: &Value,
+) -> bool {
+    let mut state = ctx.activity_state.lock().await;
+
+    match event_type {
+        "message.part.updated" => {
+            if let Some(properties) = data.get("properties").cloned()
+                && let Ok(event) = serde_json::from_value::<MessagePartUpdatedEvent>(properties)
+                && let Part::Tool(tool) = event.part
+                && tool.tool.eq_ignore_ascii_case("task")
+            {
+                return state.update_task_tool(&tool.call_id, &tool.state);
+            }
+            state.mark_activity();
+        }
+        "session.status" => {
+            if let Some(status) = data
+                .pointer("/properties/status/type")
+                .and_then(Value::as_str)
+                && status.eq_ignore_ascii_case("idle")
+            {
+                state.note_idle();
+            } else {
+                state.mark_activity();
+            }
+        }
+        "session.idle" => state.note_idle(),
+        _ => state.mark_activity(),
+    }
+
+    false
 }
 
 fn event_matches_session(event_type: &str, event: &Value, session_id: &str) -> bool {

--- a/crates/executors/src/executors/opencode/slash_commands.rs
+++ b/crates/executors/src/executors/opencode/slash_commands.rs
@@ -450,6 +450,7 @@ pub(super) async fn execute(
 
     let (control_tx, mut control_rx) = mpsc::unbounded_channel::<ControlEvent>();
     let pending_approvals = sdk::PendingApprovals::new();
+    let activity_state = sdk::new_session_activity_state();
     let event_resp = tokio::select! {
         _ = cancel.cancelled() => return Ok(()),
         res = sdk::connect_event_stream(&client, &config.base_url, &config.directory, None) => res?,
@@ -465,6 +466,7 @@ pub(super) async fn execute(
             auto_approve: config.auto_approve,
             control_tx,
             pending_approvals: pending_approvals.clone(),
+            activity_state: activity_state.clone(),
             models_cache_key: config.models_cache_key.clone(),
             cancel: cancel.clone(),
         },
@@ -517,6 +519,7 @@ pub(super) async fn execute(
         request_fut,
         &mut control_rx,
         &pending_approvals,
+        activity_state.clone(),
         cancel.clone(),
     )
     .await;

--- a/crates/executors/src/executors/opencode/types.rs
+++ b/crates/executors/src/executors/opencode/types.rs
@@ -381,6 +381,35 @@ pub(super) enum ToolStateUpdate {
     Unknown,
 }
 
+
+impl ToolStateUpdate {
+    pub(super) fn input(&self) -> Option<&Value> {
+        match self {
+            Self::Pending { input }
+            | Self::Running { input, .. }
+            | Self::Completed { input, .. }
+            | Self::Error { input, .. } => input.as_ref(),
+            Self::Unknown => None,
+        }
+    }
+
+    pub(super) fn metadata(&self) -> Option<&Value> {
+        match self {
+            Self::Running { metadata, .. }
+            | Self::Completed { metadata, .. }
+            | Self::Error { metadata, .. } => metadata.as_ref(),
+            _ => None,
+        }
+    }
+
+    pub(super) fn output(&self) -> Option<&str> {
+        match self {
+            Self::Completed { output, .. } => output.as_deref(),
+            _ => None,
+        }
+    }
+}
+
 #[derive(Debug, Deserialize)]
 pub(super) struct SessionErrorEvent {
     #[serde(default)]


### PR DESCRIPTION
## Summary

This PR improves OpenCode completion tracking for delegated/background `Task` tool runs.

It addresses a class of failures where a parent execution can report `session.idle` (or complete its `Task` tool call) **before the actual delegated child work is finished**, which causes Vibe Kanban to stop tracking activity too early and finalize the task prematurely.

## Problem

In OpenCode orchestration flows (for example a parent agent delegating to subagents like `explore` / `oracle` with `run_in_background=true`):

- the parent session may become idle before child work is really finished
- a `Task` tool call can transition to `Completed` as soon as OpenCode launches a background task
- the `Task` tool output includes metadata such as `background_task_id` and child `session_id`
- Vibe Kanban previously treated the completed `Task` call / parent idle as terminal, so it stopped tracking the run too early
- this can cause missing or premature completion notifications and other end-of-task side effects

This is closely related to upstream task/subagent completion bugs such as:
- `BloopAI/vibe-kanban#2783`
- multiple OpenCode issues around `Task`/subagent/session-idle teardown races

## What changed

### 1. Track active OpenCode `Task` tool calls
The executor now tracks `Task` tool calls explicitly instead of assuming parent idle means all delegated work is done.

### 2. Delay completion when parent goes idle while `Task` work is still active
If the parent session emits `session.idle` while task tool calls are still active, completion is delayed instead of finalizing immediately.

### 3. Track background child sessions launched by `Task`
When a `Task` tool completes with a background launch payload (for example `Background task launched` plus child `session_id`), the executor now keeps tracking that child session.

Completion is allowed only when:
- the root session is idle
- there are no active `Task` tool calls
- there are no unfinished tracked background child sessions

### 4. Add tracing around idle gating decisions
Extra tracing was added so the executor logs:
- task tool state transitions
- active task counts
- tracked background child sessions
- cases where idle is intentionally delayed

## Why this helps

This makes OpenCode behavior much more robust for orchestrator-style prompts that delegate work to background subagents.

Instead of treating:
- `parent idle`
- or `Task completed`

as the same thing as:
- `all delegated work finished`

Vibe Kanban now keeps the parent execution alive until the delegated child session flow also reaches a terminal state.

## Testing / validation

Validated with manual reproduction against a self-hosted environment where a parent OpenCode agent launched background `explore` subtasks.

Observed before fix:
- parent task finalized too early
- task tool output only indicated `Background task launched`
- child `session_id` was present in metadata/output, but was not tracked

Observed after patching / instrumentation:
- task tool state transitions are logged
- background child `session_id`s are discovered from task tool payloads
- completion gating can now defer finalization until tracked child sessions finish

## Notes

This PR intentionally focuses on a pragmatic fix for OpenCode background/delegated `Task` flows. It does **not** attempt to fully model every possible parent/child session relationship in OpenCode, but it substantially improves the concrete failure mode where delegated background subtasks outlive the parent session's first idle signal.
