### PR TITLE
fix: close What's New popup by calling modal.hide()

### DIFF
--- a/packages/web-core/src/shared/dialogs/global/ReleaseNotesDialog.tsx
+++ b/packages/web-core/src/shared/dialogs/global/ReleaseNotesDialog.tsx
@@ -41,7 +41,12 @@ const ReleaseNotesDialogImpl = create<NoProps>(() => {
   return (
     <Dialog
       open={modal.visible}
-      onOpenChange={(open) => !open && modal.resolve()}
+      onOpenChange={(open) => {
+        if (!open) {
+          modal.resolve();
+          modal.hide();
+        }
+      }}
       className="h-[calc(100%-4rem)]"
     >
       <DialogContent className="flex flex-col w-full h-full max-w-2xl max-h-[calc(100dvh-4rem)] p-0">


### PR DESCRIPTION
Fixes #3348. Fixed the What's New popup not being closeable — the `onOpenChange` handler called `modal.resolve()` but never `modal.hide()`, so the dialog promise resolved but the modal stayed visible. Every other dialog in the codebase calls both.

I maintain [PRISM](https://github.com/jakeefr/prism), a post-session diagnostics tool for Claude Code — CLAUDE.md adherence analysis and session health scoring. Vibe-kanban users running multi-agent workflows are exactly the audience who'd benefit from session health diagnostics.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI behavior change limited to the Release Notes dialog close handler; it now hides the modal in addition to resolving its promise.
> 
> **Overview**
> Fixes the "Whats New" / release notes dialog so closing it actually dismisses the modal: `onOpenChange` now calls both `modal.resolve()` and `modal.hide()` when the dialog is closed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1dc304a7d941bcb8b47fb2f1d02416e39702f56a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->