### PR TITLE
[codex] Fix workspace chat scroll jumps

### DIFF
--- a/packages/web-core/src/features/workspace-chat/ui/usePinConversationToBottomOnChatBoxResize.ts
+++ b/packages/web-core/src/features/workspace-chat/ui/usePinConversationToBottomOnChatBoxResize.ts
@@ -1,0 +1,63 @@
+import { useEffect, useRef, type RefObject } from 'react';
+
+import type { ConversationListHandle } from './ConversationListContainer';
+
+interface UsePinConversationToBottomOnChatBoxResizeOptions {
+  containerRef: RefObject<HTMLElement | null>;
+  conversationListRef: RefObject<ConversationListHandle | null>;
+  isAtBottom: boolean;
+  scopeKey: string;
+}
+
+/**
+ * Keeps the conversation visually pinned to the latest messages when the chat
+ * composer area changes height. Without this, composer/tooling growth shrinks
+ * the viewport from below and appears to "jump" the conversation upward.
+ */
+export function usePinConversationToBottomOnChatBoxResize({
+  containerRef,
+  conversationListRef,
+  isAtBottom,
+  scopeKey,
+}: UsePinConversationToBottomOnChatBoxResizeOptions) {
+  const isAtBottomRef = useRef(isAtBottom);
+
+  useEffect(() => {
+    isAtBottomRef.current = isAtBottom;
+  }, [isAtBottom]);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container || typeof ResizeObserver === 'undefined') return;
+
+    const chatBoxContainer = container.querySelector<HTMLElement>(
+      '[data-chatbox-container="true"]'
+    );
+    if (!chatBoxContainer) return;
+
+    let previousHeight = chatBoxContainer.getBoundingClientRect().height;
+
+    const observer = new ResizeObserver((entries) => {
+      const nextHeight =
+        entries[0]?.contentRect.height ??
+        chatBoxContainer.getBoundingClientRect().height;
+
+      if (Math.abs(nextHeight - previousHeight) < 0.5) return;
+      const heightDelta = nextHeight - previousHeight;
+      previousHeight = nextHeight;
+
+      if (!isAtBottomRef.current) return;
+
+      requestAnimationFrame(() => {
+        if (!isAtBottomRef.current) return;
+        conversationListRef.current?.adjustScrollBy(heightDelta);
+      });
+    });
+
+    observer.observe(chatBoxContainer);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [containerRef, conversationListRef, scopeKey]);
+}

--- a/packages/web-core/src/pages/kanban/ProjectRightSidebarContainer.tsx
+++ b/packages/web-core/src/pages/kanban/ProjectRightSidebarContainer.tsx
@@ -25,6 +25,7 @@ import {
   ConversationList,
   type ConversationListHandle,
 } from '@/features/workspace-chat/ui/ConversationListContainer';
+import { usePinConversationToBottomOnChatBoxResize } from '@/features/workspace-chat/ui/usePinConversationToBottomOnChatBoxResize';
 import { RetryUiProvider } from '@/features/workspace-chat/model/contexts/RetryUiContext';
 import { createWorkspaceWithSession } from '@/shared/types/attempt';
 import { useAppNavigation } from '@/shared/hooks/useAppNavigation';
@@ -144,6 +145,7 @@ function WorkspaceSessionPanel({
   const routeState = useCurrentKanbanRouteState();
   const { workspaces: remoteWorkspaces } = useUserContext();
   const { activeWorkspaces, archivedWorkspaces } = useWorkspaceContext();
+  const containerRef = useRef<HTMLDivElement>(null);
   const conversationListRef = useRef<ConversationListHandle>(null);
   const [isAtBottom, setIsAtBottom] = useState(true);
   const { data: workspace, isLoading: isWorkspaceLoading } = useWorkspaceRecord(
@@ -230,6 +232,13 @@ function WorkspaceSessionPanel({
     setIsAtBottom(atBottom);
   }, []);
 
+  usePinConversationToBottomOnChatBoxResize({
+    containerRef,
+    conversationListRef,
+    isAtBottom,
+    scopeKey: `${workspaceId}:${selectedSessionId ?? 'new'}`,
+  });
+
   return (
     <ExecutionProcessesProvider
       key={`${workspaceId}-${selectedSessionId ?? 'new'}`}
@@ -238,7 +247,10 @@ function WorkspaceSessionPanel({
       <ApprovalFeedbackProvider>
         <EntriesProvider key={`${workspaceId}-${selectedSessionId ?? 'new'}`}>
           <MessageEditProvider>
-            <div className="relative flex h-full flex-1 flex-col bg-primary">
+            <div
+              ref={containerRef}
+              className="relative flex h-full flex-1 flex-col bg-primary"
+            >
               <div className="flex items-center justify-between px-base py-half border-b shrink-0">
                 <div className="flex items-center gap-half min-w-0 font-ibm-plex-mono">
                   <button
@@ -314,7 +326,10 @@ function WorkspaceSessionPanel({
                 </div>
               )}
 
-              <div className="flex justify-center @container pl-px">
+              <div
+                className="flex justify-center @container pl-px"
+                data-chatbox-container="true"
+              >
                 <SessionChatBoxContainer
                   {...(isSessionsLoading || isWorkspaceLoading
                     ? {

--- a/packages/web-core/src/pages/workspaces/VSCodeWorkspacePage.tsx
+++ b/packages/web-core/src/pages/workspaces/VSCodeWorkspacePage.tsx
@@ -1,7 +1,7 @@
 // VS Code webview integration - install keyboard/clipboard bridge
 import '@/integrations/vscode/bridge';
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import type { Session } from 'shared/types';
 import { useTranslation } from 'react-i18next';
 import { AppWithStyleOverride } from '@/shared/lib/StyleOverride';
@@ -21,6 +21,7 @@ import { MessageEditProvider } from '@/features/workspace-chat/model/contexts/Me
 import { RetryUiProvider } from '@/features/workspace-chat/model/contexts/RetryUiContext';
 import { ApprovalFeedbackProvider } from '@/features/workspace-chat/model/contexts/ApprovalFeedbackContext';
 import { forwardWheelToScroller } from '@/features/workspace-chat/ui/forwardWheelToScroller';
+import { usePinConversationToBottomOnChatBoxResize } from '@/features/workspace-chat/ui/usePinConversationToBottomOnChatBoxResize';
 import { createWorkspaceWithSession } from '@/shared/types/attempt';
 
 function VSCodeChatBox({
@@ -86,7 +87,6 @@ export function VSCodeWorkspacePage() {
   const mainContainerRef = useRef<HTMLElement>(null);
   const conversationListRef = useRef<ConversationListHandle>(null);
   const [isAtBottom, setIsAtBottom] = useState(true);
-  const isAtBottomRef = useRef(isAtBottom);
 
   const {
     workspace,
@@ -126,48 +126,14 @@ export function VSCodeWorkspacePage() {
   );
 
   const handleAtBottomChange = useCallback((atBottom: boolean) => {
-    isAtBottomRef.current = atBottom;
     setIsAtBottom(atBottom);
   }, []);
-
-  useEffect(() => {
-    isAtBottomRef.current = isAtBottom;
-  }, [isAtBottom]);
-
-  useEffect(() => {
-    const container = mainContainerRef.current;
-    if (!container || typeof ResizeObserver === 'undefined') return;
-
-    const chatBoxContainer = container.querySelector<HTMLElement>(
-      '[data-chatbox-container="true"]'
-    );
-    if (!chatBoxContainer) return;
-
-    let previousHeight = chatBoxContainer.getBoundingClientRect().height;
-
-    const observer = new ResizeObserver((entries) => {
-      const nextHeight =
-        entries[0]?.contentRect.height ??
-        chatBoxContainer.getBoundingClientRect().height;
-
-      if (Math.abs(nextHeight - previousHeight) < 0.5) return;
-      const heightDelta = nextHeight - previousHeight;
-      previousHeight = nextHeight;
-
-      if (!isAtBottomRef.current) return;
-
-      requestAnimationFrame(() => {
-        if (!isAtBottomRef.current) return;
-        conversationListRef.current?.adjustScrollBy(heightDelta);
-      });
-    });
-
-    observer.observe(chatBoxContainer);
-
-    return () => {
-      observer.disconnect();
-    };
-  }, [workspaceWithSession?.id, selectedSession?.id]);
+  usePinConversationToBottomOnChatBoxResize({
+    containerRef: mainContainerRef,
+    conversationListRef,
+    isAtBottom,
+    scopeKey: `${workspaceWithSession?.id ?? 'none'}:${selectedSession?.id ?? 'new'}`,
+  });
 
   return (
     <AppWithStyleOverride setTheme={setTheme}>

--- a/packages/web-core/src/pages/workspaces/WorkspacesMainContainer.tsx
+++ b/packages/web-core/src/pages/workspaces/WorkspacesMainContainer.tsx
@@ -1,7 +1,6 @@
 import {
   forwardRef,
   useCallback,
-  useEffect,
   useImperativeHandle,
   useMemo,
   useRef,
@@ -15,6 +14,7 @@ import {
   type ConversationListHandle,
 } from '@/features/workspace-chat/ui/ConversationListContainer';
 import { SessionChatBoxContainer } from '@/features/workspace-chat/ui/SessionChatBoxContainer';
+import { usePinConversationToBottomOnChatBoxResize } from '@/features/workspace-chat/ui/usePinConversationToBottomOnChatBoxResize';
 import { ContextBarContainer } from './ContextBarContainer';
 import { EntriesProvider } from '@/features/workspace-chat/model/contexts/EntriesContext';
 import { MessageEditProvider } from '@/features/workspace-chat/model/contexts/MessageEditContext';
@@ -142,9 +142,7 @@ export const WorkspacesMainContainer = forwardRef<
   }, []);
 
   const [isAtBottom, setIsAtBottom] = useState(true);
-  const isAtBottomRef = useRef(isAtBottom);
   const handleAtBottomChange = useCallback((atBottom: boolean) => {
-    isAtBottomRef.current = atBottom;
     setIsAtBottom(atBottom);
   }, []);
 
@@ -157,44 +155,12 @@ export const WorkspacesMainContainer = forwardRef<
 
   const { session } = workspaceWithSession ?? {};
 
-  useEffect(() => {
-    isAtBottomRef.current = isAtBottom;
-  }, [isAtBottom]);
-
-  useEffect(() => {
-    const container = containerRef.current;
-    if (!container || typeof ResizeObserver === 'undefined') return;
-
-    const chatBoxContainer = container.querySelector<HTMLElement>(
-      '[data-chatbox-container="true"]'
-    );
-    if (!chatBoxContainer) return;
-
-    let previousHeight = chatBoxContainer.getBoundingClientRect().height;
-
-    const observer = new ResizeObserver((entries) => {
-      const nextHeight =
-        entries[0]?.contentRect.height ??
-        chatBoxContainer.getBoundingClientRect().height;
-
-      if (Math.abs(nextHeight - previousHeight) < 0.5) return;
-      const heightDelta = nextHeight - previousHeight;
-      previousHeight = nextHeight;
-
-      if (!isAtBottomRef.current) return;
-
-      requestAnimationFrame(() => {
-        if (!isAtBottomRef.current) return;
-        conversationListRef.current?.adjustScrollBy(heightDelta);
-      });
-    });
-
-    observer.observe(chatBoxContainer);
-
-    return () => {
-      observer.disconnect();
-    };
-  }, [workspaceWithSession?.id, session?.id]);
+  usePinConversationToBottomOnChatBoxResize({
+    containerRef,
+    conversationListRef,
+    isAtBottom,
+    scopeKey: `${workspaceWithSession?.id ?? 'none'}:${session?.id ?? 'new'}`,
+  });
 
   const entriesProviderKey = workspaceWithSession
     ? `${workspaceWithSession.id}-${selectedSessionId ?? 'new'}`


### PR DESCRIPTION
## What changed

This PR fixes workspace chat views unexpectedly jumping upward while new content arrives or the composer area changes size.

- adds a shared hook to keep the conversation pinned to the latest messages when the chat box height changes
- applies that behavior to the kanban flyout workspace chat
- reuses the same hook in the full workspace and VS Code views so the behavior stays consistent across shells

## Why

In the kanban flyout, the conversation could appear to randomly scroll backward even when the user had not intentionally scrolled up. That made it look like older problems or earlier messages had resurfaced.

## Root cause

The workspace chat list was already tracking whether the user was at the bottom, but the kanban flyout was missing the resize compensation that keeps the viewport visually anchored when the composer/tool area grows or shrinks. When the height changed, the visible conversation window effectively moved upward.

The full workspace and VS Code views had similar logic inline already, so this PR centralizes that logic into one hook and uses it everywhere the workspace chat stack is rendered.

## User impact

- chat stays anchored to the newest messages when you are already at the bottom
- intentional upward scrolling still works normally
- jump-to-point / jump-to-message actions still work normally
- kanban flyout and full-screen workspace chat behavior now match

## Validation

- `pnpm run web-core:check`
- `pnpm run local-web:check`
- `pnpm run web-core:format`
- `pnpm run local-web:format`
