### PR TITLE
fix(process): treat EPERM as terminal condition in kill_process_group

### DIFF
--- a/crates/utils/src/process.rs
+++ b/crates/utils/src/process.rs
@@ -13,11 +13,19 @@ pub async fn kill_process_group(child: &mut AsyncGroupChild) -> std::io::Result<
         for sig in [Signal::SIGINT, Signal::SIGTERM, Signal::SIGKILL] {
             tracing::info!("Sending {:?} to process group", sig);
             if let Err(e) = child.signal(sig) {
-                // break if the group does not exist anymore
-                if e.raw_os_error() == Some(nix::libc::ESRCH) {
-                    break;
+                match e.raw_os_error() {
+                    // ESRCH: group no longer exists — process already gone.
+                    Some(nix::libc::ESRCH) => break,
+                    // EPERM: pgid was recycled to an unrelated process after the
+                    // group leader exited. We must not signal a group we don't own.
+                    // SIGINT already fired; child.kill()+wait() below reaps the handle.
+                    Some(nix::libc::EPERM) => break,
+                    _ => tracing::warn!(
+                        "Failed to send signal {:?} to process group: {}",
+                        sig,
+                        e
+                    ),
                 }
-                tracing::warn!("Failed to send signal {:?} to process group: {}", sig, e);
             }
             if sig != Signal::SIGKILL {
                 tokio::time::sleep(Duration::from_secs(2)).await;


### PR DESCRIPTION
## Problem

When shutting down a process group, `kill_process_group` sends SIGINT → SIGTERM → SIGKILL in sequence. After SIGINT fires and the group leader exits, the kernel may **recycle the pgid** to an unrelated process. The subsequent `killpg(SIGTERM)` and `killpg(SIGKILL)` calls then return `EPERM` — the caller no longer owns that group.

The existing guard only breaks on `ESRCH` (group doesn't exist), so `EPERM` fell through to a warning and the loop continued attempting to signal a process group it should not touch.

**Observed in logs:**
```
INFO  utils::process: Sending SIGINT to process group
INFO  utils::process: Sending SIGTERM to process group
WARN  utils::process: Failed to send signal SIGTERM to process group: Operation not permitted (os error 1)
INFO  utils::process: Sending SIGKILL to process group
WARN  utils::process: Failed to send signal SIGKILL to process group: Operation not permitted (os error 1)
```

## Fix

Break on `EPERM` for the same reason as `ESRCH` — the shutdown is complete. SIGINT already landed. `child.kill().await` + `child.wait().await` at the end of the function reaps the handle unconditionally, so no zombie leak is introduced.

## Security note

Breaking on `EPERM` does **not** leave the child running silently. The unconditional `child.kill().await` + `child.wait().await` at lines 28–29 handles reaping regardless of which signal path succeeded. Continuing to signal a recycled pgid we don't own is the unsafe behavior — we could be sending SIGKILL to an unrelated process group.

## Changes

- `crates/utils/src/process.rs` — add `EPERM` to the break condition in the signal loop

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to process shutdown error handling on Unix. Main risk is altered behavior in rare permission-edge cases, but it reduces the chance of signaling unrelated processes.
> 
> **Overview**
> Improves Unix process-group shutdown in `kill_process_group` by treating `EPERM` from `child.signal()` as a terminal condition (like `ESRCH`), preventing repeated attempts to signal a potentially recycled/unauthorized pgid.
> 
> Also refines error handling to `match` on `raw_os_error()` and only warn on unexpected errors, while still unconditionally calling `child.kill().await` and `child.wait().await` to reap the handle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90076871fec82ed07c29f7f2ec533381396c3af1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->