### PR TITLE
chore: bump Claude Code to 2.1.112 and add xhigh effort variant (Vibe Kanban)

### DIFF
--- a/crates/executors/src/executors/claude.rs
+++ b/crates/executors/src/executors/claude.rs
@@ -62,7 +62,7 @@ fn base_command(claude_code_router: bool) -> &'static str {
     if claude_code_router {
         "npx -y @musistudio/claude-code-router@1.0.66 code"
     } else {
-        "npx -y @anthropic-ai/claude-code@2.1.62"
+        "npx -y @anthropic-ai/claude-code@2.1.112"
     }
 }
 
@@ -111,6 +111,7 @@ pub enum ClaudeEffort {
     Low,
     Medium,
     High,
+    XHigh,
     Max,
 }
 
@@ -269,7 +270,7 @@ fn default_discovered_options() -> crate::executor_discovery::ExecutorDiscovered
     };
 
     let effort_options =
-        ReasoningOption::from_names(["low", "medium", "high", "max"].map(String::from));
+        ReasoningOption::from_names(["low", "medium", "high", "xhigh", "max"].map(String::from));
 
     let supports_effort = |id: &str| -> bool { id.contains("opus") || id.contains("sonnet") };
 

--- a/crates/executors/src/executors/claude.rs
+++ b/crates/executors/src/executors/claude.rs
@@ -580,7 +580,12 @@ impl StandardCodingAgentExecutor for ClaudeCode {
         ExecutorConfig {
             executor: BaseCodingAgent::ClaudeCode,
             variant: None,
-            model_id: self.model.clone(),
+            model_id: self.model.clone().or_else(|| {
+                default_discovered_options()
+                    .model_selector
+                    .default_model
+                    .clone()
+            }),
             agent_id: None,
             reasoning_id: self.effort.as_ref().map(|e| e.as_ref().to_owned()),
             permission_policy: Some(permission_policy),

--- a/packages/web-core/src/shared/hooks/useExecutorConfig.ts
+++ b/packages/web-core/src/shared/hooks/useExecutorConfig.ts
@@ -122,7 +122,6 @@ function useEffectiveOverrides(
   userSelections: Partial<ExecutorConfig>,
   scratchConfig: ExecutorConfig | null | undefined,
   lastUsedConfig: ExecutorConfig | null,
-  variantWasUserSelected: boolean,
   presetOptions: ExecutorConfig | null | undefined
 ) {
   return useMemo((): ExecutorConfig | null => {
@@ -161,7 +160,7 @@ function useEffectiveOverrides(
             (lastUsedMatches && lastUsedModelMatches
               ? lastUsedConfig?.[field]
               : undefined) ??
-            (variantWasUserSelected ? presetOptions?.[field] : undefined));
+            presetOptions?.[field]);
       if (value !== undefined) {
         (resolved as Record<string, unknown>)[field] = value;
       }
@@ -175,7 +174,6 @@ function useEffectiveOverrides(
     scratchConfig,
     lastUsedConfig,
     presetOptions,
-    variantWasUserSelected,
   ]);
 }
 
@@ -239,7 +237,6 @@ export function useExecutorConfig({
     userSelections,
     scratchConfig,
     lastUsedConfig,
-    variant.wasUserSelected,
     presetOptions
   );
 

--- a/shared/schemas/claude_code.json
+++ b/shared/schemas/claude_code.json
@@ -44,6 +44,7 @@
         "low",
         "medium",
         "high",
+        "xhigh",
         "max",
         null
       ]

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -621,7 +621,7 @@ export type ExecutorConfigs = { executors: { [key in BaseCodingAgent]?: Executor
 
 export enum BaseAgentCapability { SESSION_FORK = "SESSION_FORK", SETUP_HELPER = "SETUP_HELPER", CONTEXT_USAGE = "CONTEXT_USAGE" }
 
-export type ClaudeEffort = "low" | "medium" | "high" | "max";
+export type ClaudeEffort = "low" | "medium" | "high" | "xhigh" | "max";
 
 export type ClaudeCode = { append_prompt: AppendPrompt, claude_code_router?: boolean | null, plan?: boolean | null, approvals?: boolean | null, model?: string | null, effort?: ClaudeEffort | null, agent?: string | null, dangerously_skip_permissions?: boolean | null, disable_api_key?: boolean | null, base_command_override?: string | null, additional_params?: Array<string> | null, env?: { [key in string]?: string } | null, };
 


### PR DESCRIPTION
`vibe-kanban/crates/executors/src/executors/claude.rs`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it updates the underlying `claude-code` CLI version and changes default/preset resolution behavior (new `xhigh` effort and model fallback), which can alter executor behavior without explicit user changes.
> 
> **Overview**
> Bumps the Claude Code executor’s underlying `@anthropic-ai/claude-code` CLI version to `2.1.112`.
> 
> Adds a new reasoning effort option `xhigh` end-to-end (Rust `ClaudeEffort`, discovered reasoning options, JSON schema, and generated TS types) so it can be selected and persisted like existing effort levels.
> 
> Tweaks config resolution defaults: `ClaudeCode::get_preset_options` now falls back to the discovered default model when no model is set, and the web `useExecutorConfig` override logic always considers `presetOptions` as the last fallback (removing the previous gating on whether the variant was user-selected).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c9b80a5211e9b873512c44e5c31efeff479091d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->