### PR TITLE
fix: vendor openssl to unblock musl + windows-msvc cross-compile (Vibe Kanban)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2806,6 +2806,7 @@ dependencies = [
  "json-patch 2.0.0",
  "jsonc-parser",
  "lru 0.12.5",
+ "openssl",
  "os_pipe",
  "rand 0.8.5",
  "regex",
@@ -6025,6 +6026,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "openssl-src"
+version = "300.5.5+3.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f1787d533e03597a7934fd0a765f0d28e94ecc5fb7789f8053b1e699a56f709"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6032,6 +6042,7 @@ checksum = "ad2f2c0eba47118757e4c6d2bff2838f3e0523380021356e7875e858372ce644"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/crates/executors/Cargo.toml
+++ b/crates/executors/Cargo.toml
@@ -41,6 +41,10 @@ codex-app-server-protocol = { git = "https://github.com/openai/codex.git", packa
 sha2 = "0.10"
 derivative = "2.2.0"
 reqwest = { workspace = true }
+# Forces openssl-sys (pulled in transitively by codex-protocol → reqwest →
+# hyper-tls → native-tls) to build from vendored C source. Required for
+# musl + windows-msvc cross-compile, which have no system OpenSSL.
+openssl = { version = "0.10", features = ["vendored"] }
 eventsource-stream = "0.2"
 walkdir = "2"
 rand = "0.8"


### PR DESCRIPTION
## What changed

Added `openssl = { version = "0.10", features = ["vendored"] }` to `crates/executors/Cargo.toml`, plus the resulting `Cargo.lock` update.

## Why

The pre-release workflow (run [#24560633908](https://github.com/BloopAI/vibe-kanban/actions/runs/24560633908)) started failing on all backend cross-compile targets after PR #3363 bumped `codex-protocol` and `codex-app-server-protocol` from `rust-v0.116.0` → `rust-v0.121.0`.

**Root cause:** `codex-protocol@0.121.0` depends on `reqwest` without `default-features = false`. Cargo unifies features across the dependency graph, so this silently enables reqwest's `default-tls` feature for the entire workspace — overriding our own `default-features = false` pin — and pulls in the chain:

```
codex-protocol → reqwest (default-tls) → hyper-tls → native-tls → openssl-sys
```

The musl Linux jobs (`x86_64-unknown-linux-musl`, `aarch64-unknown-linux-musl`) use `cargo zigbuild` with no system OpenSSL installed, so the `openssl-sys` build script aborts:

```
Could not find directory of OpenSSL installation … pkg-config has not
been configured to support cross-compilation.
```

The Windows `cargo xwin` jobs hit the same wall.

## Implementation detail

Enabling the `vendored` feature on the `openssl` crate propagates to `openssl-sys`, instructing it to compile OpenSSL from the bundled C source rather than searching for a system install. This resolves the cross-compile failure for every backend target (musl, windows-msvc, gnu, darwin) without reverting the Codex bump.

Trade-off: each backend CI job will take ~1–2 min longer due to the vendored OpenSSL compile step. For a release workflow that runs infrequently, this is acceptable.

---

*This PR was written using [Vibe Kanban](https://vibekanban.com)*