### PR TITLE
fix: scope vendored openssl to linux to unbreak windows-msvc cross-compile (Vibe Kanban)

### DIFF
--- a/crates/executors/Cargo.toml
+++ b/crates/executors/Cargo.toml
@@ -41,10 +41,6 @@ codex-app-server-protocol = { git = "https://github.com/openai/codex.git", packa
 sha2 = "0.10"
 derivative = "2.2.0"
 reqwest = { workspace = true }
-# Forces openssl-sys (pulled in transitively by codex-protocol → reqwest →
-# hyper-tls → native-tls) to build from vendored C source. Required for
-# musl + windows-msvc cross-compile, which have no system OpenSSL.
-openssl = { version = "0.10", features = ["vendored"] }
 eventsource-stream = "0.2"
 walkdir = "2"
 rand = "0.8"
@@ -55,6 +51,13 @@ async-stream = "0.3"
 
 [target.'cfg(windows)'.dependencies]
 winsplit = "0.1.0"
+
+# On Linux, codex-protocol → reqwest → hyper-tls → native-tls pulls in
+# openssl-sys. Vendor it so musl cross-compile (no system OpenSSL) builds.
+# macOS uses Security.framework and Windows uses schannel via native-tls,
+# so neither pulls in openssl-sys — keep this Linux-only.
+[target.'cfg(target_os = "linux")'.dependencies]
+openssl = { version = "0.10", features = ["vendored"] }
 
 [features]
 default = []


### PR DESCRIPTION
## What changed

Moved the `openssl = { version = "0.10", features = ["vendored"] }` dependency in `crates/executors/Cargo.toml` from `[dependencies]` (all targets) into a `[target.'cfg(target_os = "linux")'.dependencies]` block (Linux only).

## Why

The pre-release run at https://github.com/BloopAI/vibe-kanban/actions/runs/24564479064 showed all \`build-backend\` jobs failing after the previous fix (PR #3366) which vendored OpenSSL globally.

**Root cause of the regression:** The vendored OpenSSL build script invokes \`perl ./Configure VC-WIN64A\` for Windows MSVC targets. When cross-compiling from the Linux Ubuntu runner, only Linux-style Perl is available — and OpenSSL's configure script explicitly refuses Linux Perl when targeting Windows:

```
This perl implementation doesn't produce Windows like paths (with backward
slash directory separators). Please use an implementation that matches your
building platform.
This Perl version: 5.38.2 for x86_64-linux-gnu-thread-multi
```

**Why Linux-only vendoring is correct:** \`native-tls\` (pulled in transitively via \`codex-protocol → reqwest → hyper-tls → native-tls\`) only depends on \`openssl-sys\` on Linux. On macOS it uses Security.framework; on Windows it uses schannel. So vendoring OpenSSL on those platforms is unnecessary and actively harmful.

## Verified with cargo tree

| Target | openssl-sys present? |
|--------|---------------------|
| \`x86_64-unknown-linux-musl\` | ✅ vendored (needed for musl cross-compile) |
| \`x86_64-pc-windows-msvc\` | ❌ absent (uses schannel) |
| \`aarch64-apple-darwin\` | ❌ absent (uses Security.framework) |

---

*This PR was written using [Vibe Kanban](https://vibekanban.com)*