### PR TITLE
fix: stop kanban polling and scratch churn

### DIFF
--- a/packages/web-core/src/shared/hooks/useProjectRepoDefaults.ts
+++ b/packages/web-core/src/shared/hooks/useProjectRepoDefaults.ts
@@ -5,6 +5,14 @@ import {
   type ScratchPayload,
 } from 'shared/types';
 
+export interface ProjectStatusConfigData {
+  id: string;
+  name: string;
+  color: string;
+  hidden: boolean;
+  sort_order: number;
+}
+
 const SCRATCH_TYPE = ScratchType.PROJECT_REPO_DEFAULTS;
 
 /**

--- a/packages/web-core/src/shared/hooks/useUiPreferencesScratch.ts
+++ b/packages/web-core/src/shared/hooks/useUiPreferencesScratch.ts
@@ -192,6 +192,7 @@ export function useUiPreferencesScratch() {
   const hasInitializedRef = useRef(false);
   // Track whether we're currently applying server data to prevent save loops
   const isApplyingServerDataRef = useRef(false);
+  const lastSavedPayloadRef = useRef<string | null>(null);
 
   // Get current store state
   const storeState = useUiPreferencesStore((state) => ({
@@ -246,6 +247,11 @@ export function useUiPreferencesScratch() {
       kanbanProjectViewPreferences: currentState.kanbanProjectViewPreferences,
     });
 
+    const serialized = JSON.stringify(data);
+    if (serialized === lastSavedPayloadRef.current) {
+      return;
+    }
+
     try {
       await updateScratch({
         payload: {
@@ -253,6 +259,7 @@ export function useUiPreferencesScratch() {
           data,
         },
       });
+      lastSavedPayloadRef.current = serialized;
     } catch (e) {
       console.error('[useUiPreferencesScratch] Failed to save:', e);
     }
@@ -271,6 +278,7 @@ export function useUiPreferencesScratch() {
     if (scratchData) {
       // Server has data - apply it to store
       isApplyingServerDataRef.current = true;
+      lastSavedPayloadRef.current = JSON.stringify(scratchData);
       const serverState = scratchDataToStore(scratchData);
 
       // Merge server state into the store

--- a/packages/web-core/src/shared/hooks/useWorkspaces.ts
+++ b/packages/web-core/src/shared/hooks/useWorkspaces.ts
@@ -166,10 +166,10 @@ export function useWorkspaces(): UseWorkspacesResult {
       queryKey: workspaceSummaryKeys.byArchived(false, hostId),
       queryFn: () => fetchWorkspaceSummariesByArchived(false, hostId),
       enabled: activeIsInitialized,
-      staleTime: 1000,
-      refetchInterval: 15000,
+      staleTime: 60000,
+      refetchInterval: false,
       refetchOnWindowFocus: false,
-      refetchOnMount: 'always',
+      refetchOnMount: false,
       placeholderData: keepPreviousData,
     });
 
@@ -179,10 +179,10 @@ export function useWorkspaces(): UseWorkspacesResult {
       queryKey: workspaceSummaryKeys.byArchived(true, hostId),
       queryFn: () => fetchWorkspaceSummariesByArchived(true, hostId),
       enabled: archivedIsInitialized,
-      staleTime: 1000,
-      refetchInterval: 15000,
+      staleTime: 60000,
+      refetchInterval: false,
       refetchOnWindowFocus: false,
-      refetchOnMount: 'always',
+      refetchOnMount: false,
       placeholderData: keepPreviousData,
     });
 


### PR DESCRIPTION
Closes #3373

## Summary

This fixes a local-server stability regression where loading kanban boards and workspace views could drive the server into a runaway memory state and eventually hang the UI.

## Root cause

Two frontend behaviors were interacting badly with the local server:

1. `useWorkspaces()` was refetching workspace summaries too aggressively for both active and archived workspaces.
2. `useUiPreferencesScratch()` was writing `UI_PREFERENCES` scratch payloads even when the serialized payload had not changed.

Under board/workspace-heavy usage this produced repeated workspace-summary churn plus repeated no-op scratch writes, which in turn matched the observed slow-query / slow-upsert / memory-spiral behavior on the local server.

## Changes

- reduce workspace-summary refetching in `packages/web-core/src/shared/hooks/useWorkspaces.ts`
- dedupe no-op `UI_PREFERENCES` scratch writes in `packages/web-core/src/shared/hooks/useUiPreferencesScratch.ts`

## Verification

Verified on a live local install after rebuilding the frontend:

- repeated mixed kanban/workspace burst load: passed with `0` failures
- 2-minute mixed soak across board/workspace endpoints: `21,070` requests, `0` failures
- RSS stayed roughly in the `50–90 MB` range with `0` swap, instead of re-bloating into the 9–10 GB range seen before the fix
