### PR TITLE
feat(mcp): expose model_id, agent_id, reasoning_id on start_workspace

### DIFF
--- a/crates/mcp/src/task_server/tools/task_attempts.rs
+++ b/crates/mcp/src/task_server/tools/task_attempts.rs
@@ -34,6 +34,18 @@ struct StartWorkspaceRequest {
     executor: String,
     #[schemars(description = "Optional executor variant, if needed")]
     variant: Option<String>,
+    #[schemars(
+        description = "Optional model override (e.g. 'anthropic/claude-sonnet-4-20250514'). Forwarded to ExecutorConfig.model_id."
+    )]
+    model_id: Option<String>,
+    #[schemars(
+        description = "Optional agent mode override. Forwarded to ExecutorConfig.agent_id."
+    )]
+    agent_id: Option<String>,
+    #[schemars(
+        description = "Optional reasoning effort override (e.g. 'high', 'medium', 'low'). Forwarded to ExecutorConfig.reasoning_id."
+    )]
+    reasoning_id: Option<String>,
     #[schemars(description = "Repository selection for the workspace")]
     repositories: Vec<McpWorkspaceRepoInput>,
     #[schemars(
@@ -63,6 +75,15 @@ struct LinkWorkspaceIssueResponse {
     workspace_id: String,
     #[schemars(description = "The issue ID it was linked to")]
     issue_id: String,
+}
+
+fn trim_to_option(s: String) -> Option<String> {
+    let trimmed = s.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
 }
 
 fn build_workspace_prompt_from_issue(issue: &api_types::Issue) -> Option<String> {
@@ -99,6 +120,9 @@ impl McpServer {
             prompt,
             executor,
             variant,
+            model_id,
+            agent_id,
+            reasoning_id,
             repositories,
             issue_id,
         }): Parameters<StartWorkspaceRequest>,
@@ -183,9 +207,9 @@ impl McpServer {
             executor_config: ExecutorConfig {
                 executor: base_executor,
                 variant,
-                model_id: None,
-                agent_id: None,
-                reasoning_id: None,
+                model_id: model_id.and_then(trim_to_option),
+                agent_id: agent_id.and_then(trim_to_option),
+                reasoning_id: reasoning_id.and_then(trim_to_option),
                 permission_policy: None,
             },
             prompt: workspace_prompt,


### PR DESCRIPTION
## Summary

Add `model_id`, `agent_id`, and `reasoning_id` as optional string fields on the MCP `start_workspace` tool and forward them into `ExecutorConfig`. Non-breaking.

Fixes #3381.

## Problem

`crates/mcp/src/task_server/tools/task_attempts.rs` exposes only `executor` and `variant`, even though `ExecutorConfig` (`crates/executors/src/profile.rs`) has three more user-selectable override fields — `model_id`, `agent_id`, `reasoning_id` — plus `permission_policy`. The web UI and REST API reach those fields; MCP clients cannot.

Because the bundled `default_profiles.json` ships only the `DEFAULT` variant per executor, `variant` alone cannot distinguish between e.g. sonnet:medium vs sonnet:high from an MCP caller. That removes a whole axis of cost/quality control for orchestrators.

## Change

1. Add three optional schema-annotated fields to `StartWorkspaceRequest`: `model_id`, `agent_id`, `reasoning_id` — all `Option<String>`.
2. Destructure them in the handler and forward them into `ExecutorConfig`, trimming empty strings to `None` via a small `trim_to_option` helper.

## Scope notes

- `permission_policy` is intentionally left for a follow-up — it is an enum (`PermissionPolicy`) rather than a string, so threading it through the MCP schema needs a separate decision on deriving `JsonSchema` upstream in `crates/executors` vs mirroring it in the MCP crate.
- The secondary nit in #3381 (enumerating valid variant names in the schema description / adding a `list_executor_profiles` tool) is also out of scope here.

## Compatibility

Existing MCP callers that omit the new fields see identical behaviour — the three fields collapse to `None` on the wire, which matches the current hard-coded `None` values. Only callers that opt in get the new behaviour.

## Test plan

- [x] `cargo check -p mcp` on the branch — clean compile.
- [x] `cargo fmt -p mcp` — no formatting delta.

## Checklist

- [x] Rust compiles
- [x] Formatted
- [x] Non-breaking for existing MCP clients
- [x] Linked to tracking issue (#3381)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds optional parameters to the MCP `start_workspace` tool and forwards them into the existing `ExecutorConfig` without changing defaults for current callers.
> 
> **Overview**
> Adds optional `model_id`, `agent_id`, and `reasoning_id` fields to the MCP `start_workspace` request schema and threads them through the handler into `ExecutorConfig` when starting a workspace.
> 
> Empty/whitespace values are normalized to `None` via a small `trim_to_option` helper, preserving existing behavior when the new fields are omitted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e568c47b28af131998f9bb6ad005e47ee11b6b80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->