### PR TITLE
Bump Claude Code CLI pin to 2.1.119 (Vibe Kanban)

### DIFF
--- a/crates/executors/src/executors/claude.rs
+++ b/crates/executors/src/executors/claude.rs
@@ -62,7 +62,7 @@ fn base_command(claude_code_router: bool) -> &'static str {
     if claude_code_router {
         "npx -y @musistudio/claude-code-router@1.0.66 code"
     } else {
-        "npx -y @anthropic-ai/claude-code@2.1.112"
+        "npx -y @anthropic-ai/claude-code@2.1.119"
     }
 }
 


### PR DESCRIPTION
## Summary
- Update the Claude executor to use `@anthropic-ai/claude-code@2.1.119` instead of `2.1.112`.

## What Changed
- Updated the hardcoded non-router Claude base command in `crates/executors/src/executors/claude.rs`.
- Left the `claude-code-router` command unchanged.
- Kept executor behavior, flags, permissions, and model handling unchanged.

## Why
- This branch was created to bump the Claude executor in `claude.rs` to the latest Claude Code CLI version requested for the task.
- Updating the fixed version pin ensures new Claude runs launched through Vibe Kanban use `2.1.119` rather than the older `2.1.112` release.

## Implementation Details
- The change is isolated to `base_command(claude_code_router: bool)` in the Claude executor.
- Only the direct Anthropic CLI path was updated; the router path remains `npx -y @musistudio/claude-code-router@1.0.66 code`.
- Verification for this branch included `cargo test -p executors` and `pnpm run format`.

This PR was written using [Vibe Kanban](https://vibekanban.com)