### PR TITLE
Bump Codex to 0.124.0 and refresh the Codex executor surface (Vibe Kanban)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1257,13 +1257,12 @@ checksum = "e9b18233253483ce2f65329a24072ec414db782531bdbb7d0bbc4bd2ce6b7e21"
 
 [[package]]
 name = "codex-app-server-protocol"
-version = "0.121.0"
-source = "git+https://github.com/openai/codex.git?tag=rust-v0.121.0#d65ed92a5e440972626965d0af9a6345179783bc"
+version = "0.124.0"
+source = "git+https://github.com/openai/codex.git?tag=rust-v0.124.0#e9fb49366c93a1478ec71cc41ecee415a197d036"
 dependencies = [
  "anyhow",
  "clap",
  "codex-experimental-api-macros",
- "codex-git-utils",
  "codex-protocol",
  "codex-shell-command",
  "codex-utils-absolute-path",
@@ -1282,8 +1281,8 @@ dependencies = [
 
 [[package]]
 name = "codex-async-utils"
-version = "0.121.0"
-source = "git+https://github.com/openai/codex.git?tag=rust-v0.121.0#d65ed92a5e440972626965d0af9a6345179783bc"
+version = "0.124.0"
+source = "git+https://github.com/openai/codex.git?tag=rust-v0.124.0#e9fb49366c93a1478ec71cc41ecee415a197d036"
 dependencies = [
  "async-trait",
  "tokio",
@@ -1292,8 +1291,8 @@ dependencies = [
 
 [[package]]
 name = "codex-execpolicy"
-version = "0.121.0"
-source = "git+https://github.com/openai/codex.git?tag=rust-v0.121.0#d65ed92a5e440972626965d0af9a6345179783bc"
+version = "0.124.0"
+source = "git+https://github.com/openai/codex.git?tag=rust-v0.124.0#e9fb49366c93a1478ec71cc41ecee415a197d036"
 dependencies = [
  "anyhow",
  "clap",
@@ -1308,8 +1307,8 @@ dependencies = [
 
 [[package]]
 name = "codex-experimental-api-macros"
-version = "0.121.0"
-source = "git+https://github.com/openai/codex.git?tag=rust-v0.121.0#d65ed92a5e440972626965d0af9a6345179783bc"
+version = "0.124.0"
+source = "git+https://github.com/openai/codex.git?tag=rust-v0.124.0#e9fb49366c93a1478ec71cc41ecee415a197d036"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1317,27 +1316,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "codex-git-utils"
-version = "0.121.0"
-source = "git+https://github.com/openai/codex.git?tag=rust-v0.121.0#d65ed92a5e440972626965d0af9a6345179783bc"
-dependencies = [
- "codex-utils-absolute-path",
- "futures",
- "once_cell",
- "regex",
- "schemars 0.8.22",
- "serde",
- "tempfile",
- "thiserror 2.0.18",
- "tokio",
- "ts-rs 11.1.0",
- "walkdir",
-]
-
-[[package]]
 name = "codex-network-proxy"
-version = "0.121.0"
-source = "git+https://github.com/openai/codex.git?tag=rust-v0.121.0#d65ed92a5e440972626965d0af9a6345179783bc"
+version = "0.124.0"
+source = "git+https://github.com/openai/codex.git?tag=rust-v0.124.0#e9fb49366c93a1478ec71cc41ecee415a197d036"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1366,20 +1347,20 @@ dependencies = [
 
 [[package]]
 name = "codex-protocol"
-version = "0.121.0"
-source = "git+https://github.com/openai/codex.git?tag=rust-v0.121.0#d65ed92a5e440972626965d0af9a6345179783bc"
+version = "0.124.0"
+source = "git+https://github.com/openai/codex.git?tag=rust-v0.124.0#e9fb49366c93a1478ec71cc41ecee415a197d036"
 dependencies = [
  "chardetng",
  "chrono",
  "codex-async-utils",
  "codex-execpolicy",
- "codex-git-utils",
  "codex-network-proxy",
  "codex-utils-absolute-path",
  "codex-utils-image",
  "codex-utils-string",
  "codex-utils-template",
  "encoding_rs",
+ "globset",
  "icu_decimal",
  "icu_locale_core",
  "icu_provider",
@@ -1403,8 +1384,8 @@ dependencies = [
 
 [[package]]
 name = "codex-shell-command"
-version = "0.121.0"
-source = "git+https://github.com/openai/codex.git?tag=rust-v0.121.0#d65ed92a5e440972626965d0af9a6345179783bc"
+version = "0.124.0"
+source = "git+https://github.com/openai/codex.git?tag=rust-v0.124.0#e9fb49366c93a1478ec71cc41ecee415a197d036"
 dependencies = [
  "base64 0.22.1",
  "codex-protocol",
@@ -1422,8 +1403,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-absolute-path"
-version = "0.121.0"
-source = "git+https://github.com/openai/codex.git?tag=rust-v0.121.0#d65ed92a5e440972626965d0af9a6345179783bc"
+version = "0.124.0"
+source = "git+https://github.com/openai/codex.git?tag=rust-v0.124.0#e9fb49366c93a1478ec71cc41ecee415a197d036"
 dependencies = [
  "dirs 6.0.0",
  "dunce",
@@ -1434,8 +1415,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-cache"
-version = "0.121.0"
-source = "git+https://github.com/openai/codex.git?tag=rust-v0.121.0#d65ed92a5e440972626965d0af9a6345179783bc"
+version = "0.124.0"
+source = "git+https://github.com/openai/codex.git?tag=rust-v0.124.0#e9fb49366c93a1478ec71cc41ecee415a197d036"
 dependencies = [
  "lru 0.16.3",
  "sha1",
@@ -1444,8 +1425,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-home-dir"
-version = "0.121.0"
-source = "git+https://github.com/openai/codex.git?tag=rust-v0.121.0#d65ed92a5e440972626965d0af9a6345179783bc"
+version = "0.124.0"
+source = "git+https://github.com/openai/codex.git?tag=rust-v0.124.0#e9fb49366c93a1478ec71cc41ecee415a197d036"
 dependencies = [
  "codex-utils-absolute-path",
  "dirs 6.0.0",
@@ -1453,8 +1434,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-image"
-version = "0.121.0"
-source = "git+https://github.com/openai/codex.git?tag=rust-v0.121.0#d65ed92a5e440972626965d0af9a6345179783bc"
+version = "0.124.0"
+source = "git+https://github.com/openai/codex.git?tag=rust-v0.124.0#e9fb49366c93a1478ec71cc41ecee415a197d036"
 dependencies = [
  "base64 0.22.1",
  "codex-utils-cache",
@@ -1466,24 +1447,24 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-rustls-provider"
-version = "0.121.0"
-source = "git+https://github.com/openai/codex.git?tag=rust-v0.121.0#d65ed92a5e440972626965d0af9a6345179783bc"
+version = "0.124.0"
+source = "git+https://github.com/openai/codex.git?tag=rust-v0.124.0#e9fb49366c93a1478ec71cc41ecee415a197d036"
 dependencies = [
  "rustls",
 ]
 
 [[package]]
 name = "codex-utils-string"
-version = "0.121.0"
-source = "git+https://github.com/openai/codex.git?tag=rust-v0.121.0#d65ed92a5e440972626965d0af9a6345179783bc"
+version = "0.124.0"
+source = "git+https://github.com/openai/codex.git?tag=rust-v0.124.0#e9fb49366c93a1478ec71cc41ecee415a197d036"
 dependencies = [
  "regex-lite",
 ]
 
 [[package]]
 name = "codex-utils-template"
-version = "0.121.0"
-source = "git+https://github.com/openai/codex.git?tag=rust-v0.121.0#d65ed92a5e440972626965d0af9a6345179783bc"
+version = "0.124.0"
+source = "git+https://github.com/openai/codex.git?tag=rust-v0.124.0#e9fb49366c93a1478ec71cc41ecee415a197d036"
 
 [[package]]
 name = "color_quant"
@@ -1636,8 +1617,27 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
 dependencies = [
+ "percent-encoding",
  "time",
  "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
+dependencies = [
+ "cookie",
+ "document-features",
+ "idna",
+ "log",
+ "publicsuffix",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
 ]
 
 [[package]]
@@ -2414,6 +2414,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -4941,6 +4950,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
 name = "local-deployment"
 version = "0.1.43"
 dependencies = [
@@ -6786,6 +6801,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
 
 [[package]]
+name = "publicsuffix"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42ea446cab60335f76979ec15e12619a2165b5ae2c12166bef27d283a9fadf"
+dependencies = [
+ "idna",
+ "psl-types",
+]
+
+[[package]]
 name = "pxfm"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7646,6 +7671,8 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "cookie",
+ "cookie_store",
  "encoding_rs",
  "futures-channel",
  "futures-core",

--- a/crates/executors/Cargo.toml
+++ b/crates/executors/Cargo.toml
@@ -36,8 +36,8 @@ convert_case = "0.6"
 sqlx = "0.8.6"
 shlex = "1.3.0"
 agent-client-protocol = { version = "0.8", features = ["unstable"] }
-codex-protocol = { git = "https://github.com/openai/codex.git", package = "codex-protocol", tag = "rust-v0.121.0" }
-codex-app-server-protocol = { git = "https://github.com/openai/codex.git", package = "codex-app-server-protocol", tag = "rust-v0.121.0" }
+codex-protocol = { git = "https://github.com/openai/codex.git", package = "codex-protocol", tag = "rust-v0.124.0" }
+codex-app-server-protocol = { git = "https://github.com/openai/codex.git", package = "codex-app-server-protocol", tag = "rust-v0.124.0" }
 sha2 = "0.10"
 derivative = "2.2.0"
 reqwest = { workspace = true }

--- a/crates/executors/src/executors/codex.rs
+++ b/crates/executors/src/executors/codex.rs
@@ -328,6 +328,18 @@ impl StandardCodingAgentExecutor for Codex {
             model_selector: ModelSelectorConfig {
                 models: vec![
                     ModelInfo {
+                        id: "gpt-5.5".to_string(),
+                        name: "GPT-5.5".to_string(),
+                        provider_id: None,
+                        reasoning_options: xhigh_reasoning_options.clone(),
+                    },
+                    ModelInfo {
+                        id: "gpt-5.5-fast".to_string(),
+                        name: "GPT-5.5 Fast".to_string(),
+                        provider_id: None,
+                        reasoning_options: xhigh_reasoning_options.clone(),
+                    },
+                    ModelInfo {
                         id: "gpt-5.4".to_string(),
                         name: "GPT-5.4".to_string(),
                         provider_id: None,
@@ -340,26 +352,26 @@ impl StandardCodingAgentExecutor for Codex {
                         reasoning_options: xhigh_reasoning_options.clone(),
                     },
                     ModelInfo {
+                        id: "gpt-5.4-mini".to_string(),
+                        name: "GPT-5.4 Mini".to_string(),
+                        provider_id: None,
+                        reasoning_options: xhigh_reasoning_options.clone(),
+                    },
+                    ModelInfo {
                         id: "gpt-5.3-codex".to_string(),
                         name: "GPT-5.3 Codex".to_string(),
                         provider_id: None,
                         reasoning_options: xhigh_reasoning_options.clone(),
                     },
                     ModelInfo {
-                        id: "gpt-5.2-codex".to_string(),
-                        name: "GPT-5.2 Codex".to_string(),
+                        id: "gpt-5.3-codex-spark".to_string(),
+                        name: "GPT-5.3 Codex Spark".to_string(),
                         provider_id: None,
                         reasoning_options: xhigh_reasoning_options.clone(),
                     },
                     ModelInfo {
                         id: "gpt-5.2".to_string(),
                         name: "GPT-5.2".to_string(),
-                        provider_id: None,
-                        reasoning_options: xhigh_reasoning_options.clone(),
-                    },
-                    ModelInfo {
-                        id: "gpt-5.1-codex-max".to_string(),
-                        name: "GPT-5.1 Codex Max".to_string(),
                         provider_id: None,
                         reasoning_options: xhigh_reasoning_options,
                     },
@@ -393,6 +405,10 @@ impl StandardCodingAgentExecutor for Codex {
                 SlashCommandDescription {
                     name: "mcp".to_string(),
                     description: Some("list configured MCP tools".to_string()),
+                },
+                SlashCommandDescription {
+                    name: "model".to_string(),
+                    description: Some("view or switch the active model".to_string()),
                 },
                 SlashCommandDescription {
                     name: "fast".to_string(),
@@ -429,7 +445,7 @@ impl StandardCodingAgentExecutor for Codex {
 
 impl Codex {
     pub fn base_command() -> &'static str {
-        "npx -y @openai/codex@0.121.0"
+        "npx -y @openai/codex@0.124.0"
     }
 
     fn build_command_builder(&self) -> Result<CommandBuilder, CommandBuildError> {
@@ -742,5 +758,26 @@ impl Codex {
             exit_signal: Some(exit_signal_rx),
             cancel: Some(cancel),
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_model;
+
+    #[test]
+    fn resolve_model_detects_fast_suffix() {
+        assert_eq!(resolve_model(Some("gpt-5.5-fast")), (Some("gpt-5.5"), true));
+        assert_eq!(resolve_model(Some("gpt-5.4-fast")), (Some("gpt-5.4"), true));
+    }
+
+    #[test]
+    fn resolve_model_leaves_non_fast_models_unchanged() {
+        assert_eq!(resolve_model(Some("gpt-5.5")), (Some("gpt-5.5"), false));
+        assert_eq!(
+            resolve_model(Some("gpt-5.4-mini")),
+            (Some("gpt-5.4-mini"), false)
+        );
+        assert_eq!(resolve_model(None), (None, false));
     }
 }

--- a/crates/executors/src/executors/codex/normalize_logs.rs
+++ b/crates/executors/src/executors/codex/normalize_logs.rs
@@ -1120,10 +1120,11 @@ fn handle_direct_item_completed(
                             ),
                         });
                     } else {
+                        let content = result.content;
                         mcp_tool_state.result = Some(ToolResult {
                             r#type: ToolResultValueType::Json,
                             value: result.structured_content.unwrap_or_else(|| {
-                                serde_json::to_value(result.content).unwrap_or_default()
+                                serde_json::to_value(content).unwrap_or_default()
                             }),
                         });
                     }
@@ -1878,6 +1879,7 @@ pub fn normalize_logs(
                 EventMsg::McpToolCallBegin(McpToolCallBeginEvent {
                     call_id,
                     invocation,
+                    ..
                 }) => {
                     state.assistant = None;
                     state.thinking = None;
@@ -2421,7 +2423,10 @@ pub fn normalize_logs(
                 | EventMsg::RequestPermissions(..)
                 | EventMsg::HookCompleted(..)
                 | EventMsg::HookStarted(..)
-                | EventMsg::GuardianAssessment(..) => {}
+                | EventMsg::GuardianAssessment(..)
+                | EventMsg::GuardianWarning(..)
+                | EventMsg::ModelVerification(..)
+                | EventMsg::PatchApplyUpdated(..) => {}
             }
         }
     });

--- a/crates/executors/src/executors/codex/slash_commands.rs
+++ b/crates/executors/src/executors/codex/slash_commands.rs
@@ -30,7 +30,7 @@ pub enum CodexSlashCommand {
     Compact { instructions: Option<String> },
     Status,
     Mcp,
-    Fast { enable: Option<bool> },
+    Fast { enable: Option<bool>, status: bool },
 }
 
 impl CodexSlashCommand {
@@ -48,6 +48,7 @@ impl CodexSlashCommand {
             "status" => Some(Self::Status),
             "mcp" => Some(Self::Mcp),
             "fast" => Some(Self::Fast {
+                status: matches!(cmd.arguments.trim(), "status"),
                 enable: match cmd.arguments.trim() {
                     "on" | "true" | "1" | "yes" | "enable" => Some(true),
                     "off" | "false" | "0" | "no" | "disable" => Some(false),
@@ -183,7 +184,7 @@ impl Codex {
                             .send_exit_signal(ExecutorExitResult::Success)
                             .await;
                     }
-                    CodexSlashCommand::Fast { enable } => {
+                    CodexSlashCommand::Fast { enable, status } => {
                         // Read current config to support toggle
                         let current_is_fast = client
                             .config_read(None)
@@ -192,6 +193,18 @@ impl Codex {
                             .and_then(|r| r.config.service_tier)
                             .map(|t| matches!(t, ServiceTier::Fast))
                             .unwrap_or(false);
+                        if status {
+                            let message = if current_is_fast || session_fast {
+                                "**Fast mode is enabled.**".to_string()
+                            } else {
+                                "**Fast mode is disabled.**".to_string()
+                            };
+                            log_event_raw(client.log_writer(), message).await?;
+                            exit_signal_tx
+                                .send_exit_signal(ExecutorExitResult::Success)
+                                .await;
+                            return Ok(());
+                        }
                         let want_fast = match enable {
                             Some(v) => v,
                             None => !current_is_fast, // toggle
@@ -649,5 +662,50 @@ fn format_mcp_auth_status(status: &codex_app_server_protocol::McpAuthStatus) -> 
         codex_app_server_protocol::McpAuthStatus::NotLoggedIn => "not logged in",
         codex_app_server_protocol::McpAuthStatus::BearerToken => "bearer token",
         codex_app_server_protocol::McpAuthStatus::OAuth => "oauth",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CodexSlashCommand;
+
+    #[test]
+    fn parses_fast_enable_and_disable() {
+        assert!(matches!(
+            CodexSlashCommand::parse("/fast on"),
+            Some(CodexSlashCommand::Fast {
+                enable: Some(true),
+                status: false,
+            })
+        ));
+        assert!(matches!(
+            CodexSlashCommand::parse("/fast off"),
+            Some(CodexSlashCommand::Fast {
+                enable: Some(false),
+                status: false,
+            })
+        ));
+    }
+
+    #[test]
+    fn parses_fast_status() {
+        assert!(matches!(
+            CodexSlashCommand::parse("/fast status"),
+            Some(CodexSlashCommand::Fast {
+                enable: None,
+                status: true,
+            })
+        ));
+    }
+
+    #[test]
+    fn parses_fast_toggle_without_argument() {
+        assert!(matches!(
+            CodexSlashCommand::parse("/fast"),
+            Some(CodexSlashCommand::Fast {
+                enable: None,
+                status: false,
+            })
+        ));
     }
 }

--- a/docs/workspaces/slash-commands.mdx
+++ b/docs/workspaces/slash-commands.mdx
@@ -51,7 +51,7 @@ Any custom commands or skills you've installed will also appear in the typeahead
 
 ### OpenAI Codex
 
-Codex provides built-in commands. For full details, see the [Codex slash commands documentation](https://developers.openai.com/codex/cli/slash-commands/).
+Vibe Kanban surfaces a curated subset of Codex built-in commands. For the full upstream list, see the [Codex slash commands documentation](https://developers.openai.com/codex/cli/slash-commands/).
 
 | Command | Description |
 |---------|-------------|
@@ -59,6 +59,8 @@ Codex provides built-in commands. For full details, see the [Codex slash command
 | `/init` | Generate an AGENTS.md scaffold in the current directory |
 | `/status` | Display session configuration and token usage |
 | `/mcp` | List configured MCP tools |
+| `/model` | View or switch the active model |
+| `/fast` | Toggle or inspect fast mode |
 
 ### OpenCode
 


### PR DESCRIPTION
## Summary

This PR updates Vibe Kanban's Codex integration to the latest stable Codex release line and refreshes the in-app Codex metadata to match the current product surface more closely.

## What changed

- Bumped the pinned Codex Rust protocol dependencies from `rust-v0.121.0` to `rust-v0.124.0` in `crates/executors/Cargo.toml`.
- Updated the Codex CLI launch command from `@openai/codex@0.121.0` to `@openai/codex@0.124.0`.
- Refreshed `Cargo.lock` to pull in the new Codex dependency set and its transitive dependency changes.
- Updated the curated Codex model list surfaced by Vibe Kanban to include:
  - `gpt-5.5`
  - `gpt-5.5-fast`
  - `gpt-5.4`
  - `gpt-5.4-fast`
  - `gpt-5.4-mini`
  - `gpt-5.3-codex`
  - `gpt-5.3-codex-spark`
  - `gpt-5.2`
- Removed older surfaced Codex entries that were no longer part of the intended curated list.
- Added `/model` to the discovered Codex slash commands in Vibe Kanban.
- Extended `/fast` handling to support `/fast status` in addition to the existing toggle behavior.
- Added focused tests for fast-model normalization and slash-command parsing.
- Updated the Codex slash command docs to reflect that Vibe Kanban exposes a curated subset of upstream Codex commands.

## Why

The task for this branch was to bump Codex to the latest version used by the Vibe Kanban Codex executor. While doing that bump, the executor also needed to stay aligned with the current Codex model surface and fast-mode behavior, especially because GPT-5.5 and GPT-5.5 Fast are now relevant for Codex usage.

The protocol bump also introduced small compatibility gaps in the log normalizer, so those were fixed in the same change to keep the upgraded executor compiling and behaving correctly.

## Important implementation details

- The Codex executor still uses a curated model and slash-command surface rather than mirroring every upstream Codex capability.
- Fast mode remains service-tier driven; `gpt-5.5-fast` and `gpt-5.4-fast` both normalize to their base model plus fast tier behavior.
- `normalize_logs.rs` was updated to tolerate new Codex protocol event fields and variants added by the newer protocol release.
- Verification run for this branch included:
  - `cargo test -p executors codex --lib`
  - `pnpm run format`
  - `cargo check --workspace`

This PR was written using [Vibe Kanban](https://vibekanban.com)
