### PR TITLE
feat: add ghcr.io image pubslish

### DIFF
--- a/.github/workflows/ghcr-publish.yml
+++ b/.github/workflows/ghcr-publish.yml
@@ -1,0 +1,132 @@
+name: Publish Docker image to ghcr.io
+
+on:
+  push:
+    tags:
+      - 'v*'
+      - '!v*-*'
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Git ref (tag/branch/sha) to build from'
+        required: false
+        default: ''
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository_owner }}/vibe-kanban
+
+jobs:
+  build:
+    name: Build (${{ matrix.platform }})
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-24.04
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    steps:
+      - name: Prepare platform pair
+        id: prep
+        run: |
+          platform="${{ matrix.platform }}"
+          echo "pair=${platform//\//-}" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.ref || github.ref }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract image metadata (labels only)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ steps.prep.outputs.pair }}
+          cache-to: type=gha,mode=max,scope=${{ steps.prep.outputs.pair }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ steps.prep.outputs.pair }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    name: Create multi-arch manifest
+    runs-on: ubuntu-24.04
+    needs: build
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Download digest artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-') }}
+
+      - name: Create and push manifest
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}

--- a/.github/workflows/ghcr-publish.yml
+++ b/.github/workflows/ghcr-publish.yml
@@ -100,6 +100,12 @@ jobs:
           pattern: digests-*
           merge-multiple: true
 
+      - name: Download amd64 digest (for :latest)
+        uses: actions/download-artifact@v4
+        with:
+          name: digests-linux-amd64
+          path: /tmp/digests-amd64
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -110,23 +116,37 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract image metadata
+      - name: Extract image metadata (version tags, multi-arch)
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-') }}
 
-      - name: Create and push manifest
+      - name: Create and push multi-arch manifest (version tags)
         working-directory: /tmp/digests
         run: |
           docker buildx imagetools create \
-            $(jq -cr '.tags | map("-t " + .) | join(" ")' "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
 
-      - name: Inspect image
+      - name: Create and push :latest (amd64 only)
+        if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-')
+        working-directory: /tmp/digests-amd64
+        run: |
+          docker buildx imagetools create \
+            -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest \
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+      - name: Inspect version manifest
         run: |
           docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
+
+      - name: Inspect :latest
+        if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-')
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,11 @@ RUN corepack enable
 RUN pnpm config set store-dir /pnpm/store
 
 COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
+COPY patches/ patches/
 COPY packages/local-web/package.json packages/local-web/package.json
 COPY packages/ui/package.json packages/ui/package.json
 COPY packages/web-core/package.json packages/web-core/package.json
+COPY packages/remote-web/package.json packages/remote-web/package.json
 
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
     pnpm install --frozen-lockfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,54 +65,7 @@ COPY rust-toolchain.toml ./
 RUN cargo --version >/dev/null
 
 COPY Cargo.toml Cargo.lock ./
-COPY crates/api-types/Cargo.toml crates/api-types/Cargo.toml
-COPY crates/db/Cargo.toml crates/db/Cargo.toml
-COPY crates/deployment/Cargo.toml crates/deployment/Cargo.toml
-COPY crates/executors/Cargo.toml crates/executors/Cargo.toml
-COPY crates/git/Cargo.toml crates/git/Cargo.toml
-COPY crates/git-host/Cargo.toml crates/git-host/Cargo.toml
-COPY crates/local-deployment/Cargo.toml crates/local-deployment/Cargo.toml
-COPY crates/mcp/Cargo.toml crates/mcp/Cargo.toml
-COPY crates/relay-control/Cargo.toml crates/relay-control/Cargo.toml
-COPY crates/relay-hosts/Cargo.toml crates/relay-hosts/Cargo.toml
-COPY crates/relay-protocol/Cargo.toml crates/relay-protocol/Cargo.toml
-COPY crates/relay-tunnel-core/Cargo.toml crates/relay-tunnel-core/Cargo.toml
-COPY crates/relay-webrtc/Cargo.toml crates/relay-webrtc/Cargo.toml
-COPY crates/relay-ws/Cargo.toml crates/relay-ws/Cargo.toml
-COPY crates/review/Cargo.toml crates/review/Cargo.toml
-COPY crates/server/Cargo.toml crates/server/Cargo.toml
-COPY crates/server-info/Cargo.toml crates/server-info/Cargo.toml
-COPY crates/services/Cargo.toml crates/services/Cargo.toml
-COPY crates/tauri-app/Cargo.toml crates/tauri-app/Cargo.toml
-COPY crates/trusted-key-auth/Cargo.toml crates/trusted-key-auth/Cargo.toml
-COPY crates/utils/Cargo.toml crates/utils/Cargo.toml
-COPY crates/workspace-manager/Cargo.toml crates/workspace-manager/Cargo.toml
-COPY crates/worktree-manager/Cargo.toml crates/worktree-manager/Cargo.toml
-COPY crates/ws-bridge/Cargo.toml crates/ws-bridge/Cargo.toml
-
-COPY crates/api-types/ crates/api-types/
-COPY crates/db/ crates/db/
-COPY crates/deployment/ crates/deployment/
-COPY crates/executors/ crates/executors/
-COPY crates/git/ crates/git/
-COPY crates/git-host/ crates/git-host/
-COPY crates/local-deployment/ crates/local-deployment/
-COPY crates/mcp/ crates/mcp/
-COPY crates/relay-control/ crates/relay-control/
-COPY crates/relay-hosts/ crates/relay-hosts/
-COPY crates/relay-protocol/ crates/relay-protocol/
-COPY crates/relay-tunnel-core/ crates/relay-tunnel-core/
-COPY crates/relay-webrtc/ crates/relay-webrtc/
-COPY crates/relay-ws/ crates/relay-ws/
-COPY crates/review/ crates/review/
-COPY crates/server/ crates/server/
-COPY crates/server-info/ crates/server-info/
-COPY crates/services/ crates/services/
-COPY crates/trusted-key-auth/ crates/trusted-key-auth/
-COPY crates/utils/ crates/utils/
-COPY crates/workspace-manager/ crates/workspace-manager/
-COPY crates/worktree-manager/ crates/worktree-manager/
-COPY crates/ws-bridge/ crates/ws-bridge/
+COPY crates/ crates/
 COPY assets/ assets/
 COPY --from=fe-builder /app/packages/local-web/dist packages/local-web/dist
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new release pipeline that builds and publishes container images to `ghcr.io`, plus Docker build context changes that can impact build caching and artifact contents.
> 
> **Overview**
> Adds a new GitHub Actions workflow (`.github/workflows/ghcr-publish.yml`) that builds and pushes `vibe-kanban` Docker images to `ghcr.io` on `v*` release tags (and via manual dispatch), producing `linux/amd64` and `linux/arm64` images and then publishing a multi-arch manifest with semver tags.
> 
> The workflow also pushes `:latest` (amd64 only) for stable `v*` tags and uses digest artifacts + GHA cache scopes to merge per-arch builds.
> 
> Updates `Dockerfile` build inputs to include `patches/`, `packages/remote-web/package.json`, and copies `crates/` in one step (replacing many per-crate `COPY`s), which changes Docker layer invalidation and what gets included in the build context.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 999f392f5ae33e9e8027b4fcff14e9aeb76be552. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->