### PR TITLE
Sunset project routes to an export-only page (Vibe Kanban)

### DIFF
--- a/packages/web-core/src/pages/kanban/LocalProjectKanban.tsx
+++ b/packages/web-core/src/pages/kanban/LocalProjectKanban.tsx
@@ -1,30 +1,5 @@
-import { useEffect, useRef } from 'react';
-import { ProjectsGuideDialog } from '@vibe/ui/components/ProjectsGuideDialog';
-import { useAuth } from '@/shared/hooks/auth/useAuth';
-import { useUserSystem } from '@/shared/hooks/useUserSystem';
 import { ProjectKanban } from '@/pages/kanban/ProjectKanban';
 
-const PROJECTS_GUIDE_ID = 'projects-guide';
-
 export function LocalProjectKanban() {
-  const { config, updateAndSaveConfig, loading } = useUserSystem();
-  const { isLoaded, isSignedIn } = useAuth();
-  const hasAutoShownProjectsGuide = useRef(false);
-
-  useEffect(() => {
-    if (hasAutoShownProjectsGuide.current) return;
-    if (!isLoaded || !isSignedIn || loading || !config) return;
-
-    const seenFeatures = config.showcases?.seen_features ?? [];
-    if (seenFeatures.includes(PROJECTS_GUIDE_ID)) return;
-
-    hasAutoShownProjectsGuide.current = true;
-
-    void updateAndSaveConfig({
-      showcases: { seen_features: [...seenFeatures, PROJECTS_GUIDE_ID] },
-    });
-    ProjectsGuideDialog.show().finally(() => ProjectsGuideDialog.hide());
-  }, [config, isLoaded, isSignedIn, loading, updateAndSaveConfig]);
-
   return <ProjectKanban />;
 }

--- a/packages/web-core/src/pages/kanban/ProjectKanban.tsx
+++ b/packages/web-core/src/pages/kanban/ProjectKanban.tsx
@@ -1,215 +1,16 @@
-import { useEffect, useMemo, useRef, type ReactNode } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Group, Layout, Panel, Separator } from 'react-resizable-panels';
-import { OrgProvider } from '@/shared/providers/remote/OrgProvider';
-import { useOrgContext } from '@/shared/hooks/useOrgContext';
-import { ProjectProvider } from '@/shared/providers/remote/ProjectProvider';
-import { useProjectContext } from '@/shared/hooks/useProjectContext';
-import { useActions } from '@/shared/hooks/useActions';
-import { usePageTitle } from '@/shared/hooks/usePageTitle';
-import { KanbanContainer } from '@/features/kanban/ui/KanbanContainer';
-import { useIsMobile } from '@/shared/hooks/useIsMobile';
-import { ProjectRightSidebarContainer } from './ProjectRightSidebarContainer';
 import { LoginRequiredPrompt } from '@/shared/dialogs/shared/LoginRequiredPrompt';
-import {
-  PERSIST_KEYS,
-  usePaneSize,
-} from '@/shared/stores/useUiPreferencesStore';
 import { useUserOrganizations } from '@/shared/hooks/useUserOrganizations';
 import { useOrganizationProjects } from '@/shared/hooks/useOrganizationProjects';
 import { useOrganizationStore } from '@/shared/stores/useOrganizationStore';
 import { useAuth } from '@/shared/hooks/auth/useAuth';
-import { useAppNavigation } from '@/shared/hooks/useAppNavigation';
 import { useCurrentKanbanRouteState } from '@/shared/hooks/useCurrentKanbanRouteState';
 import {
   buildKanbanIssueComposerKey,
   closeKanbanIssueComposer,
 } from '@/shared/stores/useKanbanIssueComposerStore';
-/**
- * Component that registers project mutations with ActionsContext.
- * Must be rendered inside both ActionsProvider and ProjectProvider.
- */
-function ProjectMutationsRegistration({ children }: { children: ReactNode }) {
-  const { registerProjectMutations } = useActions();
-  const { removeIssue, insertIssue, getIssue, getAssigneesForIssue, issues } =
-    useProjectContext();
-
-  // Use ref to always access latest issues (avoid stale closure)
-  const issuesRef = useRef(issues);
-  useEffect(() => {
-    issuesRef.current = issues;
-  }, [issues]);
-
-  useEffect(() => {
-    registerProjectMutations({
-      removeIssue: (id) => {
-        removeIssue(id);
-      },
-      duplicateIssue: (issueId) => {
-        const issue = getIssue(issueId);
-        if (!issue) return;
-
-        // Use ref to get current issues (not stale closure)
-        const currentIssues = issuesRef.current;
-        const statusIssues = currentIssues.filter(
-          (i) => i.status_id === issue.status_id
-        );
-        const minSortOrder =
-          statusIssues.length > 0
-            ? Math.min(...statusIssues.map((i) => i.sort_order))
-            : 0;
-
-        insertIssue({
-          project_id: issue.project_id,
-          status_id: issue.status_id,
-          title: `${issue.title} (Copy)`,
-          description: issue.description,
-          priority: issue.priority,
-          sort_order: minSortOrder - 1,
-          start_date: issue.start_date,
-          target_date: issue.target_date,
-          completed_at: null,
-          parent_issue_id: issue.parent_issue_id,
-          parent_issue_sort_order: issue.parent_issue_sort_order,
-          extension_metadata: issue.extension_metadata,
-        });
-      },
-      getIssue,
-      getAssigneesForIssue,
-    });
-
-    return () => {
-      registerProjectMutations(null);
-    };
-  }, [
-    registerProjectMutations,
-    removeIssue,
-    insertIssue,
-    getIssue,
-    getAssigneesForIssue,
-  ]);
-
-  return <>{children}</>;
-}
-
-function ProjectKanbanBoard() {
-  return (
-    <div className="flex h-full min-h-0 w-full flex-col">
-      <div className="min-h-0 flex-1">
-        <KanbanContainer />
-      </div>
-    </div>
-  );
-}
-
-function ProjectKanbanLayout({ projectName }: { projectName: string }) {
-  const { issueId, isPanelOpen } = useCurrentKanbanRouteState();
-  const isMobile = useIsMobile();
-  const { getIssue } = useProjectContext();
-  const issue = issueId ? getIssue(issueId) : undefined;
-  usePageTitle(issue?.title, projectName);
-  const [kanbanLeftPanelSize, setKanbanLeftPanelSize] = usePaneSize(
-    PERSIST_KEYS.kanbanLeftPanel,
-    75
-  );
-
-  const isRightPanelOpen = isPanelOpen;
-
-  if (isMobile) {
-    return isRightPanelOpen ? (
-      <div className="h-full w-full overflow-hidden bg-secondary">
-        <ProjectRightSidebarContainer />
-      </div>
-    ) : (
-      <div className="h-full w-full overflow-hidden bg-primary">
-        <ProjectKanbanBoard />
-      </div>
-    );
-  }
-
-  const kanbanDefaultLayout: Layout =
-    typeof kanbanLeftPanelSize === 'number'
-      ? {
-          'kanban-left': kanbanLeftPanelSize,
-          'kanban-right': 100 - kanbanLeftPanelSize,
-        }
-      : { 'kanban-left': 75, 'kanban-right': 25 };
-
-  const onKanbanLayoutChange = (layout: Layout) => {
-    if (isRightPanelOpen) {
-      setKanbanLeftPanelSize(layout['kanban-left']);
-    }
-  };
-
-  return (
-    <Group
-      orientation="horizontal"
-      className="flex-1 min-w-0 h-full"
-      defaultLayout={kanbanDefaultLayout}
-      onLayoutChange={onKanbanLayoutChange}
-    >
-      <Panel
-        id="kanban-left"
-        minSize="20%"
-        className="min-w-0 h-full overflow-hidden bg-primary"
-      >
-        <ProjectKanbanBoard />
-      </Panel>
-
-      {isRightPanelOpen && (
-        <Separator
-          id="kanban-separator"
-          className="w-1 bg-panel outline-none hover:bg-brand/50 transition-colors cursor-col-resize"
-        />
-      )}
-
-      {isRightPanelOpen && (
-        <Panel
-          id="kanban-right"
-          minSize="400px"
-          maxSize="800px"
-          className="min-w-0 h-full overflow-hidden bg-secondary"
-        >
-          <ProjectRightSidebarContainer />
-        </Panel>
-      )}
-    </Group>
-  );
-}
-
-/**
- * Inner component that renders the Kanban board once we have the org context
- */
-function ProjectKanbanInner({ projectId }: { projectId: string }) {
-  const { t } = useTranslation('common');
-  const { projects, isLoading } = useOrgContext();
-
-  const project = projects.find((p) => p.id === projectId);
-
-  if (isLoading) {
-    return (
-      <div className="flex items-center justify-center h-full w-full">
-        <p className="text-low">{t('states.loading')}</p>
-      </div>
-    );
-  }
-
-  if (!project) {
-    return (
-      <div className="flex items-center justify-center h-full w-full">
-        <p className="text-low">{t('kanban.noProjectFound')}</p>
-      </div>
-    );
-  }
-
-  return (
-    <ProjectProvider projectId={projectId}>
-      <ProjectMutationsRegistration>
-        <ProjectKanbanLayout projectName={project.name} />
-      </ProjectMutationsRegistration>
-    </ProjectProvider>
-  );
-}
+import { ProjectSunsetPage } from './ProjectSunsetPage';
 
 /**
  * Hook to find a project by ID, using orgId from Zustand store
@@ -254,9 +55,7 @@ function useFindProjectById(projectId: string | undefined) {
  * NavbarContainer, AppBar, and SyncErrorProvider.
  */
 export function ProjectKanban() {
-  const { projectId, hostId, hasInvalidWorkspaceCreateDraftId } =
-    useCurrentKanbanRouteState();
-  const appNavigation = useAppNavigation();
+  const { projectId, hostId } = useCurrentKanbanRouteState();
   const { t } = useTranslation('common');
   const { isSignedIn, isLoaded: authLoaded } = useAuth();
   const issueComposerKey = useMemo(() => {
@@ -276,19 +75,8 @@ export function ProjectKanban() {
     previousIssueComposerKeyRef.current = issueComposerKey;
   }, [issueComposerKey]);
 
-  // Redirect invalid workspace-create draft URLs back to the closed project view.
-  useEffect(() => {
-    if (!projectId) return;
-
-    if (hasInvalidWorkspaceCreateDraftId) {
-      appNavigation.goToProject(projectId, {
-        replace: true,
-      });
-    }
-  }, [projectId, hasInvalidWorkspaceCreateDraftId, appNavigation]);
-
   // Find the project and get its organization
-  const { organizationId, isLoading } = useFindProjectById(
+  const { project, organizationId, isLoading } = useFindProjectById(
     projectId ?? undefined
   );
 
@@ -323,9 +111,5 @@ export function ProjectKanban() {
     );
   }
 
-  return (
-    <OrgProvider organizationId={organizationId}>
-      <ProjectKanbanInner projectId={projectId} />
-    </OrgProvider>
-  );
+  return <ProjectSunsetPage projectName={project?.name} />;
 }

--- a/packages/web-core/src/pages/kanban/ProjectSunsetPage.tsx
+++ b/packages/web-core/src/pages/kanban/ProjectSunsetPage.tsx
@@ -1,0 +1,63 @@
+import { useCallback } from 'react';
+import { ArrowSquareOutIcon, DownloadSimpleIcon } from '@phosphor-icons/react';
+import { useAppNavigation } from '@/shared/hooks/useAppNavigation';
+import { usePageTitle } from '@/shared/hooks/usePageTitle';
+
+interface ProjectSunsetPageProps {
+  projectName?: string;
+}
+
+export function ProjectSunsetPage({ projectName }: ProjectSunsetPageProps) {
+  const appNavigation = useAppNavigation();
+
+  usePageTitle(projectName, 'Project retired');
+
+  const handleExportClick = useCallback(() => {
+    appNavigation.goToExport();
+  }, [appNavigation]);
+
+  return (
+    <div className="h-full w-full overflow-auto bg-primary">
+      <div className="mx-auto flex min-h-full w-full max-w-3xl items-center px-base py-double">
+        <div className="w-full rounded-sm border border-border bg-secondary p-double">
+          <div className="space-y-base">
+            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-low">
+              Project sunset
+            </p>
+            <div className="space-y-half">
+              <h1 className="text-2xl font-semibold text-high">
+                Project functionality has been retired
+              </h1>
+              <p className="text-sm text-low">
+                {projectName
+                  ? `"${projectName}" is now export-only.`
+                  : 'This project is now export-only.'}{' '}
+                You can still download your project and issue data, but kanban,
+                issue, and workspace flows are no longer available here.
+              </p>
+            </div>
+            <div className="flex flex-col gap-half sm:flex-row">
+              <button
+                type="button"
+                onClick={handleExportClick}
+                className="inline-flex items-center justify-center gap-2 rounded-sm bg-brand px-base py-half text-sm font-medium text-on-brand transition-colors hover:bg-brand-hover"
+              >
+                <DownloadSimpleIcon className="size-icon-base" weight="bold" />
+                Export data
+              </button>
+              <a
+                href="https://vibekanban.com/shutdown"
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex items-center justify-center gap-2 rounded-sm border border-border bg-primary px-base py-half text-sm font-medium text-normal transition-colors hover:bg-tertiary"
+              >
+                <ArrowSquareOutIcon className="size-icon-base" weight="bold" />
+                Read about the shutdown
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
This PR sunsets the local project page and replaces the interactive Kanban experience with an export-only shutdown screen.

## What Changed
- Added a new `ProjectSunsetPage` that explains project functionality has been retired and gives users a direct `Export data` CTA plus a link to the shutdown page.
- Updated `ProjectKanban` so valid project routes no longer mount the Kanban board, issue panels, workspace flows, or the project provider stack.
- Kept the existing auth, loading, and not-found behavior, then render the new sunset page once a valid project is resolved.
- Removed the automatic Projects Guide side effect from `LocalProjectKanban` so sunset routes no longer mark the guide as seen or open onboarding for a retired feature.

## Why
The project page is being sunset, and the remaining supported capability is exporting data before shutdown. This change disables the project-page experience without removing the route itself, so existing project URLs still resolve while steering users to export.

## Important Implementation Details
- Project and nested issue/workspace URLs stay on their current route shape; they now terminate in the same export-only shutdown page.
- `ProjectKanban` still performs the minimal auth and project lookup needed to preserve login-required, loading, and no-project-found states.
- The page title is now set from the sunset screen using the project name when available.
- Shell-level project navigation and other global action surfaces were intentionally left unchanged in this pass; the scope here is the project page body.

This PR was written using [Vibe Kanban](https://vibekanban.com)
