### PR TITLE
Replace README hiring banner with sunsetting notice (Vibe Kanban)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@
 </p>
 
 <h1 align="center">
-  <a href="https://jobs.polymer.co/vibe-kanban?source=github"><strong>We're hiring!</strong></a>
+  <strong>Vibe Kanban is sunsetting.</strong>
+  <a href="https://www.vibekanban.com/blog/shutdown">Read the announcement.</a>
 </h1>
 
 ![](packages/public/vibe-kanban-screenshot-overview.png)


### PR DESCRIPTION
## Summary
This PR updates the top banner in README.md to communicate that Vibe Kanban is sunsetting and links readers to the shutdown announcement.

## What Changed
- Replaced the existing centered hiring banner near the top of the README
- Added a centered sunsetting notice instead
- Linked the notice to the shutdown blog post at https://www.vibekanban.com/blog/shutdown

## Why
The README previously surfaced hiring messaging that no longer reflects the current state of the project. This change makes the repository landing page immediately communicate the sunset status and gives readers a direct path to the announcement with the relevant context.

## Implementation Details
- The change is documentation-only and only touches README.md
- The new banner keeps the existing README structure and centered HTML styling already used at the top of the file
- No runtime code, build logic, or generated assets were changed

This PR was written using [Vibe Kanban](https://vibekanban.com)
