### PR TITLE
fix: bound graceful shutdown drain to 2s

### DIFF
--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use anyhow::{self, Error as AnyhowError};
 use axum::Router;
 use deployment::{Deployment, DeploymentError};
@@ -169,12 +171,12 @@ async fn main() -> Result<(), VibeKanbanError> {
     let proxy_server = axum::serve(proxy_listener, proxy_router)
         .with_graceful_shutdown(async move { proxy_shutdown.cancelled().await });
 
-    let main_handle = tokio::spawn(async move {
+    let mut main_handle = tokio::spawn(async move {
         if let Err(e) = main_server.await {
             tracing::error!("Main server error: {}", e);
         }
     });
-    let proxy_handle = tokio::spawn(async move {
+    let mut proxy_handle = tokio::spawn(async move {
         if let Err(e) = proxy_server.await {
             tracing::error!("Preview proxy error: {}", e);
         }
@@ -186,11 +188,48 @@ async fn main() -> Result<(), VibeKanbanError> {
         _ = shutdown_signal() => {
             tracing::info!("Shutdown signal received");
         }
-        _ = main_handle => {}
-        _ = proxy_handle => {}
+        _ = &mut main_handle => {}
+        _ = &mut proxy_handle => {}
     }
 
     shutdown_token.cancel();
+
+    // Bounded graceful shutdown.
+    //
+    // `axum::serve(...).with_graceful_shutdown(...)` waits for every in-flight
+    // connection to finish before dropping the listener. Long-lived streams
+    // (SSE, WebSocket, long-poll) do not drain on their own, so a single open
+    // stream can keep the listener socket alive indefinitely after the
+    // shutdown signal fires.
+    //
+    // On Windows, when the console delivers `CTRL_CLOSE_EVENT` (user closes
+    // the launcher window) the process is granted only ~5 seconds before
+    // `TerminateProcess` is invoked. If the listener is still alive at that
+    // point the AFD kernel state can linger under the dead PID, which blocks
+    // rebinding the same port until reboot.
+    //
+    // Give drain a bounded window; if it does not complete in time, abort
+    // the listener tasks so their sockets are dropped before exit.
+    const SHUTDOWN_DRAIN_TIMEOUT: Duration = Duration::from_secs(2);
+
+    let drain = async {
+        let _ = (&mut main_handle).await;
+        let _ = (&mut proxy_handle).await;
+    };
+    if tokio::time::timeout(SHUTDOWN_DRAIN_TIMEOUT, drain)
+        .await
+        .is_err()
+    {
+        tracing::warn!(
+            "Graceful shutdown exceeded {:?}; aborting listeners",
+            SHUTDOWN_DRAIN_TIMEOUT
+        );
+        main_handle.abort();
+        proxy_handle.abort();
+        // Wait for abort to propagate so the listener sockets are dropped.
+        let _ = (&mut main_handle).await;
+        let _ = (&mut proxy_handle).await;
+    }
 
     perform_cleanup_actions(&deployment).await;
 

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -182,6 +182,15 @@ async fn main() -> Result<(), VibeKanbanError> {
         }
     });
 
+    // Capture abort handles up front so the post-`select!` shutdown path can
+    // observe completion and signal cancellation without re-polling the
+    // `JoinHandle`s. `JoinHandle::poll` panics if called after it has already
+    // returned `Ready` (which happens when the `_ = &mut handle` branch of
+    // the `select!` below fires), so we stay off the handles once `select!`
+    // has consumed them.
+    let main_abort = main_handle.abort_handle();
+    let proxy_abort = proxy_handle.abort_handle();
+
     relay_registration::spawn_relay(&deployment).await;
 
     tokio::select! {
@@ -209,26 +218,38 @@ async fn main() -> Result<(), VibeKanbanError> {
     // rebinding the same port until reboot.
     //
     // Give drain a bounded window; if it does not complete in time, abort
-    // the listener tasks so their sockets are dropped before exit.
+    // the listener tasks and then give abort a short, bounded window to
+    // propagate — so a task that is slow to observe cancellation can't push
+    // total shutdown past the 5s grace window either.
+    //
+    // Completion is observed via `AbortHandle::is_finished()` polling rather
+    // than re-awaiting the `JoinHandle`s, because the `select!` above may
+    // have already consumed one of them to `Ready` and re-polling a finished
+    // `JoinHandle` panics.
     const SHUTDOWN_DRAIN_TIMEOUT: Duration = Duration::from_secs(2);
+    const POST_ABORT_TIMEOUT: Duration = Duration::from_millis(500);
+    const COMPLETION_POLL_INTERVAL: Duration = Duration::from_millis(20);
 
-    let drain = async {
-        let _ = (&mut main_handle).await;
-        let _ = (&mut proxy_handle).await;
-    };
-    if tokio::time::timeout(SHUTDOWN_DRAIN_TIMEOUT, drain)
-        .await
-        .is_err()
+    if tokio::time::timeout(SHUTDOWN_DRAIN_TIMEOUT, async {
+        while !main_abort.is_finished() || !proxy_abort.is_finished() {
+            tokio::time::sleep(COMPLETION_POLL_INTERVAL).await;
+        }
+    })
+    .await
+    .is_err()
     {
         tracing::warn!(
             "Graceful shutdown exceeded {:?}; aborting listeners",
             SHUTDOWN_DRAIN_TIMEOUT
         );
-        main_handle.abort();
-        proxy_handle.abort();
-        // Wait for abort to propagate so the listener sockets are dropped.
-        let _ = (&mut main_handle).await;
-        let _ = (&mut proxy_handle).await;
+        main_abort.abort();
+        proxy_abort.abort();
+        let _ = tokio::time::timeout(POST_ABORT_TIMEOUT, async {
+            while !main_abort.is_finished() || !proxy_abort.is_finished() {
+                tokio::time::sleep(COMPLETION_POLL_INTERVAL).await;
+            }
+        })
+        .await;
     }
 
     perform_cleanup_actions(&deployment).await;


### PR DESCRIPTION
## Summary

`axum::serve(...).with_graceful_shutdown(...)` waits for every in-flight connection to finish before dropping the listener. Long-lived streams (SSE, WebSocket, long-poll) do not drain on their own, so a single open stream can keep the drain future pending indefinitely after the shutdown signal fires.

In normal operation the tokio runtime drop at `main()` exit catches this by aborting the spawned serve tasks. On Windows, however, `CTRL_CLOSE_EVENT` (user closes the launcher / terminal window) grants the process only ~5 seconds before `TerminateProcess`. An unbounded drain leaves no time for `perform_cleanup_actions` or a clean listener drop — cleanup may never run, and the AFD kernel state of the half-closed listener can linger under a phantom PID.

This change bounds the drain to 2 seconds after `shutdown_token.cancel()`. If it doesn't complete, abort the listener tasks so their sockets drop before exit, leaving headroom for `perform_cleanup_actions` within the Windows `CTRL_CLOSE_EVENT` grace period.

## Behaviour changes

- **Windows:** graceful shutdown now completes within Windows' CTRL_CLOSE 5s grace window; `perform_cleanup_actions` runs reliably.
- **Linux:** long-lived streams (SSE/WS) are aborted 2s after shutdown instead of blocking `axum::serve` until runtime drop. End-of-process semantics are unchanged — the difference is that cleanup now runs in a consistent bounded window rather than racing the runtime drop.
- No new dependencies; no public API changes.

## Test plan

- [x] `cargo build --release --bin server` on Windows 11 MSVC; binary boots, accepts traffic, and shuts down cleanly on `Ctrl+C` with live browser-side SSE / WS connections present
- [x] Captured `tracing` output shows `"Shutdown signal received"` immediately followed by `perform_cleanup_actions` logs — drain completes sub-millisecond when peers cooperate
- [x] The 2s timeout path is defensive: the `tracing::warn!("Graceful shutdown exceeded ...")` branch is there for pathological cases (peers that refuse to disconnect) so the listener is still dropped before process exit

## Notes

- Does **not** attempt to fully fix the separate Windows-specific quirk where the kernel (AFD) can retain LISTEN socket state under a phantom PID after process exit even with clean shutdown. That requires `SO_REUSEADDR` handling at the bind site with different security tradeoffs (Windows `SO_REUSEADDR` is port-hijack semantics) and is deliberately out of scope for this PR.
- Reproducer for the overall Windows orphan-listener issue this partially addresses: run a release build, open the UI in Chrome (holds SSE), then close the launcher console. Before this change, subsequent `server.exe` runs hit `Error: Io(Os { code: 10048, kind: AddrInUse ... })`. After this change, cleanup is guaranteed to run and the race window is bounded, but a full fix requires `SO_REUSEADDR` which is left to application-level deployments with loopback-only bindings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes server shutdown behavior by adding time-bounded drain and forced task aborts, which could affect long-lived connections and shutdown ordering if timeouts are too aggressive.
> 
> **Overview**
> Implements a **bounded graceful shutdown** for the main server and preview proxy: after shutdown is signaled, the code now waits up to `2s` for `axum` drains to complete, then **aborts** the listener tasks and briefly waits for abort propagation before continuing.
> 
> Refactors the shutdown `select!` to use `&mut JoinHandle`s and captures `AbortHandle`s up front to avoid re-polling completed join handles, ensuring cleanup (`perform_cleanup_actions`) runs reliably even with long-lived connections (e.g., SSE/WS), especially on Windows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e624392831aed72a2aa478868d4639f752054e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->