### PR TITLE
fix(claude): skip Result.success re-emit when assistant content was already streamed

### DIFF
--- a/crates/executors/src/executors/claude.rs
+++ b/crates/executors/src/executors/claude.rs
@@ -1826,8 +1826,7 @@ impl ClaudeLogProcessor {
                     patches.push(ConversationPatch::add_normalized_entry(idx, entry));
                 } else if matches!(subtype.as_deref(), Some("success"))
                     && let Some(text) = result.as_ref().and_then(|v| v.as_str())
-                    && (self.last_assistant_message.is_none()
-                        || matches!(&self.last_assistant_message, Some(message) if !message.contains(text)))
+                    && self.last_assistant_message.is_none()
                 {
                     let entry = NormalizedEntry {
                         timestamp: None,
@@ -1840,6 +1839,14 @@ impl ClaudeLogProcessor {
                     let idx = entry_index_provider.next();
                     patches.push(ConversationPatch::add_normalized_entry(idx, entry));
                 }
+
+                // Reset so the skip check's "this turn" semantic is accurate:
+                // only assistant content streamed within the turn that ended
+                // at this Result event should suppress emission. If a
+                // subsequent turn arrives with no streamed assistant content
+                // (e.g. processor reused across turns), its Result.success
+                // fallback must still emit.
+                self.last_assistant_message = None;
             }
             ClaudeJson::ApprovalRequested {
                 tool_call_id,
@@ -2832,6 +2839,81 @@ mod tests {
             NormalizedEntryType::AssistantMessage
         ));
         assert_eq!(entries[0].content, "Final result");
+    }
+
+    #[test]
+    fn test_result_message_emits_fallback_in_later_turn_after_reset() {
+        // Defensive: after a Result event the processor clears
+        // `last_assistant_message`, so a subsequent turn whose Result.success
+        // is NOT preceded by streamed assistant content (e.g. a processor
+        // reused across turns, or a turn where Claude CLI produced only
+        // metadata / tool-use before the Result) still emits its fallback
+        // text. Without the reset the `.is_none()` gate would stay false
+        // for the lifetime of the processor once any assistant text has
+        // been seen, silently dropping valid fallback emissions.
+        let mut processor = ClaudeLogProcessor::new();
+
+        // Turn 1: streamed assistant text + Result.success with matching body
+        let t1_assistant = r#"{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Turn 1 reply"}]},"session_id":"s"}"#;
+        let parsed: ClaudeJson = serde_json::from_str(t1_assistant).unwrap();
+        let e1 = normalize_helper(&mut processor, &parsed, "");
+        assert_eq!(e1.len(), 1);
+        assert_eq!(e1[0].content, "Turn 1 reply");
+
+        let t1_result = r#"{"type":"result","subtype":"success","is_error":false,"duration_ms":1,"result":"Turn 1 reply"}"#;
+        let parsed: ClaudeJson = serde_json::from_str(t1_result).unwrap();
+        let e1r = normalize_helper(&mut processor, &parsed, "");
+        assert!(
+            e1r.is_empty(),
+            "redundant Result.success for this turn must be skipped"
+        );
+
+        // Turn 2: Result.success WITHOUT preceding streamed assistant content.
+        // Must still emit (the reset after Turn 1's Result cleared the gate).
+        let t2_result = r#"{"type":"result","subtype":"success","is_error":false,"duration_ms":1,"result":"Turn 2 fallback"}"#;
+        let parsed: ClaudeJson = serde_json::from_str(t2_result).unwrap();
+        let e2 = normalize_helper(&mut processor, &parsed, "");
+        assert_eq!(
+            e2.len(),
+            1,
+            "fallback Result.success in a turn without streamed content must emit, got: {e2:?}"
+        );
+        assert_eq!(e2[0].content, "Turn 2 fallback");
+    }
+
+    #[test]
+    fn test_result_message_skips_when_assistant_content_already_streamed() {
+        // Regression: when the stream already delivered assistant content via
+        // a prior `type=assistant` event (or `stream_event` deltas, which set
+        // the same `last_assistant_message` state), the terminal
+        // `type=result, subtype=success` event's `result` field is a
+        // redundant summary of that content and must NOT be emitted again.
+        //
+        // In real Claude CLI output the streamed text and the Result summary
+        // often differ by a byte or two somewhere in the middle (not just a
+        // trailing whitespace difference), so substring / trimmed-equality
+        // predicates are both insufficient. The correct predicate is:
+        // emit Result.success's text only when no assistant content was
+        // seen this turn at all.
+        let mut processor = ClaudeLogProcessor::new();
+
+        let assistant_json = r#"{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Hello world"}]},"session_id":"abc"}"#;
+        let parsed: ClaudeJson = serde_json::from_str(assistant_json).unwrap();
+        let streamed = normalize_helper(&mut processor, &parsed, "");
+        assert_eq!(streamed.len(), 1);
+        assert_eq!(streamed[0].content, "Hello world");
+
+        // Result.success with content that is NOT a substring of the streamed
+        // message (one character differs), exactly the shape observed in real
+        // output that caused the reported UI duplication.
+        let result_json = r#"{"type":"result","subtype":"success","is_error":false,"duration_ms":100,"result":"Hello World"}"#;
+        let parsed: ClaudeJson = serde_json::from_str(result_json).unwrap();
+        let after_result = normalize_helper(&mut processor, &parsed, "");
+        assert!(
+            after_result.is_empty(),
+            "Result.success must not be re-emitted when an assistant message \
+             was already streamed this turn, got duplicate: {after_result:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Re-submits #3383 (the original PR's head branch became unavailable after I migrated to a cleaner public fork). Same patch, rebased on current `main` — no conflicts with the CLI version bump in #3384.

## Summary

Fixes a backend dedup bug in `ClaudeLogProcessor::normalize_entries` that appends the final assistant message as a second `NormalizedEntry` whenever the Claude CLI's terminal `Result { subtype: "success", result }` event is processed after the stream already delivered assistant content. The UI then renders two back-to-back identical copies of the last reply, and the duplication persists across page refresh because it lives in the persisted normalized conversation (which is re-derived from the raw JSONL on every load).

## The bug

In `crates/executors/src/executors/claude.rs`, the `Result` event handler gates emission of the final AssistantMessage on:

```rust
|| matches!(&self.last_assistant_message, Some(message) if !message.contains(text))
```

Substring containment is the wrong predicate. The terminal `result` string produced by Claude CLI is not a verbatim copy of the streamed content — in real sessions the two commonly differ by a byte or two somewhere in the body. A representative case observed in an actual Claude Code session:

- Streamed `last_assistant_message` length: **3061** chars
- `Result.success.result` length: **3060** chars
- Neither a substring of the other
- Not equal after `.trim()` either

The `!contains` predicate therefore falls through, the `Result.success.result` is emitted as a second `AssistantMessage` entry with the same semantic content, and the UI shows the final reply twice.

## The fix

The `Result.success.result` field is redundant metadata when the stream has already delivered assistant content (via `type=assistant` events or `stream_event` deltas — both paths run through `content_item_to_normalized_entry`, which sets `last_assistant_message`). The correct predicate is simply:

```rust
self.last_assistant_message.is_none()
```

Only fall back to emitting Result.success's `result` as a NormalizedEntry when no assistant content was seen this turn at all.

## Tests

- Updates the regression test to `test_result_message_skips_when_assistant_content_already_streamed`, exercising a divergent-content scenario (`"Hello world"` streamed vs. `"Hello World"` in `Result.success` — not a substring, not equal after `.trim()`) that matches the real-world bug signature.
- `test_result_message_emits_final_text_if_not_seen` continues to pass (it starts with a fresh processor where `last_assistant_message` is `None`, preserving the fallback path).

```
cargo test -p executors test_result_message
```

## Scope

- **Affected:** `ClaudeLogProcessor` — and therefore Claude Code and Amp (`HistoryStrategy::AmpResume` reuses `ClaudeLogProcessor`).
- **Not affected:** audited sister executors do not share this redundant-summary pattern. Codex uses `UpdateMode::Set` (in-place replace). Gemini / Copilot / QwenCode route through the ACP common layer which does not re-emit on `Done`. Cursor explicitly `no-op`s on its `Result` variant. Droid uses a `sent_completion` flag guard. Opencode uses part-based streaming.

## Related

- #3343 — "bug: Long agent responses rendered twice in UI"

The symptom reported there matches the backend scenario fixed by this PR. The reporter hypothesised a frontend race in `useConversationHistory.ts`, but reproducing against an actual affected session shows:

1. Refreshing the page does not make the duplicate go away. It survives page refresh because it is baked into the normalized conversation that the frontend pulls from the backend.
2. The backend JSONL stream on disk contains a single `type=assistant` text content item plus one `type=result` summary event — running the current `normalize_entries` against it produces **two** `AssistantMessage` entries; running the fixed version produces **one**.

These two pieces of evidence rule out a pure frontend race for the observed bug and pinpoint the backend normalization layer as the cause. The frontend-race analysis in #3343 may still describe an independent, separate bug, but it is not the cause of the duplicated final message.

## Test plan

- [x] `cargo test -p executors test_result_message_skips_when_assistant_content_already_streamed` — reproduces the bug on `main`, passes with this change
- [x] `cargo test -p executors test_result_message_emits_final_text_if_not_seen` — continues to pass (legacy fallback)
- [x] Manual: a long Claude Code response in the UI shows a single copy of the final reply instead of two identical copies, and the single copy persists across page refresh

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts assistant message emission logic in `ClaudeLogProcessor` for Claude CLI `Result.success` events, which can affect what gets persisted to conversation history. Risk is limited in scope but could still change visible output (missing/extra final messages) if the new per-turn reset logic is wrong.
> 
> **Overview**
> Prevents duplicated final Claude assistant replies by changing `Result { subtype: "success" }` handling to **only emit the `result` fallback when no assistant content was streamed for that turn** (removing the prior substring-based dedupe).
> 
> Resets `last_assistant_message` after each `Result` event so the fallback can still emit in later turns when a processor is reused. Adds focused regression tests covering (1) divergent streamed vs. `Result.success.result` text (should skip) and (2) a later turn with only `Result.success` (should emit).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2752e003d00d88c1c78c6da1a0b3d4bc91766d95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
