### PR TITLE
bedrock support

### DIFF
--- a/crates/executors/src/executors/claude.rs
+++ b/crates/executors/src/executors/claude.rs
@@ -246,29 +246,23 @@ fn default_discovered_options() -> crate::executor_discovery::ExecutorDiscovered
                 ("claude-opus-4-6[1m]", "Opus (1M context)"),
                 ("claude-haiku-4-5-20251001", "Haiku"),
                 ("claude-sonnet-4-5-20250929", "Sonnet"),
-                // AWS Bedrock model IDs
+                // AWS Bedrock model IDs (cross-region inference profiles)
                 (
-                    "anthropic.claude-haiku-4-5-20251001-v1:0",
+                    "us.anthropic.claude-haiku-4-5-20251001-v1:0",
                     "Haiku 4.5 (Bedrock)",
                 ),
+                ("us.anthropic.claude-sonnet-4-6", "Sonnet 4.6 (Bedrock)"),
+                ("us.anthropic.claude-opus-4-6-v1", "Opus 4.6 (Bedrock)"),
                 (
-                    "anthropic.claude-sonnet-4-6",
-                    "Sonnet 4.6 (Bedrock)",
-                ),
-                (
-                    "anthropic.claude-opus-4-6-v1",
-                    "Opus 4.6 (Bedrock)",
-                ),
-                (
-                    "anthropic.claude-sonnet-4-5-20250929-v1:0",
+                    "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
                     "Sonnet 4.5 (Bedrock)",
                 ),
                 (
-                    "anthropic.claude-opus-4-1-20250805-v1:0",
+                    "us.anthropic.claude-opus-4-1-20250805-v1:0",
                     "Opus 4.1 (Bedrock)",
                 ),
                 (
-                    "anthropic.claude-opus-4-5-20251101-v1:0",
+                    "us.anthropic.claude-opus-4-5-20251101-v1:0",
                     "Opus 4.5 (Bedrock)",
                 ),
             ]
@@ -610,8 +604,6 @@ impl ClaudeCode {
         env.clone()
             .with_profile(&self.cmd)
             .apply_to_command(&mut command);
-
-
 
         // Remove ANTHROPIC_API_KEY if disable_api_key is enabled
         if self.disable_api_key.unwrap_or(false) {

--- a/crates/executors/src/executors/claude.rs
+++ b/crates/executors/src/executors/claude.rs
@@ -246,6 +246,31 @@ fn default_discovered_options() -> crate::executor_discovery::ExecutorDiscovered
                 ("claude-opus-4-6[1m]", "Opus (1M context)"),
                 ("claude-haiku-4-5-20251001", "Haiku"),
                 ("claude-sonnet-4-5-20250929", "Sonnet"),
+                // AWS Bedrock model IDs
+                (
+                    "anthropic.claude-haiku-4-5-20251001-v1:0",
+                    "Haiku 4.5 (Bedrock)",
+                ),
+                (
+                    "anthropic.claude-sonnet-4-6",
+                    "Sonnet 4.6 (Bedrock)",
+                ),
+                (
+                    "anthropic.claude-opus-4-6-v1",
+                    "Opus 4.6 (Bedrock)",
+                ),
+                (
+                    "anthropic.claude-sonnet-4-5-20250929-v1:0",
+                    "Sonnet 4.5 (Bedrock)",
+                ),
+                (
+                    "anthropic.claude-opus-4-1-20250805-v1:0",
+                    "Opus 4.1 (Bedrock)",
+                ),
+                (
+                    "anthropic.claude-opus-4-5-20251101-v1:0",
+                    "Opus 4.5 (Bedrock)",
+                ),
             ]
             .into_iter()
             .map(|(id, name)| ModelInfo {
@@ -585,6 +610,8 @@ impl ClaudeCode {
         env.clone()
             .with_profile(&self.cmd)
             .apply_to_command(&mut command);
+
+
 
         // Remove ANTHROPIC_API_KEY if disable_api_key is enabled
         if self.disable_api_key.unwrap_or(false) {

--- a/crates/executors/src/executors/mod.rs
+++ b/crates/executors/src/executors/mod.rs
@@ -21,7 +21,7 @@ use crate::{
     command::CommandBuildError,
     env::ExecutionEnv,
     executors::{
-        amp::Amp, claude::ClaudeCode, codex::Codex, copilot::Copilot, cursor::CursorAgent, 
+        amp::Amp, claude::ClaudeCode, codex::Codex, copilot::Copilot, cursor::CursorAgent,
         droid::Droid, gemini::Gemini, opencode::Opencode, qwen::QwenCode,
     },
     logs::utils::patch,

--- a/crates/executors/src/executors/mod.rs
+++ b/crates/executors/src/executors/mod.rs
@@ -21,7 +21,7 @@ use crate::{
     command::CommandBuildError,
     env::ExecutionEnv,
     executors::{
-        amp::Amp, claude::ClaudeCode, codex::Codex, copilot::Copilot, cursor::CursorAgent,
+        amp::Amp, claude::ClaudeCode, codex::Codex, copilot::Copilot, cursor::CursorAgent, 
         droid::Droid, gemini::Gemini, opencode::Opencode, qwen::QwenCode,
     },
     logs::utils::patch,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: this only expands the Claude executor’s discovered model list to include Bedrock inference profile IDs and does not change execution, auth, or request/response logic.
> 
> **Overview**
> Adds several **AWS Bedrock Claude model IDs** to `ClaudeCode`’s `default_discovered_options()` model selector list, labeling them as Bedrock variants so they can be selected like existing Claude models. No other executor behavior is modified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b09540762a2dfac7dd6be333b20ecc0eeb4a0907. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->