### PR TITLE
feat(executors): add Mistral Vibe executor with ACP harness

### DIFF
--- a/crates/executors/default_profiles.json
+++ b/crates/executors/default_profiles.json
@@ -63,6 +63,24 @@
           "autonomy": "skip-permissions-unsafe"
         }
       }
+    },
+    "MISTRAL_VIBE": {
+      "DEFAULT": {
+        "MISTRAL_VIBE": {
+          "auto_approve": true
+        }
+      },
+      "DEVSTRAL_SMALL": {
+        "MISTRAL_VIBE": {
+          "model": "devstral-small-2",
+          "auto_approve": true
+        }
+      },
+      "APPROVALS": {
+        "MISTRAL_VIBE": {
+          "auto_approve": false
+        }
+      }
     }
   }
 }

--- a/crates/executors/src/executors/acp/harness.rs
+++ b/crates/executors/src/executors/acp/harness.rs
@@ -332,7 +332,13 @@ impl AcpAgentHarness {
 
                         // Initialize
                         let _ = conn
-                            .initialize(proto::InitializeRequest::new(proto::ProtocolVersion::V1))
+                            .initialize(
+                                proto::InitializeRequest::new(proto::ProtocolVersion::V1)
+                                    .client_info(proto::Implementation::new(
+                                        "vibe-kanban",
+                                        env!("CARGO_PKG_VERSION"),
+                                    )),
+                            )
                             .await;
 
                         // Handle session creation/forking

--- a/crates/executors/src/executors/mistral_vibe.rs
+++ b/crates/executors/src/executors/mistral_vibe.rs
@@ -1,0 +1,167 @@
+use std::{path::Path, sync::Arc};
+
+use async_trait::async_trait;
+use derivative::Derivative;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use ts_rs::TS;
+use workspace_utils::msg_store::MsgStore;
+
+pub use super::acp::AcpAgentHarness;
+use crate::{
+    approvals::ExecutorApprovalService,
+    command::{CmdOverrides, CommandBuildError, CommandBuilder, apply_overrides},
+    env::ExecutionEnv,
+    executors::{
+        AppendPrompt, AvailabilityInfo, BaseCodingAgent, ExecutorError, SpawnedChild,
+        StandardCodingAgentExecutor,
+    },
+    model_selector::PermissionPolicy,
+    profile::ExecutorConfig,
+};
+
+const VIBE_COMMAND: &str = "vibe-acp";
+const SESSION_NAMESPACE: &str = "vibe_sessions";
+
+#[derive(Derivative, Clone, Serialize, Deserialize, TS, JsonSchema)]
+#[derivative(Debug, PartialEq)]
+pub struct MistralVibe {
+    #[serde(default)]
+    pub append_prompt: AppendPrompt,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub auto_approve: Option<bool>,
+    #[serde(flatten)]
+    pub cmd: CmdOverrides,
+    #[serde(skip)]
+    #[ts(skip)]
+    #[derivative(Debug = "ignore", PartialEq = "ignore")]
+    pub approvals: Option<Arc<dyn ExecutorApprovalService>>,
+}
+
+impl MistralVibe {
+    fn build_command_builder(&self) -> Result<CommandBuilder, CommandBuildError> {
+        let builder = CommandBuilder::new(VIBE_COMMAND);
+        apply_overrides(builder, &self.cmd)
+    }
+
+    fn build_harness(&self) -> AcpAgentHarness {
+        let mut harness = AcpAgentHarness::with_session_namespace(SESSION_NAMESPACE);
+        if let Some(ref model) = self.model {
+            harness = harness.with_model(model);
+        }
+        harness
+    }
+
+    fn effective_approvals(&self) -> Option<Arc<dyn ExecutorApprovalService>> {
+        if self.auto_approve.unwrap_or(false) {
+            None
+        } else {
+            self.approvals.clone()
+        }
+    }
+}
+
+#[async_trait]
+impl StandardCodingAgentExecutor for MistralVibe {
+    fn apply_overrides(&mut self, executor_config: &ExecutorConfig) {
+        if let Some(model_id) = &executor_config.model_id {
+            self.model = Some(model_id.clone());
+        }
+        if let Some(permission_policy) = executor_config.permission_policy.clone() {
+            self.auto_approve = Some(matches!(permission_policy, PermissionPolicy::Auto));
+        }
+    }
+
+    fn use_approvals(&mut self, approvals: Arc<dyn ExecutorApprovalService>) {
+        self.approvals = Some(approvals);
+    }
+
+    async fn spawn(
+        &self,
+        current_dir: &Path,
+        prompt: &str,
+        env: &ExecutionEnv,
+    ) -> Result<SpawnedChild, ExecutorError> {
+        let combined_prompt = self.append_prompt.combine_prompt(prompt);
+        let vibe_command = self.build_command_builder()?.build_initial()?;
+        self.build_harness()
+            .spawn_with_command(
+                current_dir,
+                combined_prompt,
+                vibe_command,
+                env,
+                &self.cmd,
+                self.effective_approvals(),
+            )
+            .await
+    }
+
+    async fn spawn_follow_up(
+        &self,
+        current_dir: &Path,
+        prompt: &str,
+        session_id: &str,
+        _reset_to_message_id: Option<&str>,
+        env: &ExecutionEnv,
+    ) -> Result<SpawnedChild, ExecutorError> {
+        let combined_prompt = self.append_prompt.combine_prompt(prompt);
+        let vibe_command = self.build_command_builder()?.build_follow_up(&[])?;
+        self.build_harness()
+            .spawn_follow_up_with_command(
+                current_dir,
+                combined_prompt,
+                session_id,
+                vibe_command,
+                env,
+                &self.cmd,
+                self.effective_approvals(),
+            )
+            .await
+    }
+
+    fn normalize_logs(
+        &self,
+        msg_store: Arc<MsgStore>,
+        worktree_path: &Path,
+    ) -> Vec<tokio::task::JoinHandle<()>> {
+        super::acp::normalize_logs(msg_store, worktree_path)
+    }
+
+    fn default_mcp_config_path(&self) -> Option<std::path::PathBuf> {
+        dirs::home_dir().map(|home| home.join(".mistral").join("vibe").join("mcp.json"))
+    }
+
+    fn get_availability_info(&self) -> AvailabilityInfo {
+        let mcp_config_found = self
+            .default_mcp_config_path()
+            .map(|p| p.exists())
+            .unwrap_or(false);
+
+        let installation_indicator_found = dirs::home_dir()
+            .map(|home| home.join(".mistral").join("vibe").exists())
+            .unwrap_or(false);
+
+        if mcp_config_found || installation_indicator_found {
+            AvailabilityInfo::InstallationFound
+        } else {
+            AvailabilityInfo::NotFound
+        }
+    }
+
+    fn get_preset_options(&self) -> ExecutorConfig {
+        ExecutorConfig {
+            executor: BaseCodingAgent::MistralVibe,
+            variant: None,
+            model_id: self.model.clone(),
+            agent_id: None,
+            reasoning_id: None,
+            permission_policy: Some(if self.auto_approve.unwrap_or(false) {
+                PermissionPolicy::Auto
+            } else {
+                PermissionPolicy::Supervised
+            }),
+        }
+    }
+}

--- a/crates/executors/src/executors/mod.rs
+++ b/crates/executors/src/executors/mod.rs
@@ -23,7 +23,8 @@ use crate::{
     env::ExecutionEnv,
     executors::{
         amp::Amp, claude::ClaudeCode, codex::Codex, copilot::Copilot, cursor::CursorAgent,
-        droid::Droid, gemini::Gemini, opencode::Opencode, qwen::QwenCode,
+        droid::Droid, gemini::Gemini, mistral_vibe::MistralVibe, opencode::Opencode,
+        qwen::QwenCode,
     },
     logs::utils::patch,
     mcp_config::McpConfig,
@@ -38,6 +39,7 @@ pub mod copilot;
 pub mod cursor;
 pub mod droid;
 pub mod gemini;
+pub mod mistral_vibe;
 pub mod opencode;
 #[cfg(feature = "qa-mode")]
 pub mod qa_mock;
@@ -119,6 +121,7 @@ pub enum CodingAgent {
     QwenCode,
     Copilot,
     Droid,
+    MistralVibe,
     #[cfg(feature = "qa-mode")]
     QaMock(QaMockExecutor),
 }
@@ -189,7 +192,7 @@ impl CodingAgent {
                 BaseAgentCapability::SetupHelper,
                 BaseAgentCapability::ContextUsage,
             ],
-            Self::Gemini(_) | Self::QwenCode(_) => {
+            Self::Gemini(_) | Self::QwenCode(_) | Self::MistralVibe(_) => {
                 vec![BaseAgentCapability::SessionFork]
             }
             Self::CursorAgent(_) => vec![BaseAgentCapability::SetupHelper],

--- a/crates/executors/src/mcp_config.rs
+++ b/crates/executors/src/mcp_config.rs
@@ -397,7 +397,10 @@ impl CodingAgent {
         use Adapter::*;
 
         let adapter = match self {
-            CodingAgent::ClaudeCode(_) | CodingAgent::Amp(_) | CodingAgent::Droid(_) => Passthrough,
+            CodingAgent::ClaudeCode(_)
+            | CodingAgent::Amp(_)
+            | CodingAgent::Droid(_)
+            | CodingAgent::MistralVibe(_) => Passthrough,
             CodingAgent::QwenCode(_) | CodingAgent::Gemini(_) => Gemini,
             CodingAgent::CursorAgent(_) => Cursor,
             CodingAgent::Codex(_) => Codex,

--- a/crates/server/src/bin/generate_types.rs
+++ b/crates/server/src/bin/generate_types.rs
@@ -227,6 +227,7 @@ fn generate_types_content() -> String {
         executors::executors::droid::Droid::decl(),
         executors::executors::droid::Autonomy::decl(),
         executors::executors::droid::ReasoningEffortLevel::decl(),
+        executors::executors::mistral_vibe::MistralVibe::decl(),
         executors::executors::AppendPrompt::decl(),
         executors::actions::coding_agent_initial::CodingAgentInitialRequest::decl(),
         executors::actions::coding_agent_follow_up::CodingAgentFollowUpRequest::decl(),
@@ -350,6 +351,10 @@ fn generate_schemas() -> Result<HashMap<&'static str, String>, serde_json::Error
         (
             "droid",
             generate_json_schema::<executors::executors::droid::Droid>()?,
+        ),
+        (
+            "mistral_vibe",
+            generate_json_schema::<executors::executors::mistral_vibe::MistralVibe>()?,
         ),
     ]);
     println!(

--- a/crates/tauri-app/gen/schemas/linux-schema.json
+++ b/crates/tauri-app/gen/schemas/linux-schema.json
@@ -204,6 +204,10 @@
                             "url"
                           ],
                           "properties": {
+                            "url": {
+                              "description": "A URL that can be opened by the webview when using the Opener APIs.\n\nWildcards can be used following the UNIX glob pattern.\n\nExamples:\n\n- \"https://*\" : allows all HTTPS origin\n\n- \"https://*.github.com/tauri-apps/tauri\": allows any subdomain of \"github.com\" with the \"tauri-apps/api\" path\n\n- \"https://myapi.service.com/users/*\": allows access to any URLs that begins with \"https://myapi.service.com/users/\"",
+                              "type": "string"
+                            },
                             "app": {
                               "description": "An application to open this url with, for example: firefox.",
                               "allOf": [
@@ -211,10 +215,6 @@
                                   "$ref": "#/definitions/Application"
                                 }
                               ]
-                            },
-                            "url": {
-                              "description": "A URL that can be opened by the webview when using the Opener APIs.\n\nWildcards can be used following the UNIX glob pattern.\n\nExamples:\n\n- \"https://*\" : allows all HTTPS origin\n\n- \"https://*.github.com/tauri-apps/tauri\": allows any subdomain of \"github.com\" with the \"tauri-apps/api\" path\n\n- \"https://myapi.service.com/users/*\": allows access to any URLs that begins with \"https://myapi.service.com/users/\"",
-                              "type": "string"
                             }
                           }
                         },
@@ -224,6 +224,10 @@
                             "path"
                           ],
                           "properties": {
+                            "path": {
+                              "description": "A path that can be opened by the webview when using the Opener APIs.\n\nThe pattern can start with a variable that resolves to a system base directory. The variables are: `$AUDIO`, `$CACHE`, `$CONFIG`, `$DATA`, `$LOCALDATA`, `$DESKTOP`, `$DOCUMENT`, `$DOWNLOAD`, `$EXE`, `$FONT`, `$HOME`, `$PICTURE`, `$PUBLIC`, `$RUNTIME`, `$TEMPLATE`, `$VIDEO`, `$RESOURCE`, `$APP`, `$LOG`, `$TEMP`, `$APPCONFIG`, `$APPDATA`, `$APPLOCALDATA`, `$APPCACHE`, `$APPLOG`.",
+                              "type": "string"
+                            },
                             "app": {
                               "description": "An application to open this path with, for example: xdg-open.",
                               "allOf": [
@@ -231,10 +235,6 @@
                                   "$ref": "#/definitions/Application"
                                 }
                               ]
-                            },
-                            "path": {
-                              "description": "A path that can be opened by the webview when using the Opener APIs.\n\nThe pattern can start with a variable that resolves to a system base directory. The variables are: `$AUDIO`, `$CACHE`, `$CONFIG`, `$DATA`, `$LOCALDATA`, `$DESKTOP`, `$DOCUMENT`, `$DOWNLOAD`, `$EXE`, `$FONT`, `$HOME`, `$PICTURE`, `$PUBLIC`, `$RUNTIME`, `$TEMPLATE`, `$VIDEO`, `$RESOURCE`, `$APP`, `$LOG`, `$TEMP`, `$APPCONFIG`, `$APPDATA`, `$APPLOCALDATA`, `$APPCACHE`, `$APPLOG`.",
-                              "type": "string"
                             }
                           }
                         }
@@ -252,6 +252,10 @@
                             "url"
                           ],
                           "properties": {
+                            "url": {
+                              "description": "A URL that can be opened by the webview when using the Opener APIs.\n\nWildcards can be used following the UNIX glob pattern.\n\nExamples:\n\n- \"https://*\" : allows all HTTPS origin\n\n- \"https://*.github.com/tauri-apps/tauri\": allows any subdomain of \"github.com\" with the \"tauri-apps/api\" path\n\n- \"https://myapi.service.com/users/*\": allows access to any URLs that begins with \"https://myapi.service.com/users/\"",
+                              "type": "string"
+                            },
                             "app": {
                               "description": "An application to open this url with, for example: firefox.",
                               "allOf": [
@@ -259,10 +263,6 @@
                                   "$ref": "#/definitions/Application"
                                 }
                               ]
-                            },
-                            "url": {
-                              "description": "A URL that can be opened by the webview when using the Opener APIs.\n\nWildcards can be used following the UNIX glob pattern.\n\nExamples:\n\n- \"https://*\" : allows all HTTPS origin\n\n- \"https://*.github.com/tauri-apps/tauri\": allows any subdomain of \"github.com\" with the \"tauri-apps/api\" path\n\n- \"https://myapi.service.com/users/*\": allows access to any URLs that begins with \"https://myapi.service.com/users/\"",
-                              "type": "string"
                             }
                           }
                         },
@@ -272,6 +272,10 @@
                             "path"
                           ],
                           "properties": {
+                            "path": {
+                              "description": "A path that can be opened by the webview when using the Opener APIs.\n\nThe pattern can start with a variable that resolves to a system base directory. The variables are: `$AUDIO`, `$CACHE`, `$CONFIG`, `$DATA`, `$LOCALDATA`, `$DESKTOP`, `$DOCUMENT`, `$DOWNLOAD`, `$EXE`, `$FONT`, `$HOME`, `$PICTURE`, `$PUBLIC`, `$RUNTIME`, `$TEMPLATE`, `$VIDEO`, `$RESOURCE`, `$APP`, `$LOG`, `$TEMP`, `$APPCONFIG`, `$APPDATA`, `$APPLOCALDATA`, `$APPCACHE`, `$APPLOG`.",
+                              "type": "string"
+                            },
                             "app": {
                               "description": "An application to open this path with, for example: xdg-open.",
                               "allOf": [
@@ -279,10 +283,6 @@
                                   "$ref": "#/definitions/Application"
                                 }
                               ]
-                            },
-                            "path": {
-                              "description": "A path that can be opened by the webview when using the Opener APIs.\n\nThe pattern can start with a variable that resolves to a system base directory. The variables are: `$AUDIO`, `$CACHE`, `$CONFIG`, `$DATA`, `$LOCALDATA`, `$DESKTOP`, `$DOCUMENT`, `$DOWNLOAD`, `$EXE`, `$FONT`, `$HOME`, `$PICTURE`, `$PUBLIC`, `$RUNTIME`, `$TEMPLATE`, `$VIDEO`, `$RESOURCE`, `$APP`, `$LOG`, `$TEMP`, `$APPCONFIG`, `$APPDATA`, `$APPLOCALDATA`, `$APPCACHE`, `$APPLOG`.",
-                              "type": "string"
                             }
                           }
                         }
@@ -391,6 +391,14 @@
                             "name"
                           ],
                           "properties": {
+                            "name": {
+                              "description": "The name for this allowed shell command configuration.\n\nThis name will be used inside of the webview API to call this command along with any specified arguments.",
+                              "type": "string"
+                            },
+                            "cmd": {
+                              "description": "The command name. It can start with a variable that resolves to a system base directory. The variables are: `$AUDIO`, `$CACHE`, `$CONFIG`, `$DATA`, `$LOCALDATA`, `$DESKTOP`, `$DOCUMENT`, `$DOWNLOAD`, `$EXE`, `$FONT`, `$HOME`, `$PICTURE`, `$PUBLIC`, `$RUNTIME`, `$TEMPLATE`, `$VIDEO`, `$RESOURCE`, `$LOG`, `$TEMP`, `$APPCONFIG`, `$APPDATA`, `$APPLOCALDATA`, `$APPCACHE`, `$APPLOG`.",
+                              "type": "string"
+                            },
                             "args": {
                               "description": "The allowed arguments for the command execution.",
                               "allOf": [
@@ -398,14 +406,6 @@
                                   "$ref": "#/definitions/ShellScopeEntryAllowedArgs"
                                 }
                               ]
-                            },
-                            "cmd": {
-                              "description": "The command name. It can start with a variable that resolves to a system base directory. The variables are: `$AUDIO`, `$CACHE`, `$CONFIG`, `$DATA`, `$LOCALDATA`, `$DESKTOP`, `$DOCUMENT`, `$DOWNLOAD`, `$EXE`, `$FONT`, `$HOME`, `$PICTURE`, `$PUBLIC`, `$RUNTIME`, `$TEMPLATE`, `$VIDEO`, `$RESOURCE`, `$LOG`, `$TEMP`, `$APPCONFIG`, `$APPDATA`, `$APPLOCALDATA`, `$APPCACHE`, `$APPLOG`.",
-                              "type": "string"
-                            },
-                            "name": {
-                              "description": "The name for this allowed shell command configuration.\n\nThis name will be used inside of the webview API to call this command along with any specified arguments.",
-                              "type": "string"
                             }
                           },
                           "additionalProperties": false
@@ -417,6 +417,10 @@
                             "sidecar"
                           ],
                           "properties": {
+                            "name": {
+                              "description": "The name for this allowed shell command configuration.\n\nThis name will be used inside of the webview API to call this command along with any specified arguments.",
+                              "type": "string"
+                            },
                             "args": {
                               "description": "The allowed arguments for the command execution.",
                               "allOf": [
@@ -424,10 +428,6 @@
                                   "$ref": "#/definitions/ShellScopeEntryAllowedArgs"
                                 }
                               ]
-                            },
-                            "name": {
-                              "description": "The name for this allowed shell command configuration.\n\nThis name will be used inside of the webview API to call this command along with any specified arguments.",
-                              "type": "string"
                             },
                             "sidecar": {
                               "description": "If this command is a sidecar command.",
@@ -451,6 +451,14 @@
                             "name"
                           ],
                           "properties": {
+                            "name": {
+                              "description": "The name for this allowed shell command configuration.\n\nThis name will be used inside of the webview API to call this command along with any specified arguments.",
+                              "type": "string"
+                            },
+                            "cmd": {
+                              "description": "The command name. It can start with a variable that resolves to a system base directory. The variables are: `$AUDIO`, `$CACHE`, `$CONFIG`, `$DATA`, `$LOCALDATA`, `$DESKTOP`, `$DOCUMENT`, `$DOWNLOAD`, `$EXE`, `$FONT`, `$HOME`, `$PICTURE`, `$PUBLIC`, `$RUNTIME`, `$TEMPLATE`, `$VIDEO`, `$RESOURCE`, `$LOG`, `$TEMP`, `$APPCONFIG`, `$APPDATA`, `$APPLOCALDATA`, `$APPCACHE`, `$APPLOG`.",
+                              "type": "string"
+                            },
                             "args": {
                               "description": "The allowed arguments for the command execution.",
                               "allOf": [
@@ -458,14 +466,6 @@
                                   "$ref": "#/definitions/ShellScopeEntryAllowedArgs"
                                 }
                               ]
-                            },
-                            "cmd": {
-                              "description": "The command name. It can start with a variable that resolves to a system base directory. The variables are: `$AUDIO`, `$CACHE`, `$CONFIG`, `$DATA`, `$LOCALDATA`, `$DESKTOP`, `$DOCUMENT`, `$DOWNLOAD`, `$EXE`, `$FONT`, `$HOME`, `$PICTURE`, `$PUBLIC`, `$RUNTIME`, `$TEMPLATE`, `$VIDEO`, `$RESOURCE`, `$LOG`, `$TEMP`, `$APPCONFIG`, `$APPDATA`, `$APPLOCALDATA`, `$APPCACHE`, `$APPLOG`.",
-                              "type": "string"
-                            },
-                            "name": {
-                              "description": "The name for this allowed shell command configuration.\n\nThis name will be used inside of the webview API to call this command along with any specified arguments.",
-                              "type": "string"
                             }
                           },
                           "additionalProperties": false
@@ -477,6 +477,10 @@
                             "sidecar"
                           ],
                           "properties": {
+                            "name": {
+                              "description": "The name for this allowed shell command configuration.\n\nThis name will be used inside of the webview API to call this command along with any specified arguments.",
+                              "type": "string"
+                            },
                             "args": {
                               "description": "The allowed arguments for the command execution.",
                               "allOf": [
@@ -484,10 +488,6 @@
                                   "$ref": "#/definitions/ShellScopeEntryAllowedArgs"
                                 }
                               ]
-                            },
-                            "name": {
-                              "description": "The name for this allowed shell command configuration.\n\nThis name will be used inside of the webview API to call this command along with any specified arguments.",
-                              "type": "string"
                             },
                             "sidecar": {
                               "description": "If this command is a sidecar command.",
@@ -3001,6 +3001,22 @@
         }
       ]
     },
+    "ShellScopeEntryAllowedArgs": {
+      "description": "A set of command arguments allowed to be executed by the webview API.\n\nA value of `true` will allow any arguments to be passed to the command. `false` will disable all arguments. A list of [`ShellScopeEntryAllowedArg`] will set those arguments as the only valid arguments to be passed to the attached command configuration.",
+      "anyOf": [
+        {
+          "description": "Use a simple boolean to allow all or disable all arguments to this command configuration.",
+          "type": "boolean"
+        },
+        {
+          "description": "A specific set of [`ShellScopeEntryAllowedArg`] that are valid to call for the command configuration.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ShellScopeEntryAllowedArg"
+          }
+        }
+      ]
+    },
     "ShellScopeEntryAllowedArg": {
       "description": "A command argument allowed to be executed by the webview API.",
       "anyOf": [
@@ -3015,33 +3031,17 @@
             "validator"
           ],
           "properties": {
+            "validator": {
+              "description": "[regex] validator to require passed values to conform to an expected input.\n\nThis will require the argument value passed to this variable to match the `validator` regex before it will be executed.\n\nThe regex string is by default surrounded by `^...$` to match the full string. For example the `https?://\\w+` regex would be registered as `^https?://\\w+$`.\n\n[regex]: <https://docs.rs/regex/latest/regex/#syntax>",
+              "type": "string"
+            },
             "raw": {
               "description": "Marks the validator as a raw regex, meaning the plugin should not make any modification at runtime.\n\nThis means the regex will not match on the entire string by default, which might be exploited if your regex allow unexpected input to be considered valid. When using this option, make sure your regex is correct.",
               "default": false,
               "type": "boolean"
-            },
-            "validator": {
-              "description": "[regex] validator to require passed values to conform to an expected input.\n\nThis will require the argument value passed to this variable to match the `validator` regex before it will be executed.\n\nThe regex string is by default surrounded by `^...$` to match the full string. For example the `https?://\\w+` regex would be registered as `^https?://\\w+$`.\n\n[regex]: <https://docs.rs/regex/latest/regex/#syntax>",
-              "type": "string"
             }
           },
           "additionalProperties": false
-        }
-      ]
-    },
-    "ShellScopeEntryAllowedArgs": {
-      "description": "A set of command arguments allowed to be executed by the webview API.\n\nA value of `true` will allow any arguments to be passed to the command. `false` will disable all arguments. A list of [`ShellScopeEntryAllowedArg`] will set those arguments as the only valid arguments to be passed to the attached command configuration.",
-      "anyOf": [
-        {
-          "description": "Use a simple boolean to allow all or disable all arguments to this command configuration.",
-          "type": "boolean"
-        },
-        {
-          "description": "A specific set of [`ShellScopeEntryAllowedArg`] that are valid to call for the command configuration.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/ShellScopeEntryAllowedArg"
-          }
         }
       ]
     }

--- a/packages/public/agents/mistral-vibe-dark.svg
+++ b/packages/public/agents/mistral-vibe-dark.svg
@@ -1,0 +1,10 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="2" y="2" width="3" height="3" fill="#F7D046"/>
+<rect x="6.5" y="2" width="3" height="3" fill="#F7D046"/>
+<rect x="11" y="2" width="3" height="3" fill="#F7D046"/>
+<rect x="2" y="6.5" width="3" height="3" fill="#F2A73B"/>
+<rect x="6.5" y="6.5" width="3" height="3" fill="#FFFFFF"/>
+<rect x="11" y="6.5" width="3" height="3" fill="#F2A73B"/>
+<rect x="2" y="11" width="3" height="3" fill="#EE792F"/>
+<rect x="11" y="11" width="3" height="3" fill="#EE792F"/>
+</svg>

--- a/packages/public/agents/mistral-vibe-light.svg
+++ b/packages/public/agents/mistral-vibe-light.svg
@@ -1,0 +1,10 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="2" y="2" width="3" height="3" fill="#F7D046"/>
+<rect x="6.5" y="2" width="3" height="3" fill="#F7D046"/>
+<rect x="11" y="2" width="3" height="3" fill="#F7D046"/>
+<rect x="2" y="6.5" width="3" height="3" fill="#F2A73B"/>
+<rect x="6.5" y="6.5" width="3" height="3" fill="#0C0C0C"/>
+<rect x="11" y="6.5" width="3" height="3" fill="#F2A73B"/>
+<rect x="2" y="11" width="3" height="3" fill="#EE792F"/>
+<rect x="11" y="11" width="3" height="3" fill="#EE792F"/>
+</svg>

--- a/packages/web-core/src/shared/components/AgentIcon.tsx
+++ b/packages/web-core/src/shared/components/AgentIcon.tsx
@@ -29,6 +29,8 @@ export function getAgentName(
       return 'Copilot';
     case BaseCodingAgent.DROID:
       return 'Droid';
+    case BaseCodingAgent.MISTRAL_VIBE:
+      return 'Mistral Vibe';
   }
 }
 
@@ -72,6 +74,9 @@ export function AgentIcon({ agent, className = 'h-4 w-4' }: AgentIconProps) {
       break;
     case BaseCodingAgent.DROID:
       iconPath = `/agents/droid${suffix}.svg`;
+      break;
+    case BaseCodingAgent.MISTRAL_VIBE:
+      iconPath = `/agents/mistral-vibe${suffix}.svg`;
       break;
     default:
       return null;

--- a/shared/schemas/mistral_vibe.json
+++ b/shared/schemas/mistral_vibe.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "properties": {
+    "append_prompt": {
+      "title": "Append Prompt",
+      "description": "Extra text appended to the prompt",
+      "type": [
+        "string",
+        "null"
+      ],
+      "format": "textarea",
+      "default": null
+    },
+    "model": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "auto_approve": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "base_command_override": {
+      "title": "Base Command Override",
+      "description": "Override the base command with a custom command",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "additional_params": {
+      "title": "Additional Parameters",
+      "description": "Additional parameters to append to the base command",
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": "string"
+      }
+    },
+    "env": {
+      "title": "Environment Variables",
+      "description": "Environment variables to set when running the executor",
+      "type": [
+        "object",
+        "null"
+      ],
+      "additionalProperties": {
+        "type": "string"
+      }
+    }
+  },
+  "type": "object"
+}

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -573,9 +573,9 @@ working_dir: string | null, };
 
 export type ScriptRequestLanguage = "Bash";
 
-export enum BaseCodingAgent { CLAUDE_CODE = "CLAUDE_CODE", AMP = "AMP", GEMINI = "GEMINI", CODEX = "CODEX", OPENCODE = "OPENCODE", CURSOR_AGENT = "CURSOR_AGENT", QWEN_CODE = "QWEN_CODE", COPILOT = "COPILOT", DROID = "DROID" }
+export enum BaseCodingAgent { CLAUDE_CODE = "CLAUDE_CODE", AMP = "AMP", GEMINI = "GEMINI", CODEX = "CODEX", OPENCODE = "OPENCODE", CURSOR_AGENT = "CURSOR_AGENT", QWEN_CODE = "QWEN_CODE", COPILOT = "COPILOT", DROID = "DROID", MISTRAL_VIBE = "MISTRAL_VIBE" }
 
-export type CodingAgent = { "CLAUDE_CODE": ClaudeCode } | { "AMP": Amp } | { "GEMINI": Gemini } | { "CODEX": Codex } | { "OPENCODE": Opencode } | { "CURSOR_AGENT": CursorAgent } | { "QWEN_CODE": QwenCode } | { "COPILOT": Copilot } | { "DROID": Droid };
+export type CodingAgent = { "CLAUDE_CODE": ClaudeCode } | { "AMP": Amp } | { "GEMINI": Gemini } | { "CODEX": Codex } | { "OPENCODE": Opencode } | { "CURSOR_AGENT": CursorAgent } | { "QWEN_CODE": QwenCode } | { "COPILOT": Copilot } | { "DROID": Droid } | { "MISTRAL_VIBE": MistralVibe };
 
 export type SlashCommandDescription = { 
 /**
@@ -615,7 +615,7 @@ models?: Array<string>,
  */
 reasoning_by_model?: { [key in string]?: string }, };
 
-export type ExecutorProfile = { recently_used_models?: ExecutorRecentModels | null, } & ({ [key in string]?: { "CLAUDE_CODE": ClaudeCode } | { "AMP": Amp } | { "GEMINI": Gemini } | { "CODEX": Codex } | { "OPENCODE": Opencode } | { "CURSOR_AGENT": CursorAgent } | { "QWEN_CODE": QwenCode } | { "COPILOT": Copilot } | { "DROID": Droid } });
+export type ExecutorProfile = { recently_used_models?: ExecutorRecentModels | null, } & ({ [key in string]?: { "CLAUDE_CODE": ClaudeCode } | { "AMP": Amp } | { "GEMINI": Gemini } | { "CODEX": Codex } | { "OPENCODE": Opencode } | { "CURSOR_AGENT": CursorAgent } | { "QWEN_CODE": QwenCode } | { "COPILOT": Copilot } | { "DROID": Droid } | { "MISTRAL_VIBE": MistralVibe } });
 
 export type ExecutorConfigs = { executors: { [key in BaseCodingAgent]?: ExecutorProfile }, };
 
@@ -662,6 +662,8 @@ export type Droid = { append_prompt: AppendPrompt, autonomy: Autonomy, model?: s
 export type Autonomy = "normal" | "low" | "medium" | "high" | "skip-permissions-unsafe";
 
 export type DroidReasoningEffort = "none" | "dynamic" | "off" | "low" | "medium" | "high";
+
+export type MistralVibe = { append_prompt: AppendPrompt, model?: string | null, auto_approve?: boolean | null, base_command_override?: string | null, additional_params?: Array<string> | null, env?: { [key in string]?: string } | null, };
 
 export type AppendPrompt = string | null;
 


### PR DESCRIPTION
## Summary

Add Mistral Vibe as a new ACP-based coding agent executor, following established patterns from Gemini and Qwen. Resumes work from #1876 against the current codebase. Closes #1812.

Also fixes a `client_info` validation error in the ACP harness initialization that benefits all ACP executors (Gemini, Qwen, MistralVibe). Mistral's API rejected requests with empty `client_name`/`client_version` metadata; the fix populates `Implementation` from `CARGO_PKG_VERSION`.

## Changes

- New executor `MistralVibe` in `crates/executors/src/executors/mistral_vibe.rs` with model selection and auto-approve mode (session namespace `vibe_sessions`, MCP config `~/.mistral/vibe/mcp.json`)
- Register variant in `CodingAgent` enum and `mcp_config.rs` (Passthrough adapter)
- Default profiles: `MISTRAL_VIBE`, `MISTRAL_VIBE_DEVSTRAL_SMALL`, `MISTRAL_VIBE_APPROVALS`
- Frontend: `mistral-vibe-{light,dark}.svg` assets + `AgentIcon` switch arms
- Type generation: ts-rs export + JSON schema (`shared/schemas/mistral_vibe.json`)
- ACP harness fix: `InitializeRequest::client_info(Implementation::new("vibe-kanban", env!("CARGO_PKG_VERSION")))`

## Testing

- `cargo check --workspace` passes
- `pnpm run generate-types` regenerates `shared/types.ts` cleanly
- `pnpm run format` + `pnpm run lint` pass
- Manual: tested Mistral Vibe end-to-end after `client_info` fix; prior "metadata value cannot be empty" error resolved

## Related Issues

- Closes #1812
- Refs #1876

## Notes for Reviewer

The `client_info` fix in `crates/executors/src/executors/acp/harness.rs` affects all three ACP executors (Gemini, Qwen, MistralVibe). Worth verifying no regression in Gemini/Qwen sessions.