### PR TITLE
Add crates/remote/starter: one-command local self-host bootstrap

### DIFF
--- a/crates/remote/starter/.gitignore
+++ b/crates/remote/starter/.gitignore
@@ -1,2 +1,0 @@
-backup-*.sql
-.DS_Store

--- a/crates/remote/starter/.gitignore
+++ b/crates/remote/starter/.gitignore
@@ -1,0 +1,2 @@
+backup-*.sql
+.DS_Store

--- a/crates/remote/starter/Makefile
+++ b/crates/remote/starter/Makefile
@@ -8,7 +8,7 @@
 #   make rebuild   → up with --build (pulls in upstream changes)
 #   make logs      → tail remote-server logs
 #   make status    → docker compose ps
-#   make backup    → pg_dump to backup-<timestamp>.sql
+#   make backup    → pg_dump to $SELFHOST_DATA_DIR/backups/<timestamp>.sql
 #   make clean     → tear down and wipe volumes + data dir (destructive)
 
 SHELL := /bin/bash
@@ -80,7 +80,9 @@ status: _ensure_setup
 
 backup: _ensure_setup
 	@. "$(ENV_FILE)" && \
-	  f="backup-$$(date +%Y%m%d-%H%M%S).sql"; \
+	  dest="$$SELFHOST_DATA_DIR/backups" && \
+	  mkdir -p "$$dest" && \
+	  f="$$dest/backup-$$(date +%Y%m%d-%H%M%S).sql" && \
 	  PGPASSWORD=remote pg_dump -h localhost -p "$${REMOTE_DB_PORT:-15433}" -U remote remote > "$$f" && \
 	  echo "wrote $$f"
 

--- a/crates/remote/starter/Makefile
+++ b/crates/remote/starter/Makefile
@@ -1,0 +1,94 @@
+# crates/remote/starter — local self-host operations.
+#
+# Primary entry points:
+#   make start     → docker up + launch frontend app (prompts to run setup if missing)
+#   make up        → just docker (no frontend app); use from a second terminal
+#   make stop      → docker compose down
+#   make restart   → stop + up (docker only, no frontend relaunch)
+#   make rebuild   → up with --build (pulls in upstream changes)
+#   make logs      → tail remote-server logs
+#   make status    → docker compose ps
+#   make backup    → pg_dump to backup-<timestamp>.sql
+#   make clean     → tear down and wipe volumes + data dir (destructive)
+
+SHELL := /bin/bash
+
+# Resolved at parse time from this Makefile's location (crates/remote/starter/).
+VK_REPO_ROOT := $(abspath $(CURDIR)/../../..)
+COMPOSE_DIR := $(abspath $(CURDIR)/..)
+ENV_FILE := $(VK_REPO_ROOT)/.env.remote
+
+COMPOSE := docker compose \
+  -f $(COMPOSE_DIR)/docker-compose.yml \
+  -f $(CURDIR)/docker-compose.override.yml \
+  -f $(CURDIR)/docker-compose.ports.yml \
+  -f $(CURDIR)/docker-compose.no-ssh.yml \
+  --env-file $(ENV_FILE)
+
+.DEFAULT_GOAL := help
+.PHONY: help setup start up stop restart rebuild logs status backup clean _ensure_setup
+
+help:
+	@awk 'NR==1,/^$$/ { if (/^#/) { sub(/^#[[:space:]]?/, ""); print } }' $(MAKEFILE_LIST)
+
+setup:
+	@./setup.sh
+
+# Guard: if .env.remote isn't there yet, offer to run setup. Safe to chain
+# before any recipe that touches docker.
+_ensure_setup:
+	@if [ ! -f $(ENV_FILE) ]; then \
+	  read -rp "Stack isn't configured yet. Run 'make setup' now? [Y/n] " ans; \
+	  case "$$ans" in n|N) echo "aborted"; exit 1 ;; esac; \
+	  ./setup.sh; \
+	fi
+
+up: _ensure_setup
+	@cd "$(COMPOSE_DIR)" && \
+	  if docker images -q remote-remote-server 2>/dev/null | grep -q .; then \
+	    $(COMPOSE) up -d; \
+	  else \
+	    echo "first start — building images (~10-15 min)..."; \
+	    $(COMPOSE) up -d --build; \
+	  fi
+	@. "$(ENV_FILE)" && \
+	  echo "" && \
+	  echo "Backend up at http://localhost:$${REMOTE_SERVER_PORT:-13000}" && \
+	  grep -E '^SELF_HOST_LOCAL_AUTH_(EMAIL|PASSWORD)=' "$(ENV_FILE)" | sed 's/^/  /'
+
+start: up
+	@. "$(ENV_FILE)" && \
+	  echo "" && \
+	  echo "Launching frontend app at http://localhost:$${FRONTEND_PORT:-13333} (Ctrl+C exits; docker stays up — use 'make stop' after)..." && \
+	  VK_SHARED_API_BASE=http://localhost:$${REMOTE_SERVER_PORT:-13000} \
+	    PORT=$${FRONTEND_PORT:-13333} \
+	    npx -y vibe-kanban@latest
+
+stop: _ensure_setup
+	@cd "$(COMPOSE_DIR)" && $(COMPOSE) down
+
+restart: stop up
+
+rebuild: _ensure_setup
+	@cd "$(COMPOSE_DIR)" && $(COMPOSE) up -d --build
+
+logs: _ensure_setup
+	@cd "$(COMPOSE_DIR)" && $(COMPOSE) logs -f remote-server
+
+status: _ensure_setup
+	@cd "$(COMPOSE_DIR)" && $(COMPOSE) ps
+
+backup: _ensure_setup
+	@. "$(ENV_FILE)" && \
+	  f="backup-$$(date +%Y%m%d-%H%M%S).sql"; \
+	  PGPASSWORD=remote pg_dump -h localhost -p "$${REMOTE_DB_PORT:-15433}" -U remote remote > "$$f" && \
+	  echo "wrote $$f"
+
+clean: _ensure_setup
+	@. "$(ENV_FILE)" && \
+	  read -rp "Destroy all data (volumes + $$SELFHOST_DATA_DIR + $(ENV_FILE))? [y/N] " ans; \
+	  case "$$ans" in y|Y) ;; *) echo "aborted"; exit 1 ;; esac; \
+	  cd "$(COMPOSE_DIR)" && $(COMPOSE) down -v; \
+	  rm -rf "$$SELFHOST_DATA_DIR"; \
+	  rm -f "$(ENV_FILE)"; \
+	  echo "wiped $$SELFHOST_DATA_DIR, removed $(ENV_FILE)"

--- a/crates/remote/starter/README.md
+++ b/crates/remote/starter/README.md
@@ -1,12 +1,21 @@
 # crates/remote/starter
 
 Opinionated one-command bootstrap for running a local self-hosted Vibe Kanban
-remote (Postgres + Electric + remote-server) on top of `crates/remote/docker-compose.yml`,
-with a frontend app pointed at it.
+remote (Postgres + Electric + remote-server) on top of
+`crates/remote/docker-compose.yml`, with a frontend app pointed at it.
 
 Single-user, local-only. Bootstrap admin login (no OAuth wiring required).
 Layered on top of upstream compose via `-f` overrides — does not modify the
 base `docker-compose.yml`.
+
+## Prerequisites
+
+- Docker Engine with the `compose` plugin (Docker Desktop, OrbStack, Colima,
+  Rancher Desktop, or a plain `docker.io` install). `docker compose version`
+  should print `v2.x`.
+- `make`, `bash`, `git`, `openssl`, `sed`, `grep` — standard on Linux and
+  macOS, available via your package manager.
+- Windows: run from WSL.
 
 ## Quickstart
 
@@ -32,20 +41,21 @@ When it's up you'll have:
 
 ## Defaults
 
-Defaults are picked to avoid common port conflicts on Windows / Hyper-V / WSL,
-where 3000-3009 and 5432-5433 can be dynamically reserved at boot:
+Defaults are picked to avoid common port conflicts. Hyper-V / WSL2 can
+dynamically reserve `3000-3009` and `5432-5433` at boot, so the starter
+defaults to ports outside those ranges:
 
 | | default |
 |---|---|
 | Backend host port | `13000` |
 | Frontend host port | `13333` |
 | Postgres host port | `15433` |
-| Data dir | `~/vibe-kanban-data` |
+| Data dir | `$HOME/vibe-kanban-data` |
 | Admin email | `admin@local` |
 | Admin password | randomly generated, in `.env.remote` |
 
-Everything is overridable interactively or by editing `.env.remote` after the
-fact.
+Everything is overridable interactively at setup time or by editing
+`.env.remote` after the fact.
 
 ## Make targets
 
@@ -56,14 +66,14 @@ fact.
 | `make up` | Bring docker up only. Useful from a second terminal. |
 | `make stop` | `docker compose down` |
 | `make restart` | stop + up (docker only, doesn't re-spawn the frontend app) |
-| `make rebuild` | `up -d --build` — pulls in upstream changes |
+| `make rebuild` | `up -d --build` — picks up upstream code or compose changes |
 | `make logs` | tail `remote-server` logs |
 | `make status` | `docker compose ps` |
-| `make backup` | `pg_dump` into `crates/remote/starter/backup-<timestamp>.sql` |
+| `make backup` | `pg_dump` into `$SELFHOST_DATA_DIR/backups/backup-<timestamp>.sql` |
 | `make clean` | Destroy volumes + data dir + `.env.remote` (asks for confirmation) |
 
-`./setup.sh -y` skips all prompts and uses defaults (handy for CI or
-re-provisioning).
+`./setup.sh -y` skips all prompts and uses defaults — handy for CI or
+re-provisioning.
 
 ## Files in this directory
 
@@ -73,7 +83,7 @@ re-provisioning).
 | `setup.sh` | One-shot configurator. Writes `<repo>/.env.remote` and runs `docker compose config` to validate the merge. |
 | `env.remote.template` | Template with `__PLACEHOLDERS__` filled in by `setup.sh`. |
 | `docker-compose.override.yml` | Bind-mounts `postgres/` and `electric/` data dirs under `SELFHOST_DATA_DIR`. |
-| `docker-compose.ports.yml` | Pins host ports to Windows-safe ranges via `REMOTE_SERVER_PORT`, `REMOTE_DB_PORT`. |
+| `docker-compose.ports.yml` | Pins host ports to safer defaults via `REMOTE_SERVER_PORT`, `REMOTE_DB_PORT`. |
 | `docker-compose.no-ssh.yml` | Removes upstream's build-time SSH agent forwarding — not needed when `FEATURES` is empty, and fails on machines without an SSH agent. |
 
 ## Caveats
@@ -85,8 +95,6 @@ re-provisioning).
   cannot reach your instance.
 - **Attachments disabled.** The Azurite profile is not enabled here. Issue
   attachments won't work until you enable that profile and add the env vars.
-- **Linux/macOS focus.** The Makefile assumes GNU/BSD make + a POSIX shell.
-  On Windows, run from WSL.
 
 ## Troubleshooting
 
@@ -94,8 +102,8 @@ re-provisioning).
 the `electric_sync` Postgres role on first startup, Electric retries until it
 succeeds. Wait ~30s or `make logs` and watch.
 
-**Frontend app shows your old hosted-cloud data.** Sign out of the old cloud
-account first, quit the app. `make start` always launches with
+**Frontend app shows the hosted-cloud data instead of local.** Sign out of the
+old cloud account first, quit the app. `make start` always launches with
 `VK_SHARED_API_BASE` pointed at your local backend.
 
 **Want a fresh start.** `make clean` tears everything down (asks first), then

--- a/crates/remote/starter/README.md
+++ b/crates/remote/starter/README.md
@@ -1,0 +1,105 @@
+# crates/remote/starter
+
+Opinionated one-command bootstrap for running a local self-hosted Vibe Kanban
+remote (Postgres + Electric + remote-server) on top of `crates/remote/docker-compose.yml`,
+with a frontend app pointed at it.
+
+Single-user, local-only. Bootstrap admin login (no OAuth wiring required).
+Layered on top of upstream compose via `-f` overrides — does not modify the
+base `docker-compose.yml`.
+
+## Quickstart
+
+```bash
+cd crates/remote/starter
+make start
+```
+
+`make start` detects there's no `.env.remote` yet, prompts to run setup,
+generates secrets, brings docker up, and launches the frontend app pointed at
+your local backend. First build is ~10-15 min (Rust + Vite frontend); restarts
+are seconds.
+
+When it's up you'll have:
+
+- **Backend** at `http://localhost:13000` (configurable). Bootstrap admin
+  credentials are printed to the terminal and persisted in `<repo>/.env.remote`.
+- **Frontend app** at `http://localhost:13333` (configurable), running in the
+  foreground. Ctrl+C exits the app; docker stays up. `make stop` to take the
+  backend down.
+- **Postgres + Electric** data bind-mounted to `~/vibe-kanban-data` (or
+  wherever you pointed `SELFHOST_DATA_DIR`).
+
+## Defaults
+
+Defaults are picked to avoid common port conflicts on Windows / Hyper-V / WSL,
+where 3000-3009 and 5432-5433 can be dynamically reserved at boot:
+
+| | default |
+|---|---|
+| Backend host port | `13000` |
+| Frontend host port | `13333` |
+| Postgres host port | `15433` |
+| Data dir | `~/vibe-kanban-data` |
+| Admin email | `admin@local` |
+| Admin password | randomly generated, in `.env.remote` |
+
+Everything is overridable interactively or by editing `.env.remote` after the
+fact.
+
+## Make targets
+
+| target | what it does |
+|---|---|
+| `make setup` | Prompts for ports / data dir / admin email. Generates JWT + admin password. Writes `<repo>/.env.remote`. Idempotent — preserves existing secrets. |
+| `make start` | `up` + launch the frontend app in the foreground. Prompts to run setup first if needed. |
+| `make up` | Bring docker up only. Useful from a second terminal. |
+| `make stop` | `docker compose down` |
+| `make restart` | stop + up (docker only, doesn't re-spawn the frontend app) |
+| `make rebuild` | `up -d --build` — pulls in upstream changes |
+| `make logs` | tail `remote-server` logs |
+| `make status` | `docker compose ps` |
+| `make backup` | `pg_dump` into `crates/remote/starter/backup-<timestamp>.sql` |
+| `make clean` | Destroy volumes + data dir + `.env.remote` (asks for confirmation) |
+
+`./setup.sh -y` skips all prompts and uses defaults (handy for CI or
+re-provisioning).
+
+## Files in this directory
+
+| file | purpose |
+|---|---|
+| `Makefile` | User-facing entry point. Layers the four compose files for every docker call. |
+| `setup.sh` | One-shot configurator. Writes `<repo>/.env.remote` and runs `docker compose config` to validate the merge. |
+| `env.remote.template` | Template with `__PLACEHOLDERS__` filled in by `setup.sh`. |
+| `docker-compose.override.yml` | Bind-mounts `postgres/` and `electric/` data dirs under `SELFHOST_DATA_DIR`. |
+| `docker-compose.ports.yml` | Pins host ports to Windows-safe ranges via `REMOTE_SERVER_PORT`, `REMOTE_DB_PORT`. |
+| `docker-compose.no-ssh.yml` | Removes upstream's build-time SSH agent forwarding — not needed when `FEATURES` is empty, and fails on machines without an SSH agent. |
+
+## Caveats
+
+- **No OAuth.** Single shared bootstrap credential pair. Configure OAuth in
+  `.env.remote` if you need multi-user.
+- **No relay / tunnel.** The frontend app on `FRONTEND_PORT` talks to the
+  backend on `REMOTE_SERVER_PORT` directly. Other machines on your network
+  cannot reach your instance.
+- **Attachments disabled.** The Azurite profile is not enabled here. Issue
+  attachments won't work until you enable that profile and add the env vars.
+- **Linux/macOS focus.** The Makefile assumes GNU/BSD make + a POSIX shell.
+  On Windows, run from WSL.
+
+## Troubleshooting
+
+**Electric can't connect on first boot.** Expected — the remote server creates
+the `electric_sync` Postgres role on first startup, Electric retries until it
+succeeds. Wait ~30s or `make logs` and watch.
+
+**Frontend app shows your old hosted-cloud data.** Sign out of the old cloud
+account first, quit the app. `make start` always launches with
+`VK_SHARED_API_BASE` pointed at your local backend.
+
+**Want a fresh start.** `make clean` tears everything down (asks first), then
+`make start` re-provisions from scratch.
+
+**Existing port collision.** Edit `REMOTE_SERVER_PORT`, `FRONTEND_PORT`, or
+`REMOTE_DB_PORT` in `.env.remote` and `make restart`.

--- a/crates/remote/starter/docker-compose.no-ssh.yml
+++ b/crates/remote/starter/docker-compose.no-ssh.yml
@@ -1,0 +1,8 @@
+# Remove upstream build-time SSH agent forwarding for the local self-host build.
+# The private `billing` crate is stripped when FEATURES is empty, so the
+# default starter path does not need a host SSH agent. Disabling this also
+# avoids failures on machines that don't have an SSH agent running.
+services:
+  remote-server:
+    build:
+      ssh: !reset []

--- a/crates/remote/starter/docker-compose.override.yml
+++ b/crates/remote/starter/docker-compose.override.yml
@@ -1,0 +1,10 @@
+# Bind-mount postgres + electric data dirs onto the host so the data
+# survives Docker VM wipes / `docker volume prune`.
+services:
+  remote-db:
+    volumes:
+      - ${SELFHOST_DATA_DIR}/postgres:/var/lib/postgresql/data
+
+  electric:
+    volumes:
+      - ${SELFHOST_DATA_DIR}/electric:/app/persistent

--- a/crates/remote/starter/docker-compose.ports.yml
+++ b/crates/remote/starter/docker-compose.ports.yml
@@ -1,0 +1,11 @@
+# Keep host-facing ports local and outside common Windows reserved ranges.
+# Windows / Hyper-V / WSL2 can dynamically reserve low ports like 3000-3009 and
+# 5432-5433 at boot, which conflicts with the upstream defaults.
+services:
+  remote-db:
+    ports: !override
+      - "127.0.0.1:${REMOTE_DB_PORT:-15433}:5432"
+
+  remote-server:
+    ports: !override
+      - "127.0.0.1:${REMOTE_SERVER_PORT:-13000}:8081"

--- a/crates/remote/starter/env.remote.template
+++ b/crates/remote/starter/env.remote.template
@@ -1,0 +1,28 @@
+# Self-host config for Vibe Kanban remote (crates/remote/docker-compose.yml +
+# crates/remote/starter/docker-compose.*.yml overrides). Populated by setup.sh;
+# edit values here if you need to change them later.
+
+# --- Required secrets ---
+VIBEKANBAN_REMOTE_JWT_SECRET=__JWT_SECRET__
+ELECTRIC_ROLE_PASSWORD=remote
+
+# --- Host ports (local only) ---
+# Defaults avoid the low 3000s and 5433 because Windows / Hyper-V / WSL can
+# reserve them at boot. Override here if needed.
+REMOTE_SERVER_PORT=__REMOTE_SERVER_PORT__
+FRONTEND_PORT=__FRONTEND_PORT__
+REMOTE_DB_PORT=__REMOTE_DB_PORT__
+
+# --- Public URL (local only) ---
+PUBLIC_BASE_URL=http://localhost:__REMOTE_SERVER_PORT__
+
+# --- Bootstrap admin login (no OAuth) ---
+SELF_HOST_LOCAL_AUTH_EMAIL=__ADMIN_EMAIL__
+SELF_HOST_LOCAL_AUTH_PASSWORD=__ADMIN_PASSWORD__
+
+# --- Frontend build arg (unused locally, keep empty) ---
+VITE_RELAY_API_BASE_URL=
+
+# --- Persistent data dir on host (consumed by docker-compose.override.yml) ---
+# Bind-mounts Postgres + Electric onto host disk so data survives Docker VM wipes.
+SELFHOST_DATA_DIR=__DATA_DIR__

--- a/crates/remote/starter/setup.sh
+++ b/crates/remote/starter/setup.sh
@@ -73,7 +73,7 @@ for cmd in docker git openssl; do
   fi
 done
 if ! docker info >/dev/null 2>&1; then
-  echo "error: docker daemon is not running (start OrbStack / Docker Desktop)" >&2
+  echo "error: docker daemon is not running (start your Docker engine)" >&2
   exit 1
 fi
 

--- a/crates/remote/starter/setup.sh
+++ b/crates/remote/starter/setup.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# setup.sh — configure a local self-hosted Vibe Kanban stack.
+#
+# Lives inside the repo at crates/remote/starter/, so the checkout you're
+# running it from IS the Vibe Kanban it configures. Generates JWT + admin
+# secrets, prompts for host ports + data dir, writes .env.remote at the
+# repo root.
+#
+# Does NOT start docker — use `make start` for that.
+#
+# Flags:
+#   -y, --yes    non-interactive; accept all defaults
+#   -h, --help   this message
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VK_REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+# ---- Flags -------------------------------------------------------------------
+NONINTERACTIVE=0
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -y|--yes)    NONINTERACTIVE=1 ;;
+    -h|--help)   sed -n '2,13p' "${BASH_SOURCE[0]}" | sed 's/^#[[:space:]]*//'; exit 0 ;;
+    *)           echo "unknown flag: $1" >&2; exit 2 ;;
+  esac
+  shift
+done
+
+# ---- Defaults ----------------------------------------------------------------
+DATA_DIR_DEFAULT="$HOME/vibe-kanban-data"
+ADMIN_EMAIL_DEFAULT="admin@local"
+# Default ports avoid low 3000s and 5433 because Windows / Hyper-V / WSL can
+# reserve them at boot.
+REMOTE_SERVER_PORT_DEFAULT="13000"
+FRONTEND_PORT_DEFAULT="13333"
+REMOTE_DB_PORT_DEFAULT="15433"
+
+ask() {
+  local prompt="$1" default="$2" var
+  if [[ "$NONINTERACTIVE" == 1 ]]; then
+    printf '%s\n' "$default"
+    return
+  fi
+  read -rp "$prompt [$default]: " var
+  printf '%s\n' "${var:-$default}"
+}
+
+env_value_or_default() {
+  local path="$1" name="$2" default="$3"
+  if [[ -f "$path" ]]; then
+    grep "^${name}=" "$path" | tail -n 1 | cut -d= -f2- || printf '%s\n' "$default"
+  else
+    printf '%s\n' "$default"
+  fi
+}
+
+upsert_env() {
+  local path="$1" name="$2" value="$3"
+  if grep -q "^${name}=" "$path"; then
+    sed -i.bak "s|^${name}=.*|${name}=${value}|" "$path" && rm -f "$path.bak"
+  else
+    printf '%s=%s\n' "$name" "$value" >> "$path"
+  fi
+}
+
+# ---- Prereqs -----------------------------------------------------------------
+for cmd in docker git openssl; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "error: '$cmd' is required but not installed" >&2
+    exit 1
+  fi
+done
+if ! docker info >/dev/null 2>&1; then
+  echo "error: docker daemon is not running (start OrbStack / Docker Desktop)" >&2
+  exit 1
+fi
+
+# ---- Prompts -----------------------------------------------------------------
+ENV_PATH="$VK_REPO_ROOT/.env.remote"
+
+DATA_DIR_PREV="$(env_value_or_default "$ENV_PATH" SELFHOST_DATA_DIR "$DATA_DIR_DEFAULT")"
+ADMIN_EMAIL_PREV="$(env_value_or_default "$ENV_PATH" SELF_HOST_LOCAL_AUTH_EMAIL "$ADMIN_EMAIL_DEFAULT")"
+REMOTE_SERVER_PORT_PREV="$(env_value_or_default "$ENV_PATH" REMOTE_SERVER_PORT "$REMOTE_SERVER_PORT_DEFAULT")"
+FRONTEND_PORT_PREV="$(env_value_or_default "$ENV_PATH" FRONTEND_PORT "$FRONTEND_PORT_DEFAULT")"
+REMOTE_DB_PORT_PREV="$(env_value_or_default "$ENV_PATH" REMOTE_DB_PORT "$REMOTE_DB_PORT_DEFAULT")"
+
+DATA_DIR="$(ask 'Persistent data dir' "$DATA_DIR_PREV")"
+ADMIN_EMAIL="$(ask 'Admin email' "$ADMIN_EMAIL_PREV")"
+REMOTE_SERVER_PORT="$(ask 'Backend host port' "$REMOTE_SERVER_PORT_PREV")"
+FRONTEND_PORT="$(ask 'Frontend host port' "$FRONTEND_PORT_PREV")"
+REMOTE_DB_PORT="$(ask 'Postgres host port' "$REMOTE_DB_PORT_PREV")"
+
+# ---- Write .env.remote -------------------------------------------------------
+if [[ -f "$ENV_PATH" ]]; then
+  echo "[1/3] $ENV_PATH exists — preserving secrets, updating ports/dirs"
+  ADMIN_PASSWORD=$(grep '^SELF_HOST_LOCAL_AUTH_PASSWORD=' "$ENV_PATH" | cut -d= -f2- || echo "<existing>")
+  upsert_env "$ENV_PATH" SELFHOST_DATA_DIR "$DATA_DIR"
+  upsert_env "$ENV_PATH" SELF_HOST_LOCAL_AUTH_EMAIL "$ADMIN_EMAIL"
+  upsert_env "$ENV_PATH" REMOTE_SERVER_PORT "$REMOTE_SERVER_PORT"
+  upsert_env "$ENV_PATH" FRONTEND_PORT "$FRONTEND_PORT"
+  upsert_env "$ENV_PATH" REMOTE_DB_PORT "$REMOTE_DB_PORT"
+  upsert_env "$ENV_PATH" PUBLIC_BASE_URL "http://localhost:$REMOTE_SERVER_PORT"
+else
+  JWT_SECRET="$(openssl rand -base64 48)"
+  ADMIN_PASSWORD="$(openssl rand -base64 18 | tr -d '/+=' | head -c 24)"
+  sed \
+    -e "s|__JWT_SECRET__|$JWT_SECRET|" \
+    -e "s|__REMOTE_SERVER_PORT__|$REMOTE_SERVER_PORT|" \
+    -e "s|__FRONTEND_PORT__|$FRONTEND_PORT|" \
+    -e "s|__REMOTE_DB_PORT__|$REMOTE_DB_PORT|" \
+    -e "s|__ADMIN_EMAIL__|$ADMIN_EMAIL|" \
+    -e "s|__ADMIN_PASSWORD__|$ADMIN_PASSWORD|" \
+    -e "s|__DATA_DIR__|$DATA_DIR|" \
+    "$SCRIPT_DIR/env.remote.template" > "$ENV_PATH"
+  chmod 600 "$ENV_PATH"
+  echo "[1/3] wrote $ENV_PATH"
+fi
+
+# ---- Create data dirs --------------------------------------------------------
+mkdir -p "$DATA_DIR/postgres" "$DATA_DIR/electric"
+echo "[2/3] ensured data dirs under $DATA_DIR"
+
+# ---- Validate merged compose config -----------------------------------------
+( cd "$VK_REPO_ROOT/crates/remote" && \
+  docker compose \
+    -f docker-compose.yml \
+    -f "$SCRIPT_DIR/docker-compose.override.yml" \
+    -f "$SCRIPT_DIR/docker-compose.ports.yml" \
+    -f "$SCRIPT_DIR/docker-compose.no-ssh.yml" \
+    --env-file "$ENV_PATH" \
+    config >/dev/null )
+echo "[3/3] docker compose config validated"
+
+# ---- Next steps --------------------------------------------------------------
+cat <<EOF
+
+Setup complete.
+
+  Start the stack:
+    make start
+
+  Backend/project-management UI: http://localhost:$REMOTE_SERVER_PORT
+    email:    $ADMIN_EMAIL
+    password: $ADMIN_PASSWORD
+  (Both are in $ENV_PATH if you need them later.)
+
+  Or launch the frontend app yourself:
+    VK_SHARED_API_BASE=http://localhost:$REMOTE_SERVER_PORT \\
+      PORT=$FRONTEND_PORT npx vibe-kanban@latest
+
+  All ops:  make help
+EOF


### PR DESCRIPTION
A small, self-contained scaffold under `crates/remote/starter/` that gives
people a single `make start` path to a working local self-hosted Vibe Kanban,
without modifying anything in the base `crates/remote/docker-compose.yml`.

Posting as a draft to gauge interest / placement / scope before polishing.

## What it adds

```
crates/remote/starter/
├── Makefile
├── README.md
├── setup.sh
├── env.remote.template
├── docker-compose.override.yml   # bind-mount Postgres + Electric data dirs
├── docker-compose.ports.yml      # Windows-safe host ports (13000/13333/15433)
├── docker-compose.no-ssh.yml     # drop build-time SSH agent forwarding
└── .gitignore
```

All four compose files are layered via `-f` flags from the Makefile — the
base `crates/remote/docker-compose.yml` is **not modified**. If this dir is
deleted, nothing else changes.

## Why this and not just docs

The existing `docs/self-hosting/local-development.mdx` walks through the same
moving parts (JWT secret generation, `.env.remote`, port mapping, OAuth-or-bootstrap
auth, desktop client pointed at `VK_SHARED_API_BASE`), but as prose. This is the
same flow, scripted, with sensible defaults:

- **Windows-safe ports out of the box.** Hyper-V / WSL2 commonly reserve
  3000-3009 and 5432-5433 dynamically at boot; defaulting to 13000 / 13333 /
  15433 avoids the surprise.
- **SSH-agent forwarding off by default.** The build only needs `ssh:` for
  the private `billing` crate; with `FEATURES` empty, removing the SSH mount
  also makes the build work on machines without an SSH agent.
- **Bind-mounted data dirs** under `SELFHOST_DATA_DIR` so `docker volume
  prune` or a Docker VM wipe doesn't take Postgres with it.
- **Random admin password** generated into `.env.remote` (mode `0600`).
  `make start` prints the credentials each time it brings the stack up.
- **Idempotent setup.** Re-running `setup.sh` preserves the generated JWT
  and admin password, only updates ports / data dir / email.

## Usage

```bash
cd crates/remote/starter
make start    # ~10-15 min first build, seconds after
```

`make start` notices there's no `.env.remote` yet, prompts to run setup,
generates secrets, brings docker up, and launches the frontend app
(`npx vibe-kanban@latest`) in the foreground pointed at `localhost:13000`.

Day-to-day:

| | |
|---|---|
| `make stop` | `docker compose down` |
| `make restart` | stop + up |
| `make rebuild` | `up --build` (pulls in upstream changes) |
| `make logs` | tail `remote-server` |
| `make status` | `docker compose ps` |
| `make backup` | `pg_dump` to `backup-<timestamp>.sql` |
| `make clean` | tear down + wipe volumes + data dir (asks) |

`./setup.sh -y` skips all prompts and accepts defaults (CI / re-provisioning).

## Scope

Single-user, local-only. Doesn't try to do OAuth, relay/tunnel, or
attachments — those stay configurable via `.env.remote` and the existing
profiles. Linux/macOS focus; Windows users should run from WSL.

## Happy to adjust

If `crates/remote/starter/` isn't the right place, easy to move (e.g. a
top-level `self-host/`, under `docs/self-hosting/starter/`, or kept out of
tree entirely as a separate repo). Same goes for the scope — could keep
only the script + remove the Makefile, or vice versa.