### PR TITLE
fix: exclude ambiguous characters from relay pairing codes

### DIFF
--- a/crates/trusted-key-auth/src/spake2.rs
+++ b/crates/trusted-key-auth/src/spake2.rs
@@ -7,7 +7,8 @@ use crate::error::TrustedKeyAuthError;
 const SPAKE2_CLIENT_ID: &[u8] = b"vibe-kanban-browser";
 const SPAKE2_SERVER_ID: &[u8] = b"vibe-kanban-server";
 pub const ENROLLMENT_CODE_LENGTH: usize = 6;
-const ENROLLMENT_CODE_CHARSET: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+// Excludes visually ambiguous characters: O (vs 0), I (vs 1), L (vs 1), U (vs V)
+const ENROLLMENT_CODE_CHARSET: &[u8] = b"ABCDEFGHJKMNPQRSTVWXYZ0123456789";
 
 #[derive(Debug)]
 pub struct Spake2StartOutcome {
@@ -68,6 +69,15 @@ pub fn normalize_enrollment_code(raw_code: &str) -> Result<String, TrustedKeyAut
         ));
     }
 
+    // Map visually ambiguous characters to their intended equivalents.
+    // New codes no longer contain O/I/L/U, but users may still type them
+    // when reading a code displayed in a font where 0≈O or 1≈I≈L.
+    let code = code
+        .replace('O', "0")
+        .replace('I', "1")
+        .replace('L', "1")
+        .replace('U', "V");
+
     Ok(code)
 }
 
@@ -98,7 +108,31 @@ mod tests {
         assert_eq!(code.len(), ENROLLMENT_CODE_LENGTH);
         assert!(
             code.bytes()
-                .all(|byte| byte.is_ascii_uppercase() || byte.is_ascii_digit())
+                .all(|byte| ENROLLMENT_CODE_CHARSET.contains(&byte))
         );
+    }
+
+    #[test]
+    fn generate_one_time_code_excludes_ambiguous_characters() {
+        // Generate many codes and verify none contain O, I, L, or U
+        for _ in 0..1000 {
+            let code = generate_one_time_code();
+            assert!(!code.contains('O'), "Code should not contain 'O': {code}");
+            assert!(!code.contains('I'), "Code should not contain 'I': {code}");
+            assert!(!code.contains('L'), "Code should not contain 'L': {code}");
+            assert!(!code.contains('U'), "Code should not contain 'U': {code}");
+        }
+    }
+
+    #[test]
+    fn normalize_enrollment_code_maps_ambiguous_characters() {
+        // O → 0
+        assert_eq!(normalize_enrollment_code("ABO1Z9").unwrap(), "AB01Z9");
+        // I → 1
+        assert_eq!(normalize_enrollment_code("ABI2Z9").unwrap(), "AB12Z9");
+        // L → 1
+        assert_eq!(normalize_enrollment_code("ABL2Z9").unwrap(), "AB12Z9");
+        // U → V
+        assert_eq!(normalize_enrollment_code("ABU2Z9").unwrap(), "ABV2Z9");
     }
 }

--- a/packages/web-core/src/shared/lib/relayPake.ts
+++ b/packages/web-core/src/shared/lib/relayPake.ts
@@ -34,7 +34,13 @@ export function normalizeEnrollmentCode(rawCode: string): string {
   return rawCode
     .trim()
     .toUpperCase()
-    .replace(/[^A-Z0-9]/g, '');
+    .replace(/[^A-Z0-9]/g, '')
+    // Map visually ambiguous characters to their intended equivalents.
+    // New codes no longer contain O/I/L/U, but users may still type them.
+    .replace(/O/g, '0')
+    .replace(/I/g, '1')
+    .replace(/L/g, '1')
+    .replace(/U/g, 'V');
 }
 
 export async function startSpake2Enrollment(


### PR DESCRIPTION
﻿## Summary

- **Removes visually ambiguous characters** (`O`, `I`, `L`, `U`) from `ENROLLMENT_CODE_CHARSET` to prevent mistyping relay pairing codes
- **Adds fallback normalization** in both backend (Rust) and frontend (TypeScript) to map commonly confused characters: `O`->`0`, `I`->`1`, `L`->`1`, `U`->`V`
- Uses a Crockford Base32-inspired alphabet that avoids character pairs that look identical in most monospace fonts

## Problem

The current charset includes characters that are visually indistinguishable in many fonts (e.g., `O` vs `0`, `I` vs `1`, `L` vs `1`). When a user mistypes one of these, the one-time code is silently consumed and returns "Unauthorized", requiring a fresh code.

## Changes

| File | Change |
|------|--------|
| `crates/trusted-key-auth/src/spake2.rs` | Updated `ENROLLMENT_CODE_CHARSET` to exclude `O`, `I`, `L`, `U`; added normalization mapping in `normalize_enrollment_code()`; added tests |
| `packages/web-core/src/shared/lib/relayPake.ts` | Added matching normalization in `normalizeEnrollmentCode()` |

## Charset

Before: `ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789` (36 chars)
After: `ABCDEFGHJKMNPQRSTVWXYZ0123456789` (32 chars)

Removed: `I` (looks like `1`), `L` (looks like `1`), `O` (looks like `0`), `U` (looks like `V`)

Entropy impact: 6-character code goes from 36^6 (2.18B) to 32^6 (1.07B) — still well above brute-force threshold for a one-time code.

Fixes #3359

## Test plan

- [ ] `cargo test -p trusted-key-auth` — verify new and existing tests pass
- [ ] Generate 1000+ codes and verify none contain `O`, `I`, `L`, or `U`
- [ ] Type a code containing `O` on the frontend — verify it normalizes to `0`
- [ ] Pair a device using the new charset — verify pairing succeeds
