### PR TITLE
feat: add start_date and target_date to update_issue MCP tool

### DIFF
--- a/crates/mcp/Cargo.toml
+++ b/crates/mcp/Cargo.toml
@@ -29,4 +29,5 @@ sentry = { version = "0.46.2", default-features = false, features = ["anyhow", "
 reqwest = { workspace = true }
 rustls = { workspace = true }
 regex = "1"
+chrono = { version = "0.4", features = ["serde"] }
 thiserror = { workspace = true }

--- a/crates/mcp/src/task_server/tools/remote_issues.rs
+++ b/crates/mcp/src/task_server/tools/remote_issues.rs
@@ -216,6 +216,14 @@ struct McpUpdateIssueRequest {
         description = "Parent issue ID to set this as a subissue. Pass null to un-nest from parent."
     )]
     parent_issue_id: Option<Option<Uuid>>,
+    #[schemars(
+        description = "Start date for the issue as an ISO 8601 date string (e.g. '2025-06-01T00:00:00Z'). Pass null to clear."
+    )]
+    start_date: Option<Option<String>>,
+    #[schemars(
+        description = "Target/due date for the issue as an ISO 8601 date string (e.g. '2025-06-15T00:00:00Z'). Pass null to clear."
+    )]
+    target_date: Option<Option<String>>,
 }
 
 #[derive(Debug, Serialize, schemars::JsonSchema)]
@@ -492,6 +500,8 @@ impl McpServer {
             status,
             priority,
             parent_issue_id,
+            start_date,
+            target_date,
         }): Parameters<McpUpdateIssueRequest>,
     ) -> Result<CallToolResult, ErrorData> {
         // First get the issue to know its project_id for status resolution
@@ -529,13 +539,39 @@ impl McpServer {
             None
         };
 
+        // Parse optional date strings into DateTime<Utc>
+        let start_date = match start_date {
+            Some(Some(s)) => match s.parse::<chrono::DateTime<chrono::Utc>>() {
+                Ok(dt) => Some(Some(dt)),
+                Err(_) => {
+                    return Ok(McpServer::tool_error(ToolError::message(format!(
+                        "Invalid start_date format. Expected ISO 8601 (e.g. '2025-06-01T00:00:00Z'), got: {s}"
+                    ))))
+                }
+            },
+            Some(None) => Some(None), // explicitly clear the date
+            None => None,             // not provided, don't change
+        };
+        let target_date = match target_date {
+            Some(Some(s)) => match s.parse::<chrono::DateTime<chrono::Utc>>() {
+                Ok(dt) => Some(Some(dt)),
+                Err(_) => {
+                    return Ok(McpServer::tool_error(ToolError::message(format!(
+                        "Invalid target_date format. Expected ISO 8601 (e.g. '2025-06-15T00:00:00Z'), got: {s}"
+                    ))))
+                }
+            },
+            Some(None) => Some(None),
+            None => None,
+        };
+
         let payload = UpdateIssueRequest {
             status_id,
             title,
             description: expanded_description,
             priority,
-            start_date: None,
-            target_date: None,
+            start_date,
+            target_date,
             completed_at: None,
             sort_order: None,
             parent_issue_id,


### PR DESCRIPTION
﻿## Summary

- **Adds `start_date` and `target_date` parameters** to the `update_issue` MCP tool
- The `get_issue` tool already returns these fields, but `update_issue` previously hardcoded them to `None` — dates were readable via MCP but not writable
- Both parameters accept ISO 8601 date strings (e.g. `2025-06-15T00:00:00Z`) or `null` to clear

## Changes

| File | Change |
|------|--------|
| `crates/mcp/Cargo.toml` | Added `chrono` dependency for date parsing |
| `crates/mcp/src/task_server/tools/remote_issues.rs` | Added `start_date` and `target_date` to `McpUpdateIssueRequest`; added ISO 8601 parsing with error messages; wired through to `UpdateIssueRequest` payload |

## Usage

```json
// Set dates
{ "issue_id": "...", "start_date": "2025-06-01T00:00:00Z", "target_date": "2025-06-15T00:00:00Z" }

// Clear dates
{ "issue_id": "...", "start_date": null, "target_date": null }

// Leave dates unchanged (omit the fields)
{ "issue_id": "...", "title": "Updated title" }
```

Fixes #3341

## Test plan

- [ ] `cargo build -p mcp` compiles successfully
- [ ] Call `update_issue` with valid ISO 8601 `start_date` — verify date is set
- [ ] Call `update_issue` with `start_date: null` — verify date is cleared
- [ ] Call `update_issue` without date fields — verify existing dates are unchanged
- [ ] Call `update_issue` with invalid date string — verify clear error message
- [ ] Call `get_issue` after update — verify dates round-trip correctly
