### PR TITLE
fix: validate MCP backend URL with health-check probe before use

### DIFF
--- a/crates/mcp/src/bin/vibe_kanban_mcp.rs
+++ b/crates/mcp/src/bin/vibe_kanban_mcp.rs
@@ -97,6 +97,28 @@ where
     Ok(LaunchConfig { mode })
 }
 
+/// Probe a candidate backend URL by sending a lightweight GET request.
+/// Returns `true` if the backend responds (any HTTP status), `false` on
+/// connection failure or timeout.
+async fn probe_backend(url: &str, log_prefix: &str) -> bool {
+    let probe_url = format!("{}/api/health", url.trim_end_matches('/'));
+    tracing::debug!("[{}] Probing backend at {}", log_prefix, probe_url);
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(2))
+        .build()
+        .unwrap_or_default();
+    match client.get(&probe_url).send().await {
+        Ok(_) => {
+            tracing::debug!("[{}] Backend alive at {}", log_prefix, url);
+            true
+        }
+        Err(e) => {
+            tracing::debug!("[{}] Backend probe failed at {}: {}", log_prefix, url, e);
+            false
+        }
+    }
+}
+
 async fn resolve_base_url(log_prefix: &str) -> anyhow::Result<String> {
     if let Ok(url) = std::env::var("VIBE_BACKEND_URL") {
         tracing::info!(
@@ -128,9 +150,42 @@ async fn resolve_base_url(log_prefix: &str) -> anyhow::Result<String> {
         }
     };
 
-    let url = format!("http://{}:{}", host, port);
-    tracing::info!("[{}] Using backend URL: {}", log_prefix, url);
-    Ok(url)
+    // Build candidate URL and validate it with a health-check probe.
+    // If the primary host fails, try alternate loopback addresses to handle
+    // the case where the backend binds to `localhost` (which may resolve to
+    // `::1` on macOS) while we default to `127.0.0.1`, or vice versa.
+    let primary_url = format!("http://{}:{}", host, port);
+    if probe_backend(&primary_url, log_prefix).await {
+        tracing::info!("[{}] Using backend URL: {}", log_prefix, primary_url);
+        return Ok(primary_url);
+    }
+
+    // Try alternate loopback hosts
+    let alternates: &[&str] = if host == "127.0.0.1" {
+        &["localhost", "[::1]"]
+    } else if host == "localhost" {
+        &["127.0.0.1", "[::1]"]
+    } else {
+        &["localhost", "127.0.0.1"]
+    };
+
+    for alt_host in alternates {
+        let alt_url = format!("http://{}:{}", alt_host, port);
+        if probe_backend(&alt_url, log_prefix).await {
+            tracing::info!(
+                "[{}] Primary host {} unreachable, using alternate: {}",
+                log_prefix, host, alt_url
+            );
+            return Ok(alt_url);
+        }
+    }
+
+    // Fall through to original URL — downstream will report the real error
+    tracing::warn!(
+        "[{}] No backend responded on port {}. Using {} (may fail).",
+        log_prefix, port, primary_url
+    );
+    Ok(primary_url)
 }
 
 fn init_process_logging(log_prefix: &str, version: &str) {


### PR DESCRIPTION
﻿## Summary

- Add `probe_backend()` health-check function that validates backend reachability with a lightweight GET to `/api/health` (2s timeout)
- Enhance `resolve_base_url()` to probe the primary URL before accepting it, and try alternate loopback addresses (`localhost` ↔ `127.0.0.1` ↔ `[::1]`) on failure
- Fall through to original URL with a warning if no backend responds, preserving existing behavior for downstream error reporting

## Problem

The MCP server discovers its backend URL from a port file or environment variables but never verifies the backend is actually reachable. On macOS, `localhost` resolves to `::1` while the backend may bind to `127.0.0.1` (or vice versa), causing silent connection failures that are difficult to diagnose.

Fixes #3349

## Test plan

- [ ] Start backend on `127.0.0.1:PORT` → MCP connects on first try
- [ ] Start backend on `localhost` (`::1`) while MCP defaults to `127.0.0.1` → MCP falls back to `localhost` automatically
- [ ] No backend running → MCP logs warning and falls through (existing behavior preserved)
- [ ] `VIBE_BACKEND_URL` env var set → skips probe entirely (existing fast path)
