### PR TITLE
[codex] Add GPT-5.5 model support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,7 +236,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "api-types"
-version = "0.1.44"
+version = "0.1.45"
 dependencies = [
  "chrono",
  "schemars 1.2.1",
@@ -1223,7 +1223,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "client-info"
-version = "0.1.44"
+version = "0.1.45"
 
 [[package]]
 name = "clipboard-win"
@@ -2016,7 +2016,7 @@ checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "db"
-version = "0.1.44"
+version = "0.1.45"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2069,7 +2069,7 @@ dependencies = [
 
 [[package]]
 name = "deployment"
-version = "0.1.44"
+version = "0.1.45"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2234,7 +2234,7 @@ dependencies = [
 
 [[package]]
 name = "desktop-bridge"
-version = "0.1.44"
+version = "0.1.45"
 dependencies = [
  "base64 0.22.1",
  "dirs 5.0.1",
@@ -2605,7 +2605,7 @@ checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
 
 [[package]]
 name = "embedded-ssh"
-version = "0.1.44"
+version = "0.1.45"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2793,7 +2793,7 @@ dependencies = [
 
 [[package]]
 name = "executors"
-version = "0.1.44"
+version = "0.1.45"
 dependencies = [
  "agent-client-protocol",
  "async-stream",
@@ -3512,7 +3512,7 @@ dependencies = [
 
 [[package]]
 name = "git"
-version = "0.1.44"
+version = "0.1.45"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -3527,7 +3527,7 @@ dependencies = [
 
 [[package]]
 name = "git-host"
-version = "0.1.44"
+version = "0.1.45"
 dependencies = [
  "async-trait",
  "backon",
@@ -4957,7 +4957,7 @@ checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "local-deployment"
-version = "0.1.44"
+version = "0.1.45"
 dependencies = [
  "anyhow",
  "api-types",
@@ -5177,7 +5177,7 @@ checksum = "8863b587001c1b9a8a4e36008cebc6b3612cb1226fe2de94858e06092687b608"
 
 [[package]]
 name = "mcp"
-version = "0.1.44"
+version = "0.1.45"
 dependencies = [
  "anyhow",
  "api-types",
@@ -6695,7 +6695,7 @@ dependencies = [
 
 [[package]]
 name = "preview-proxy"
-version = "0.1.44"
+version = "0.1.45"
 dependencies = [
  "axum",
  "http",
@@ -7501,7 +7501,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "relay-client"
-version = "0.1.44"
+version = "0.1.45"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -7524,7 +7524,7 @@ dependencies = [
 
 [[package]]
 name = "relay-control"
-version = "0.1.44"
+version = "0.1.45"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -7538,7 +7538,7 @@ dependencies = [
 
 [[package]]
 name = "relay-hosts"
-version = "0.1.44"
+version = "0.1.45"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -7571,7 +7571,7 @@ dependencies = [
 
 [[package]]
 name = "relay-protocol"
-version = "0.1.44"
+version = "0.1.45"
 dependencies = [
  "anyhow",
  "axum",
@@ -7582,7 +7582,7 @@ dependencies = [
 
 [[package]]
 name = "relay-tunnel-core"
-version = "0.1.44"
+version = "0.1.45"
 dependencies = [
  "anyhow",
  "axum",
@@ -7601,7 +7601,7 @@ dependencies = [
 
 [[package]]
 name = "relay-types"
-version = "0.1.44"
+version = "0.1.45"
 dependencies = [
  "chrono",
  "serde",
@@ -7612,7 +7612,7 @@ dependencies = [
 
 [[package]]
 name = "relay-webrtc"
-version = "0.1.44"
+version = "0.1.45"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -7638,7 +7638,7 @@ dependencies = [
 
 [[package]]
 name = "relay-ws"
-version = "0.1.44"
+version = "0.1.45"
 dependencies = [
  "anyhow",
  "axum",
@@ -7661,7 +7661,7 @@ dependencies = [
 
 [[package]]
 name = "remote-info"
-version = "0.1.44"
+version = "0.1.45"
 
 [[package]]
 name = "reqwest"
@@ -7760,7 +7760,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "review"
-version = "0.1.44"
+version = "0.1.45"
 dependencies = [
  "anyhow",
  "clap",
@@ -8866,7 +8866,7 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.1.44"
+version = "0.1.45"
 dependencies = [
  "anyhow",
  "api-types",
@@ -8932,7 +8932,7 @@ dependencies = [
 
 [[package]]
 name = "services"
-version = "0.1.44"
+version = "0.1.45"
 dependencies = [
  "anyhow",
  "api-types",
@@ -10968,7 +10968,7 @@ checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
 
 [[package]]
 name = "trusted-key-auth"
-version = "0.1.44"
+version = "0.1.45"
 dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",
@@ -11317,7 +11317,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "utils"
-version = "0.1.44"
+version = "0.1.45"
 dependencies = [
  "axum",
  "bytes",
@@ -11390,7 +11390,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vibe-kanban-tauri"
-version = "0.1.44"
+version = "0.1.45"
 dependencies = [
  "arboard",
  "async-trait",
@@ -12707,7 +12707,7 @@ dependencies = [
 
 [[package]]
 name = "workspace-manager"
-version = "0.1.44"
+version = "0.1.45"
 dependencies = [
  "db",
  "git",
@@ -12722,7 +12722,7 @@ dependencies = [
 
 [[package]]
 name = "worktree-manager"
-version = "0.1.44"
+version = "0.1.45"
 dependencies = [
  "dunce",
  "git",
@@ -12785,7 +12785,7 @@ dependencies = [
 
 [[package]]
 name = "ws-bridge"
-version = "0.1.44"
+version = "0.1.45"
 dependencies = [
  "axum",
  "bytes",

--- a/crates/api-types/Cargo.toml
+++ b/crates/api-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "api-types"
-version = "0.1.44"
+version = "0.1.45"
 edition = "2024"
 
 [dependencies]

--- a/crates/client-info/Cargo.toml
+++ b/crates/client-info/Cargo.toml
@@ -1,4 +1,4 @@
 [package]
 name = "client-info"
-version = "0.1.44"
+version = "0.1.45"
 edition = "2024"

--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "db"
-version = "0.1.44"
+version = "0.1.45"
 edition = "2024"
 
 [dependencies]

--- a/crates/deployment/Cargo.toml
+++ b/crates/deployment/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deployment"
-version = "0.1.44"
+version = "0.1.45"
 edition = "2024"
 
 [dependencies]

--- a/crates/desktop-bridge/Cargo.toml
+++ b/crates/desktop-bridge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "desktop-bridge"
-version = "0.1.44"
+version = "0.1.45"
 edition = "2024"
 publish = false
 

--- a/crates/embedded-ssh/Cargo.toml
+++ b/crates/embedded-ssh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embedded-ssh"
-version = "0.1.44"
+version = "0.1.45"
 edition = "2024"
 
 [dependencies]

--- a/crates/executors/Cargo.toml
+++ b/crates/executors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "executors"
-version = "0.1.44"
+version = "0.1.45"
 edition = "2024"
 
 [dependencies]

--- a/crates/executors/src/executors/copilot.rs
+++ b/crates/executors/src/executors/copilot.rs
@@ -197,6 +197,7 @@ impl StandardCodingAgentExecutor for Copilot {
         let options = ExecutorDiscoveredOptions {
             model_selector: ModelSelectorConfig {
                 models: [
+                    ("gpt-5.5", "GPT-5.5"),
                     ("gpt-5.4", "GPT-5.4"),
                     ("claude-opus-4.6", "Claude Opus 4.6"),
                     ("claude-opus-4.6-fast", "Claude Opus 4.6 Fast"),

--- a/crates/executors/src/executors/cursor.rs
+++ b/crates/executors/src/executors/cursor.rs
@@ -47,7 +47,7 @@ pub struct CursorAgent {
     pub force: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schemars(
-        description = "auto, opus-4.6, sonnet-4.6, gpt-5.4, gpt-5.4-fast, gpt-5.3-codex, gpt-5.3-codex-fast, gpt-5.3-codex-spark-preview, gpt-5.2, gpt-5.2-codex, gpt-5.2-codex-fast, gpt-5.1, gpt-5.1-codex-max, gpt-5.1-codex-mini, grok, kimi-k2.5, gemini-3.1-pro, gemini-3-pro, gemini-3-flash, opus-4.5, sonnet-4.5, composer-1.5, composer-1, composer-2, composer-2-fast"
+        description = "auto, opus-4.6, sonnet-4.6, gpt-5.5, gpt-5.5-fast, gpt-5.4, gpt-5.4-fast, gpt-5.3-codex, gpt-5.3-codex-fast, gpt-5.3-codex-spark-preview, gpt-5.2, gpt-5.2-codex, gpt-5.2-codex-fast, gpt-5.1, gpt-5.1-codex-max, gpt-5.1-codex-mini, grok, kimi-k2.5, gemini-3.1-pro, gemini-3-pro, gemini-3-flash, opus-4.5, sonnet-4.5, composer-1.5, composer-1, composer-2, composer-2-fast"
     )]
     pub model: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -59,6 +59,16 @@ pub struct CursorAgent {
 // get the model full name
 fn resolve_cursor_model_name<'a>(base_model: &'a str, reasoning: Option<&'a str>) -> &'a str {
     match (base_model, reasoning) {
+        ("gpt-5.5", Some("low")) => "gpt-5.5-low",
+        ("gpt-5.5", Some("medium")) => "gpt-5.5-medium",
+        ("gpt-5.5", Some("high") | None) => "gpt-5.5-high",
+        ("gpt-5.5", Some("xhigh")) => "gpt-5.5-xhigh",
+
+        ("gpt-5.5-fast", Some("low")) => "gpt-5.5-low-fast",
+        ("gpt-5.5-fast", Some("medium")) => "gpt-5.5-medium-fast",
+        ("gpt-5.5-fast", Some("high") | None) => "gpt-5.5-high-fast",
+        ("gpt-5.5-fast", Some("xhigh")) => "gpt-5.5-xhigh-fast",
+
         ("gpt-5.4", Some("medium")) => "gpt-5.4-medium",
         ("gpt-5.4", Some("high") | None) => "gpt-5.4-high",
         ("gpt-5.4", Some("xhigh")) => "gpt-5.4-xhigh",
@@ -111,6 +121,9 @@ fn resolve_cursor_model_name<'a>(base_model: &'a str, reasoning: Option<&'a str>
 
 fn cursor_reasoning_options(base_model: &str) -> Vec<ReasoningOption> {
     match base_model {
+        "gpt-5.5" | "gpt-5.5-fast" => {
+            ReasoningOption::from_names(["low", "medium", "high", "xhigh"].map(String::from))
+        }
         "gpt-5.4" | "gpt-5.4-fast" => {
             ReasoningOption::from_names(["medium", "high", "xhigh"].map(String::from))
         }
@@ -648,6 +661,8 @@ impl StandardCodingAgentExecutor for CursorAgent {
     ) -> Result<futures::stream::BoxStream<'static, json_patch::Patch>, ExecutorError> {
         let models: Vec<ModelInfo> = [
             ("auto", "Auto"),
+            ("gpt-5.5", "GPT-5.5"),
+            ("gpt-5.5-fast", "GPT-5.5 Fast"),
             ("gpt-5.4", "GPT-5.4"),
             ("gpt-5.4-fast", "GPT-5.4 Fast"),
             ("gemini-3.1-pro", "Gemini 3.1 Pro"),

--- a/crates/executors/src/executors/droid.rs
+++ b/crates/executors/src/executors/droid.rs
@@ -69,7 +69,7 @@ pub struct Droid {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schemars(
         title = "Model",
-        description = "Model to use (e.g., gpt-5-codex, claude-sonnet-4-5-20250929, gpt-5-2025-08-07, claude-opus-4-1-20250805, claude-haiku-4-5-20251001, glm-4.6)"
+        description = "Model to use (e.g., gpt-5.5, gpt-5.3-codex, claude-sonnet-4-5-20250929, claude-opus-4-6, claude-haiku-4-5-20251001, glm-5)"
     )]
     pub model: Option<String>,
 
@@ -242,6 +242,7 @@ impl StandardCodingAgentExecutor for Droid {
                     ("claude-opus-4-6-fast", "Claude Opus 4.6 Fast Mode"),
                     ("gemini-3.1-pro-preview", "Gemini 3.1 Pro"),
                     ("glm-5", "GLM-5"),
+                    ("gpt-5.5", "GPT 5.5"),
                     ("gpt-5.3-codex", "GPT 5.3 Codex"),
                     ("claude-sonnet-4-6", "Claude Sonnet 4.6"),
                     ("kimi-k2.5", "Kimi K2.5"),

--- a/crates/git-host/Cargo.toml
+++ b/crates/git-host/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-host"
-version = "0.1.44"
+version = "0.1.45"
 edition = "2024"
 
 [dependencies]

--- a/crates/git/Cargo.toml
+++ b/crates/git/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git"
-version = "0.1.44"
+version = "0.1.45"
 edition = "2024"
 
 [features]

--- a/crates/local-deployment/Cargo.toml
+++ b/crates/local-deployment/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "local-deployment"
-version = "0.1.44"
+version = "0.1.45"
 edition = "2024"
 
 [dependencies]

--- a/crates/mcp/Cargo.toml
+++ b/crates/mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp"
-version = "0.1.44"
+version = "0.1.45"
 edition = "2024"
 autobins = false
 

--- a/crates/preview-proxy/Cargo.toml
+++ b/crates/preview-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "preview-proxy"
-version = "0.1.44"
+version = "0.1.45"
 edition = "2024"
 
 [dependencies]

--- a/crates/relay-client/Cargo.toml
+++ b/crates/relay-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "relay-client"
-version = "0.1.44"
+version = "0.1.45"
 edition = "2024"
 
 [dependencies]

--- a/crates/relay-control/Cargo.toml
+++ b/crates/relay-control/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "relay-control"
-version = "0.1.44"
+version = "0.1.45"
 edition = "2024"
 
 [dependencies]

--- a/crates/relay-hosts/Cargo.toml
+++ b/crates/relay-hosts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "relay-hosts"
-version = "0.1.44"
+version = "0.1.45"
 edition = "2024"
 
 [dependencies]

--- a/crates/relay-protocol/Cargo.toml
+++ b/crates/relay-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "relay-protocol"
-version = "0.1.44"
+version = "0.1.45"
 edition = "2024"
 
 [dependencies]

--- a/crates/relay-tunnel-core/Cargo.toml
+++ b/crates/relay-tunnel-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "relay-tunnel-core"
-version = "0.1.44"
+version = "0.1.45"
 edition = "2024"
 
 [dependencies]

--- a/crates/relay-tunnel/Cargo.lock
+++ b/crates/relay-tunnel/Cargo.lock
@@ -34,7 +34,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "api-types"
-version = "0.1.44"
+version = "0.1.45"
 dependencies = [
  "chrono",
  "schemars",
@@ -1687,7 +1687,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "relay-control"
-version = "0.1.44"
+version = "0.1.45"
 dependencies = [
  "anyhow",
  "base64",
@@ -1701,7 +1701,7 @@ dependencies = [
 
 [[package]]
 name = "relay-protocol"
-version = "0.1.44"
+version = "0.1.45"
 dependencies = [
  "anyhow",
  "axum",
@@ -1748,7 +1748,7 @@ dependencies = [
 
 [[package]]
 name = "relay-tunnel-core"
-version = "0.1.44"
+version = "0.1.45"
 dependencies = [
  "anyhow",
  "axum",
@@ -1767,7 +1767,7 @@ dependencies = [
 
 [[package]]
 name = "relay-types"
-version = "0.1.44"
+version = "0.1.45"
 dependencies = [
  "chrono",
  "serde",
@@ -1778,7 +1778,7 @@ dependencies = [
 
 [[package]]
 name = "relay-ws"
-version = "0.1.44"
+version = "0.1.45"
 dependencies = [
  "anyhow",
  "axum",
@@ -3366,7 +3366,7 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "ws-bridge"
-version = "0.1.44"
+version = "0.1.45"
 dependencies = [
  "axum",
  "bytes",

--- a/crates/relay-types/Cargo.toml
+++ b/crates/relay-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "relay-types"
-version = "0.1.44"
+version = "0.1.45"
 edition = "2024"
 
 [dependencies]

--- a/crates/relay-webrtc/Cargo.toml
+++ b/crates/relay-webrtc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "relay-webrtc"
-version = "0.1.44"
+version = "0.1.45"
 edition = "2024"
 
 [dependencies]

--- a/crates/relay-ws/Cargo.toml
+++ b/crates/relay-ws/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "relay-ws"
-version = "0.1.44"
+version = "0.1.45"
 edition = "2024"
 
 [dependencies]

--- a/crates/remote-info/Cargo.toml
+++ b/crates/remote-info/Cargo.toml
@@ -1,4 +1,4 @@
 [package]
 name = "remote-info"
-version = "0.1.44"
+version = "0.1.45"
 edition = "2024"

--- a/crates/remote/Cargo.lock
+++ b/crates/remote/Cargo.lock
@@ -99,7 +99,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "api-types"
-version = "0.1.44"
+version = "0.1.45"
 dependencies = [
  "chrono",
  "schemars",
@@ -3188,7 +3188,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "relay-types"
-version = "0.1.44"
+version = "0.1.45"
 dependencies = [
  "chrono",
  "serde",
@@ -4853,7 +4853,7 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utils"
-version = "0.1.44"
+version = "0.1.45"
 dependencies = [
  "axum",
  "bytes",

--- a/crates/review/Cargo.toml
+++ b/crates/review/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "review"
-version = "0.1.44"
+version = "0.1.45"
 edition = "2024"
 publish = false
 

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "server"
-version = "0.1.44"
+version = "0.1.45"
 edition = "2024"
 default-run = "server"
 

--- a/crates/services/Cargo.toml
+++ b/crates/services/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "services"
-version = "0.1.44"
+version = "0.1.45"
 edition = "2024"
 
 [features]

--- a/crates/tauri-app/Cargo.toml
+++ b/crates/tauri-app/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vibe-kanban-tauri"
-version = "0.1.44"
+version = "0.1.45"
 edition = "2024"
 
 [[bin]]

--- a/crates/trusted-key-auth/Cargo.toml
+++ b/crates/trusted-key-auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusted-key-auth"
-version = "0.1.44"
+version = "0.1.45"
 edition = "2024"
 
 [dependencies]

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "utils"
-version = "0.1.44"
+version = "0.1.45"
 edition = "2024"
 
 [dependencies]

--- a/crates/workspace-manager/Cargo.toml
+++ b/crates/workspace-manager/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workspace-manager"
-version = "0.1.44"
+version = "0.1.45"
 edition = "2024"
 
 [dependencies]

--- a/crates/worktree-manager/Cargo.toml
+++ b/crates/worktree-manager/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "worktree-manager"
-version = "0.1.44"
+version = "0.1.45"
 edition = "2024"
 
 [dependencies]

--- a/crates/ws-bridge/Cargo.toml
+++ b/crates/ws-bridge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ws-bridge"
-version = "0.1.44"
+version = "0.1.45"
 edition = "2024"
 
 [dependencies]

--- a/npx-cli/package-lock.json
+++ b/npx-cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vibe-kanban",
-  "version": "0.1.44",
+  "version": "0.1.45",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vibe-kanban",
-      "version": "0.1.44",
+      "version": "0.1.45",
       "dependencies": {
         "adm-zip": "^0.5.16",
         "cac": "^7.0.0"

--- a/npx-cli/package.json
+++ b/npx-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vibe-kanban",
   "private": false,
-  "version": "0.1.44",
+  "version": "0.1.45",
   "main": "index.js",
   "bin": {
     "vibe-kanban": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-kanban",
-  "version": "0.1.44",
+  "version": "0.1.45",
   "private": true,
   "bin": {
     "vibe-kanban": "npx-cli/bin/cli.js"

--- a/shared/schemas/cursor_agent.json
+++ b/shared/schemas/cursor_agent.json
@@ -19,7 +19,7 @@
       ]
     },
     "model": {
-      "description": "auto, opus-4.6, sonnet-4.6, gpt-5.4, gpt-5.4-fast, gpt-5.3-codex, gpt-5.3-codex-fast, gpt-5.3-codex-spark-preview, gpt-5.2, gpt-5.2-codex, gpt-5.2-codex-fast, gpt-5.1, gpt-5.1-codex-max, gpt-5.1-codex-mini, grok, kimi-k2.5, gemini-3.1-pro, gemini-3-pro, gemini-3-flash, opus-4.5, sonnet-4.5, composer-1.5, composer-1, composer-2, composer-2-fast",
+      "description": "auto, opus-4.6, sonnet-4.6, gpt-5.5, gpt-5.5-fast, gpt-5.4, gpt-5.4-fast, gpt-5.3-codex, gpt-5.3-codex-fast, gpt-5.3-codex-spark-preview, gpt-5.2, gpt-5.2-codex, gpt-5.2-codex-fast, gpt-5.1, gpt-5.1-codex-max, gpt-5.1-codex-mini, grok, kimi-k2.5, gemini-3.1-pro, gemini-3-pro, gemini-3-flash, opus-4.5, sonnet-4.5, composer-1.5, composer-1, composer-2, composer-2-fast",
       "type": [
         "string",
         "null"

--- a/shared/schemas/droid.json
+++ b/shared/schemas/droid.json
@@ -26,7 +26,7 @@
     },
     "model": {
       "title": "Model",
-      "description": "Model to use (e.g., gpt-5-codex, claude-sonnet-4-5-20250929, gpt-5-2025-08-07, claude-opus-4-1-20250805, claude-haiku-4-5-20251001, glm-4.6)",
+      "description": "Model to use (e.g., gpt-5.5, gpt-5.3-codex, claude-sonnet-4-5-20250929, claude-opus-4-6, claude-haiku-4-5-20251001, glm-5)",
       "type": [
         "string",
         "null"


### PR DESCRIPTION
## Summary
- add GPT-5.5 to Cursor Agent, Copilot, and Droid model selectors
- add Cursor GPT-5.5 fast/reasoning variant mapping
- bump app/package crate versions to 0.1.45 and refresh relevant lockfiles

## Validation
- cargo fmt --all
- cargo fmt --all --manifest-path crates/remote/Cargo.toml
- cargo check -p executors

## Notes
- pnpm run generate-types could not run because pnpm is not installed and Corepack failed signature verification; cargo run --bin generate_types also failed because libsqlite3-sys could not find libclang.dll. The schema description changes were applied to the generated JSON schema files directly to keep them in sync.
- cargo check --workspace is blocked locally by the same missing libclang.dll bindgen setup.
- cargo test -p executors resolve_model --lib could not complete after the broader build filled the disk; the ignored target directory was removed to recover space.