### PR TITLE
[codex] Bound historical log replay memory

### DIFF
--- a/crates/git/src/cli.rs
+++ b/crates/git/src/cli.rs
@@ -65,6 +65,14 @@ pub struct StatusDiffEntry {
     pub old_path: Option<String>,
 }
 
+/// One entry from `git diff --numstat`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NumstatEntry {
+    pub additions: Option<usize>,
+    pub deletions: Option<usize>,
+    pub path: String,
+}
+
 /// Parsed worktree entry from `git worktree list --porcelain`
 #[derive(Debug, Clone)]
 pub struct WorktreeEntry {
@@ -171,7 +179,52 @@ impl GitCli {
         base_commit: &Commit,
         opts: StatusDiffOptions,
     ) -> Result<Vec<StatusDiffEntry>, GitCliError> {
-        // Create a temp index file
+        let (_tmp_dir, envs) = self.create_staged_temp_index(worktree_path)?;
+        // git diff --cached
+        let mut args: Vec<OsString> = vec![
+            "-c".into(),
+            "core.quotepath=false".into(),
+            "diff".into(),
+            "--cached".into(),
+            "-M".into(),
+            "--name-status".into(),
+            OsString::from(base_commit.to_string()),
+        ];
+        args = Self::apply_pathspec_filter(args, opts.path_filter.as_ref());
+        let out = self.git_with_env(worktree_path, args, &envs)?;
+        Ok(Self::parse_name_status(&out))
+    }
+
+    /// Diff line/file stats vs a base commit using a temporary index.
+    ///
+    /// This follows `diff_status` staging semantics so committed, uncommitted,
+    /// and untracked changes are counted without materializing file contents.
+    pub fn diff_numstat(
+        &self,
+        worktree_path: &Path,
+        base_commit: &Commit,
+        opts: StatusDiffOptions,
+    ) -> Result<Vec<NumstatEntry>, GitCliError> {
+        let (_tmp_dir, envs) = self.create_staged_temp_index(worktree_path)?;
+
+        let mut args: Vec<OsString> = vec![
+            "-c".into(),
+            "core.quotepath=false".into(),
+            "diff".into(),
+            "--cached".into(),
+            "-M".into(),
+            "--numstat".into(),
+            OsString::from(base_commit.to_string()),
+        ];
+        args = Self::apply_pathspec_filter(args, opts.path_filter.as_ref());
+        let out = self.git_with_env(worktree_path, args, &envs)?;
+        Ok(Self::parse_numstat(&out))
+    }
+
+    fn create_staged_temp_index(
+        &self,
+        worktree_path: &Path,
+    ) -> Result<(tempfile::TempDir, Vec<(OsString, OsString)>), GitCliError> {
         let tmp_dir = tempfile::TempDir::new()
             .map_err(|e| GitCliError::CommandFailed(format!("temp dir create failed: {e}")))?;
         let tmp_index = tmp_dir.path().join("index");
@@ -180,11 +233,8 @@ impl GitCli {
             tmp_index.as_os_str().to_os_string(),
         )];
 
-        // Use a temp index from HEAD to accurately track renames in untracked files
         let _ = self.git_with_env(worktree_path, ["read-tree", "HEAD"], &envs)?;
 
-        // Stage changed and untracked files explicitly, which is faster than `git add -A` for large repos.
-        // Use raw paths from `get_worktree_status` to avoid lossy UTF-8 conversions for odd filenames.
         let status = self.get_worktree_status(worktree_path)?;
         let mut paths_to_add: Vec<Vec<u8>> = Vec::new();
         for entry in status.entries {
@@ -212,19 +262,7 @@ impl GitCli {
             ];
             self.git_with_stdin(worktree_path, args, Some(&envs), &input)?;
         }
-        // git diff --cached
-        let mut args: Vec<OsString> = vec![
-            "-c".into(),
-            "core.quotepath=false".into(),
-            "diff".into(),
-            "--cached".into(),
-            "-M".into(),
-            "--name-status".into(),
-            OsString::from(base_commit.to_string()),
-        ];
-        args = Self::apply_pathspec_filter(args, opts.path_filter.as_ref());
-        let out = self.git_with_env(worktree_path, args, &envs)?;
-        Ok(Self::parse_name_status(&out))
+        Ok((tmp_dir, envs))
     }
 
     /// Return `git status --porcelain` parsed into a structured summary
@@ -504,6 +542,29 @@ impl GitCli {
                         });
                     }
                 }
+            }
+        }
+        out
+    }
+
+    fn parse_numstat(output: &str) -> Vec<NumstatEntry> {
+        let mut out = Vec::new();
+        for line in output.lines() {
+            let line = line.trim_end();
+            if line.is_empty() {
+                continue;
+            }
+            let mut parts = line.splitn(3, '\t');
+            let additions = parts.next().and_then(|v| v.parse::<usize>().ok());
+            let deletions = parts.next().and_then(|v| v.parse::<usize>().ok());
+            if let Some(path) = parts.next()
+                && !path.is_empty()
+            {
+                out.push(NumstatEntry {
+                    additions,
+                    deletions,
+                    path: path.to_string(),
+                });
             }
         }
         out
@@ -942,4 +1003,22 @@ pub struct WorktreeStatus {
     pub uncommitted_tracked: usize,
     pub untracked: usize,
     pub entries: Vec<StatusEntry>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::GitCli;
+
+    #[test]
+    fn parse_numstat_counts_text_and_binary_files() {
+        let entries = GitCli::parse_numstat("12\t3\tsrc/main.rs\n-\t-\tassets/logo.png\n");
+
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].additions, Some(12));
+        assert_eq!(entries[0].deletions, Some(3));
+        assert_eq!(entries[0].path, "src/main.rs");
+        assert_eq!(entries[1].additions, None);
+        assert_eq!(entries[1].deletions, None);
+        assert_eq!(entries[1].path, "assets/logo.png");
+    }
 }

--- a/crates/git/src/lib.rs
+++ b/crates/git/src/lib.rs
@@ -29,6 +29,13 @@ pub struct FileStat {
     pub last_time: DateTime<Utc>,
 }
 
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct DiffStats {
+    pub files_changed: usize,
+    pub lines_added: usize,
+    pub lines_removed: usize,
+}
+
 #[derive(Debug, Error)]
 pub enum GitServiceError {
     #[error(transparent)]
@@ -369,6 +376,30 @@ impl GitService {
             )
             .map_err(|e| GitServiceError::InvalidRepository(format!("git diff failed: {e}")))?;
         Ok(entries.into_iter().map(|e| e.path).collect())
+    }
+
+    /// Returns diff counts without loading file contents.
+    pub fn get_diff_stats(
+        &self,
+        worktree_path: &Path,
+        base_commit: &Commit,
+    ) -> Result<DiffStats, GitServiceError> {
+        let git = GitCli::new();
+        let entries = git
+            .diff_numstat(
+                worktree_path,
+                base_commit,
+                cli::StatusDiffOptions { path_filter: None },
+            )
+            .map_err(|e| GitServiceError::InvalidRepository(format!("git diff failed: {e}")))?;
+
+        let mut stats = DiffStats::default();
+        for entry in entries {
+            stats.files_changed += 1;
+            stats.lines_added += entry.additions.unwrap_or(0);
+            stats.lines_removed += entry.deletions.unwrap_or(0);
+        }
+        Ok(stats)
     }
 
     /// Extract file path from a Diff (for indexing and ConversationPatch)

--- a/crates/local-deployment/src/lib.rs
+++ b/crates/local-deployment/src/lib.rs
@@ -252,7 +252,9 @@ impl Deployment for LocalDeployment {
             None => None,
         };
         let pr_sync_notify = Arc::new(Notify::new());
-        {
+        if std::env::var("VK_DISABLE_PR_MONITOR").is_ok() {
+            tracing::info!("PR monitoring service disabled by VK_DISABLE_PR_MONITOR");
+        } else {
             let db = db.clone();
             let analytics = analytics.as_ref().map(|s| AnalyticsContext {
                 user_id: user_id.clone(),

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -141,8 +141,11 @@ async fn main() -> Result<(), VibeKanbanError> {
 
     let app_router = routes::router(deployment.clone());
 
-    // Production only: open browser
-    if !cfg!(debug_assertions) {
+    // Production only: open browser unless disabled for diagnostics.
+    let disable_auto_open_browser = std::env::var("VK_DISABLE_AUTO_OPEN_BROWSER")
+        .ok()
+        .is_some_and(|value| matches!(value.as_str(), "1" | "true" | "TRUE" | "yes" | "YES"));
+    if !cfg!(debug_assertions) && !disable_auto_open_browser {
         tracing::info!("Opening browser...");
         let browser_port = actual_main_port;
         tokio::spawn(async move {

--- a/crates/server/src/routes/frontend.rs
+++ b/crates/server/src/routes/frontend.rs
@@ -1,5 +1,7 @@
+use std::borrow::Cow;
+
 use axum::{
-    body::Body,
+    body::{Body, Bytes},
     http::HeaderValue,
     response::{IntoResponse, Response},
 };
@@ -20,11 +22,27 @@ pub(super) async fn serve_frontend_root() -> impl IntoResponse {
 }
 
 async fn serve_file(path: &str) -> impl IntoResponse + use<> {
+    if trace_frontend_assets() {
+        tracing::info!(path, "Frontend asset request");
+    }
+
+    if path.ends_with(".map") && !serve_frontend_source_maps() {
+        if trace_frontend_assets() {
+            tracing::info!(path, "Frontend source map request blocked");
+        }
+
+        return Response::builder()
+            .status(StatusCode::NOT_FOUND)
+            .body(Body::from("404 Not Found"))
+            .unwrap();
+    }
+
     let file = Assets::get(path);
 
     match file {
         Some(content) => {
             let mime = mime_guess::from_path(path).first_or_octet_stream();
+            let body = embedded_asset_body(content.data);
 
             Response::builder()
                 .status(StatusCode::OK)
@@ -32,16 +50,18 @@ async fn serve_file(path: &str) -> impl IntoResponse + use<> {
                     header::CONTENT_TYPE,
                     HeaderValue::from_str(mime.as_ref()).unwrap(),
                 )
-                .body(Body::from(content.data.into_owned()))
+                .body(body)
                 .unwrap()
         }
         None => {
             // For SPA routing, serve index.html for unknown routes
             if let Some(index) = Assets::get("index.html") {
+                let body = embedded_asset_body(index.data);
+
                 Response::builder()
                     .status(StatusCode::OK)
                     .header(header::CONTENT_TYPE, HeaderValue::from_static("text/html"))
-                    .body(Body::from(index.data.into_owned()))
+                    .body(body)
                     .unwrap()
             } else {
                 Response::builder()
@@ -51,4 +71,23 @@ async fn serve_file(path: &str) -> impl IntoResponse + use<> {
             }
         }
     }
+}
+
+fn embedded_asset_body(data: Cow<'static, [u8]>) -> Body {
+    match data {
+        Cow::Borrowed(bytes) => Body::from(Bytes::from_static(bytes)),
+        Cow::Owned(bytes) => Body::from(Bytes::from(bytes)),
+    }
+}
+
+fn serve_frontend_source_maps() -> bool {
+    std::env::var("VK_SERVE_FRONTEND_SOURCE_MAPS")
+        .ok()
+        .is_some_and(|value| matches!(value.as_str(), "1" | "true" | "TRUE" | "yes" | "YES"))
+}
+
+fn trace_frontend_assets() -> bool {
+    std::env::var("VK_TRACE_FRONTEND_ASSETS")
+        .ok()
+        .is_some_and(|value| matches!(value.as_str(), "1" | "true" | "TRUE" | "yes" | "YES"))
 }

--- a/crates/server/src/routes/mod.rs
+++ b/crates/server/src/routes/mod.rs
@@ -71,6 +71,7 @@ pub fn router(deployment: DeploymentImpl) -> IntoMakeService<Router> {
         .merge(relay_auth::router())
         .merge(host_relay::router(&deployment))
         .merge(relay_signed_routes)
+        .layer(CompressionLayer::new())
         .layer(ValidateRequestHeaderLayer::custom(
             middleware::validate_origin,
         ))
@@ -81,6 +82,5 @@ pub fn router(deployment: DeploymentImpl) -> IntoMakeService<Router> {
         .route("/", get(frontend::serve_frontend_root))
         .route("/{*path}", get(frontend::serve_frontend))
         .nest("/api", api_routes)
-        .layer(CompressionLayer::new())
         .into_make_service()
 }

--- a/crates/server/src/routes/workspaces/workspace_summary.rs
+++ b/crates/server/src/routes/workspaces/workspace_summary.rs
@@ -9,6 +9,7 @@ use db::models::{
     workspace::Workspace,
 };
 use deployment::Deployment;
+use futures_util::StreamExt;
 use serde::{Deserialize, Serialize};
 use ts_rs::TS;
 use utils::response::ApiResponse;
@@ -66,6 +67,8 @@ pub struct DiffStats {
     pub lines_removed: usize,
 }
 
+const DIFF_STATS_CONCURRENCY: usize = 4;
+
 /// Fetch summary information for workspaces filtered by archived status.
 /// This endpoint returns data that cannot be efficiently included in the streaming endpoint.
 #[axum::debug_handler]
@@ -112,26 +115,25 @@ pub async fn get_workspace_summaries(
     // 6. Get PR status for each workspace
     let pr_statuses = PullRequest::get_latest_for_workspaces(pool, archived).await?;
 
-    // 7. Compute diff stats for each workspace (in parallel)
-    let diff_futures: Vec<_> = workspaces
-        .iter()
-        .map(|ws| {
-            let workspace = ws.clone();
-            let deployment = deployment.clone();
-            async move {
-                if workspace.container_ref.is_some() {
-                    compute_workspace_diff_stats(&deployment, &workspace)
-                        .await
-                        .map(|stats| (workspace.id, stats))
-                } else {
-                    None
-                }
-            }
-        })
-        .collect();
-
+    // 7. Compute diff stats with bounded concurrency. This endpoint is polled,
+    // so avoid launching Git work for every workspace at once.
     let diff_results: Vec<Option<(Uuid, DiffStats)>> =
-        futures_util::future::join_all(diff_futures).await;
+        futures_util::stream::iter(workspaces.iter().cloned())
+            .map(|workspace| {
+                let deployment = deployment.clone();
+                async move {
+                    if workspace.container_ref.is_some() {
+                        compute_workspace_diff_stats(&deployment, &workspace)
+                            .await
+                            .map(|stats| (workspace.id, stats))
+                    } else {
+                        None
+                    }
+                }
+            })
+            .buffer_unordered(DIFF_STATS_CONCURRENCY)
+            .collect()
+            .await;
     let diff_stats: HashMap<Uuid, DiffStats> = diff_results.into_iter().flatten().collect();
 
     // 8. Assemble response

--- a/crates/services/src/services/container.rs
+++ b/crates/services/src/services/container.rs
@@ -60,6 +60,9 @@ use worktree_manager::WorktreeError;
 use crate::services::{execution_process, notification::NotificationService};
 pub type ContainerRef = String;
 
+const HISTORICAL_NORMALIZATION_HISTORY_BYTES: usize = 8 * 1024 * 1024;
+const MAX_HISTORICAL_NORMALIZED_PATCH_BYTES: usize = 1024 * 1024;
+
 #[derive(Debug, Error)]
 pub enum ContainerError {
     #[error(transparent)]
@@ -812,16 +815,15 @@ pub trait ContainerService {
                     .boxed(),
             );
         } else {
-            let messages = execution_process::load_raw_log_messages(&self.db().pool, *id).await?;
-
-            let stream = futures::stream::iter(
-                messages
-                    .into_iter()
-                    .filter(|m| matches!(m, LogMsg::Stdout(_) | LogMsg::Stderr(_)))
-                    .chain(std::iter::once(LogMsg::Finished))
-                    .map(Ok::<_, std::io::Error>),
-            )
-            .boxed();
+            let stream = execution_process::stream_raw_log_messages(&self.db().pool, *id)
+                .await?
+                .filter(|msg| {
+                    future::ready(matches!(msg, Ok(LogMsg::Stdout(_) | LogMsg::Stderr(_))))
+                })
+                .chain(futures::stream::once(async {
+                    Ok::<_, std::io::Error>(LogMsg::Finished)
+                }))
+                .boxed();
 
             Some(stream)
         }
@@ -843,21 +845,9 @@ pub trait ContainerService {
                     .boxed(),
             )
         } else {
-            let raw_messages =
-                execution_process::load_raw_log_messages(&self.db().pool, *id).await?;
-
-            // Create temporary store and populate
-            // Include JsonPatch messages (already normalized) and Stdout/Stderr (need normalization)
-            let temp_store = Arc::new(MsgStore::new());
-            for msg in raw_messages {
-                if matches!(
-                    msg,
-                    LogMsg::Stdout(_) | LogMsg::Stderr(_) | LogMsg::JsonPatch(_)
-                ) {
-                    temp_store.push(msg);
-                }
-            }
-            temp_store.push_finished();
+            let raw_stream = execution_process::stream_raw_log_messages(&self.db().pool, *id)
+                .await?
+                .boxed();
 
             let process = match ExecutionProcess::find_by_id(&self.db().pool, *id).await {
                 Ok(Some(process)) => process,
@@ -912,7 +902,13 @@ pub trait ContainerService {
                 return None;
             };
 
-            // Spawn normalizer on populated store and collect JoinHandles
+            // Historical replay streams raw logs into a reduced-history store
+            // instead of materializing the whole log file and parsed message vec.
+            let temp_store = Arc::new(MsgStore::new_with_history_bytes(
+                HISTORICAL_NORMALIZATION_HISTORY_BYTES,
+            ));
+
+            // Spawn normalizer on the live-fed store and collect JoinHandles.
             let handles = match executor_action.typ() {
                 ExecutorActionType::CodingAgentInitialRequest(request) => {
                     #[cfg(feature = "qa-mode")]
@@ -972,18 +968,6 @@ pub trait ContainerService {
                 }
             };
 
-            // Await all normalizer tasks, then push Ready so the dedup
-            // stream knows when to flush its buffer and terminate.
-            {
-                let store = temp_store.clone();
-                tokio::spawn(async move {
-                    for handle in handles {
-                        let _ = handle.await;
-                    }
-                    store.push(LogMsg::Ready);
-                });
-            }
-
             // Stream normalized patches, deduplicating consecutive patches
             // that target the same path (only the final state matters for
             // historical replay). The Ready sentinel flushes the buffer.
@@ -1001,6 +985,41 @@ pub trait ContainerService {
                         _ => None,
                     }
                 });
+
+            {
+                let store = temp_store.clone();
+                tokio::spawn(async move {
+                    tokio::task::yield_now().await;
+
+                    let mut raw_stream = raw_stream;
+                    let mut forwarded_messages = 0usize;
+                    while let Some(msg) = raw_stream.next().await {
+                        match msg {
+                            Ok(
+                                msg
+                                @ (LogMsg::Stdout(_) | LogMsg::Stderr(_) | LogMsg::JsonPatch(_)),
+                            ) => store.push(msg),
+                            Ok(_) => {}
+                            Err(err) => {
+                                tracing::warn!("Failed to stream historical log message: {err}");
+                                break;
+                            }
+                        }
+
+                        forwarded_messages += 1;
+                        if forwarded_messages.is_multiple_of(256) {
+                            tokio::task::yield_now().await;
+                        }
+                    }
+
+                    store.push_finished();
+
+                    for handle in handles {
+                        let _ = handle.await;
+                    }
+                    store.push(LogMsg::Ready);
+                });
+            }
 
             let deduped = futures::stream::unfold(
                 (stream.boxed(), None::<Patch>, HashSet::<String>::new()),
@@ -1035,6 +1054,19 @@ pub trait ContainerService {
                 },
             )
             .filter_map(|opt| async move { opt })
+            .filter_map(|patch| async move {
+                let bytes = LogMsg::json_patch_approx_bytes(&patch);
+                if bytes <= MAX_HISTORICAL_NORMALIZED_PATCH_BYTES {
+                    Some(patch)
+                } else {
+                    tracing::warn!(
+                        bytes,
+                        path = ?patch_entry_path(&patch),
+                        "Skipping oversized historical normalized log patch"
+                    );
+                    None
+                }
+            })
             .map(|p| Ok::<_, std::io::Error>(LogMsg::JsonPatch(p)))
             .chain(futures::stream::once(async {
                 Ok::<_, std::io::Error>(LogMsg::Finished)

--- a/crates/services/src/services/diff_stream.rs
+++ b/crates/services/src/services/diff_stream.rs
@@ -75,16 +75,14 @@ pub async fn compute_diff_stats(
         let diffs_result = tokio::task::spawn_blocking({
             let git = git.clone();
             let worktree = worktree_path.clone();
-            move || git.get_diffs(&worktree, &base_commit, None)
+            move || git.get_diff_stats(&worktree, &base_commit)
         })
         .await;
 
-        if let Ok(Ok(diffs)) = diffs_result {
-            for diff in diffs {
-                stats.files_changed += 1;
-                stats.lines_added += diff.additions.unwrap_or(0);
-                stats.lines_removed += diff.deletions.unwrap_or(0);
-            }
+        if let Ok(Ok(repo_stats)) = diffs_result {
+            stats.files_changed += repo_stats.files_changed;
+            stats.lines_added += repo_stats.lines_added;
+            stats.lines_removed += repo_stats.lines_removed;
         }
     }
 

--- a/crates/services/src/services/execution_process.rs
+++ b/crates/services/src/services/execution_process.rs
@@ -15,7 +15,12 @@ use db::{
 use futures::{StreamExt, TryStreamExt};
 use indicatif::{ProgressBar, ProgressStyle};
 use sqlx::SqlitePool;
-use tokio::{io::AsyncWriteExt, sync::RwLock, task::JoinHandle};
+use tokio::{
+    fs::File,
+    io::{AsyncBufReadExt, AsyncWriteExt, BufReader},
+    sync::RwLock,
+    task::JoinHandle,
+};
 use utils::{
     assets::prod_asset_dir_path,
     execution_logs::{
@@ -26,6 +31,8 @@ use utils::{
     msg_store::MsgStore,
 };
 use uuid::Uuid;
+
+const MAX_HISTORICAL_LOG_LINE_BYTES: usize = 1024 * 1024;
 
 pub async fn migrate_execution_logs_to_files() -> Result<()> {
     let pool = DBService::new_migration_pool()
@@ -238,6 +245,29 @@ pub async fn load_raw_log_messages(pool: &SqlitePool, execution_id: Uuid) -> Opt
     }
 }
 
+pub async fn stream_raw_log_messages(
+    pool: &SqlitePool,
+    execution_id: Uuid,
+) -> Option<futures::stream::BoxStream<'static, Result<LogMsg, std::io::Error>>> {
+    if let Some(lines) = open_execution_log_lines(pool, execution_id)
+        .await
+        .inspect_err(|e| {
+            tracing::warn!(
+                "Failed to open execution log file for execution {}: {:#}",
+                execution_id,
+                e
+            );
+        })
+        .ok()
+        .flatten()
+    {
+        return Some(stream_log_lines_lossy(execution_id, lines));
+    }
+
+    let messages = load_raw_log_messages(pool, execution_id).await?;
+    Some(futures::stream::iter(messages.into_iter().map(Ok::<_, std::io::Error>)).boxed())
+}
+
 pub async fn append_log_message(session_id: Uuid, execution_id: Uuid, msg: &LogMsg) -> Result<()> {
     let mut log_writer = ExecutionLogWriter::new_for_execution(session_id, execution_id)
         .await
@@ -346,6 +376,164 @@ pub fn spawn_stream_raw_logs_to_storage(
             }
         }
     })
+}
+
+async fn open_execution_log_lines(
+    pool: &SqlitePool,
+    execution_id: Uuid,
+) -> Result<Option<BufReader<File>>> {
+    let session_id = if let Some(process) = ExecutionProcess::find_by_id(pool, execution_id).await?
+    {
+        process.session_id
+    } else {
+        return Ok(None);
+    };
+
+    let path = process_log_file_path(session_id, execution_id);
+    match File::open(&path).await {
+        Ok(file) => return Ok(Some(BufReader::new(file))),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => {
+            return Err(e).with_context(|| {
+                format!(
+                    "open execution log file for execution {execution_id} at {}",
+                    path.display()
+                )
+            });
+        }
+    }
+
+    if cfg!(debug_assertions) {
+        // Convenience for local development with a clone of a prod db. Read only access to prod logs.
+        let prod_path =
+            process_log_file_path_in_root(&prod_asset_dir_path(), session_id, execution_id);
+        match File::open(&prod_path).await {
+            Ok(file) => return Ok(Some(BufReader::new(file))),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+            Err(err) => {
+                return Err(err).with_context(|| {
+                    format!(
+                        "open execution log file for execution {execution_id} from {}",
+                        prod_path.display()
+                    )
+                });
+            }
+        }
+    }
+
+    Ok(None)
+}
+
+fn stream_log_lines_lossy(
+    execution_id: Uuid,
+    reader: BufReader<File>,
+) -> futures::stream::BoxStream<'static, Result<LogMsg, std::io::Error>> {
+    futures::stream::unfold(
+        (reader, 0usize, 0usize),
+        move |(mut reader, mut bad_lines, mut oversized_lines)| async move {
+            loop {
+                match read_bounded_line(&mut reader, MAX_HISTORICAL_LOG_LINE_BYTES).await {
+                    Ok(Some((line, oversized))) => {
+                        if oversized {
+                            oversized_lines += 1;
+                            if oversized_lines <= 3 {
+                                tracing::warn!(
+                                    "Skipping oversized historical log line for execution {}",
+                                    execution_id
+                                );
+                            }
+                            return Some((
+                                Ok(LogMsg::Stderr(format!(
+                                    "[vibe-kanban] Skipped an oversized historical log entry larger than {} bytes.",
+                                    MAX_HISTORICAL_LOG_LINE_BYTES
+                                ))),
+                                (reader, bad_lines, oversized_lines),
+                            ));
+                        }
+
+                        if line.iter().all(|byte| byte.is_ascii_whitespace()) {
+                            continue;
+                        }
+                        match serde_json::from_slice::<LogMsg>(&line) {
+                            Ok(msg) => return Some((Ok(msg), (reader, bad_lines, oversized_lines))),
+                            Err(e) => {
+                                bad_lines += 1;
+                                if bad_lines <= 3 {
+                                    tracing::warn!(
+                                        "Skipping unparsable log line for execution {}: {}",
+                                        execution_id,
+                                        e
+                                    );
+                                }
+                            }
+                        }
+                    }
+                    Ok(None) => {
+                        if bad_lines > 3 {
+                            tracing::warn!(
+                                "Skipped {} unparsable log lines for execution {}",
+                                bad_lines,
+                                execution_id
+                            );
+                        }
+                        if oversized_lines > 3 {
+                            tracing::warn!(
+                                "Skipped {} oversized historical log lines for execution {}",
+                                oversized_lines,
+                                execution_id
+                            );
+                        }
+                        return None;
+                    }
+                    Err(e) => return Some((Err(e), (reader, bad_lines, oversized_lines))),
+                }
+            }
+        },
+    )
+    .boxed()
+}
+
+async fn read_bounded_line(
+    reader: &mut BufReader<File>,
+    max_bytes: usize,
+) -> std::io::Result<Option<(Vec<u8>, bool)>> {
+    let mut line = Vec::with_capacity(4096);
+    let mut oversized = false;
+
+    loop {
+        let available = reader.fill_buf().await?;
+        if available.is_empty() {
+            if line.is_empty() && !oversized {
+                return Ok(None);
+            }
+            return Ok(Some((line, oversized)));
+        }
+
+        let consumed = if let Some(newline_index) = available.iter().position(|b| *b == b'\n') {
+            newline_index + 1
+        } else {
+            available.len()
+        };
+        let found_newline = available
+            .get(consumed.saturating_sub(1))
+            .is_some_and(|byte| *byte == b'\n');
+
+        if !oversized {
+            let remaining = max_bytes.saturating_sub(line.len());
+            if consumed <= remaining {
+                line.extend_from_slice(&available[..consumed]);
+            } else {
+                line.extend_from_slice(&available[..remaining]);
+                oversized = true;
+            }
+        }
+
+        reader.consume(consumed);
+
+        if found_newline {
+            return Ok(Some((line, oversized)));
+        }
+    }
 }
 
 async fn read_execution_logs_for_execution(

--- a/crates/utils/src/log_msg.rs
+++ b/crates/utils/src/log_msg.rs
@@ -1,6 +1,7 @@
 use axum::{extract::ws::Message, response::sse::Event};
-use json_patch::Patch;
+use json_patch::{Patch, PatchOperation};
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 pub const EV_STDOUT: &str = "stdout";
 pub const EV_STDERR: &str = "stderr";
@@ -71,14 +72,54 @@ impl LogMsg {
         match self {
             LogMsg::Stdout(s) => EV_STDOUT.len() + s.len() + OVERHEAD,
             LogMsg::Stderr(s) => EV_STDERR.len() + s.len() + OVERHEAD,
-            LogMsg::JsonPatch(patch) => {
-                let json_len = serde_json::to_string(patch).map(|s| s.len()).unwrap_or(2);
-                EV_JSON_PATCH.len() + json_len + OVERHEAD
-            }
+            LogMsg::JsonPatch(patch) => EV_JSON_PATCH.len() + patch_approx_bytes(patch) + OVERHEAD,
             LogMsg::SessionId(s) => EV_SESSION_ID.len() + s.len() + OVERHEAD,
             LogMsg::MessageId(s) => EV_MESSAGE_ID.len() + s.len() + OVERHEAD,
             LogMsg::Ready => EV_READY.len() + OVERHEAD,
             LogMsg::Finished => EV_FINISHED.len() + OVERHEAD,
+        }
+    }
+
+    pub fn json_patch_approx_bytes(patch: &Patch) -> usize {
+        patch_approx_bytes(patch)
+    }
+}
+
+fn patch_approx_bytes(patch: &Patch) -> usize {
+    patch.0.iter().map(patch_op_approx_bytes).sum::<usize>() + 2
+}
+
+fn patch_op_approx_bytes(op: &PatchOperation) -> usize {
+    const OP_OVERHEAD: usize = 32;
+    match op {
+        PatchOperation::Add(add) => OP_OVERHEAD + add.path.len() + value_approx_bytes(&add.value),
+        PatchOperation::Remove(remove) => OP_OVERHEAD + remove.path.len(),
+        PatchOperation::Replace(replace) => {
+            OP_OVERHEAD + replace.path.len() + value_approx_bytes(&replace.value)
+        }
+        PatchOperation::Move(move_op) => OP_OVERHEAD + move_op.path.len() + move_op.from.len(),
+        PatchOperation::Copy(copy) => OP_OVERHEAD + copy.path.len() + copy.from.len(),
+        PatchOperation::Test(test) => {
+            OP_OVERHEAD + test.path.len() + value_approx_bytes(&test.value)
+        }
+    }
+}
+
+fn value_approx_bytes(value: &Value) -> usize {
+    match value {
+        Value::Null => 4,
+        Value::Bool(_) => 5,
+        Value::Number(n) => n.to_string().len(),
+        Value::String(s) => s.len() + 2,
+        Value::Array(items) => {
+            items.iter().map(value_approx_bytes).sum::<usize>() + items.len() + 2
+        }
+        Value::Object(map) => {
+            map.iter()
+                .map(|(key, value)| key.len() + value_approx_bytes(value) + 4)
+                .sum::<usize>()
+                + map.len()
+                + 2
         }
     }
 }

--- a/crates/utils/src/msg_store.rs
+++ b/crates/utils/src/msg_store.rs
@@ -21,6 +21,7 @@ struct StoredMsg {
 struct Inner {
     history: VecDeque<StoredMsg>,
     total_bytes: usize,
+    max_history_bytes: usize,
 }
 
 pub struct MsgStore {
@@ -36,11 +37,16 @@ impl Default for MsgStore {
 
 impl MsgStore {
     pub fn new() -> Self {
+        Self::new_with_history_bytes(HISTORY_BYTES)
+    }
+
+    pub fn new_with_history_bytes(max_history_bytes: usize) -> Self {
         let (sender, _) = broadcast::channel(100000);
         Self {
             inner: RwLock::new(Inner {
                 history: VecDeque::with_capacity(32),
                 total_bytes: 0,
+                max_history_bytes,
             }),
             sender,
         }
@@ -51,7 +57,10 @@ impl MsgStore {
         let bytes = msg.approx_bytes();
 
         let mut inner = self.inner.write().unwrap();
-        while inner.total_bytes.saturating_add(bytes) > HISTORY_BYTES {
+        if bytes > inner.max_history_bytes {
+            return;
+        }
+        while inner.total_bytes.saturating_add(bytes) > inner.max_history_bytes {
             if let Some(front) = inner.history.pop_front() {
                 inner.total_bytes = inner.total_bytes.saturating_sub(front.bytes);
             } else {
@@ -170,5 +179,38 @@ impl MsgStore {
                 }
             }
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bounded_history_keeps_recent_messages_under_limit() {
+        let store = MsgStore::new_with_history_bytes(64);
+
+        store.push_stdout("first");
+        store.push_stdout("second");
+        store.push_stdout("third");
+
+        let history = store.get_history();
+        assert!(!history.is_empty());
+        assert!(history.iter().map(LogMsg::approx_bytes).sum::<usize>() <= 64);
+        assert!(matches!(history.last(), Some(LogMsg::Stdout(s)) if s == "third"));
+    }
+
+    #[test]
+    fn oversized_message_is_broadcast_but_not_retained() {
+        let store = MsgStore::new_with_history_bytes(16);
+        let mut receiver = store.get_receiver();
+
+        store.push_stdout("this message is too large for history");
+
+        assert!(store.get_history().is_empty());
+        assert!(matches!(
+            receiver.try_recv(),
+            Ok(LogMsg::Stdout(s)) if s == "this message is too large for history"
+        ));
     }
 }

--- a/packages/web-core/src/features/workspace-chat/model/hooks/useConversationHistory.ts
+++ b/packages/web-core/src/features/workspace-chat/model/hooks/useConversationHistory.ts
@@ -20,6 +20,10 @@ export interface UseConversationHistoryResult {
   isFirstTurn: boolean;
   /** Whether background batches are still loading older history entries */
   isLoadingHistory: boolean;
+  /** Whether older historical execution processes remain unloaded */
+  hasMoreHistory: boolean;
+  /** Load the next batch of older historical execution processes */
+  loadMoreHistory: () => Promise<void>;
 }
 import {
   MIN_INITIAL_ENTRIES,
@@ -47,6 +51,8 @@ export const useConversationHistory = ({
     new Map()
   );
   const [isLoadingHistoryState, setIsLoadingHistory] = useState(false);
+  const [hasMoreHistory, setHasMoreHistory] = useState(false);
+  const isLoadingMoreHistoryRef = useRef(false);
 
   // Derive whether this is the first turn (no follow-up processes exist)
   const isFirstTurn = useMemo(() => {
@@ -298,6 +304,7 @@ export const useConversationHistory = ({
       if (!executionProcesses?.current) return false;
 
       let anyUpdated = false;
+      let loadedEntries = 0;
       for (const executionProcess of [
         ...executionProcesses.current,
       ].reverse()) {
@@ -313,6 +320,7 @@ export const useConversationHistory = ({
         const entriesWithKey = entries.map((e, idx) =>
           patchWithKey(e, executionProcess.id, idx)
         );
+        loadedEntries += entriesWithKey.length;
 
         mergeIntoDisplayed((state) => {
           state[executionProcess.id] = {
@@ -321,9 +329,7 @@ export const useConversationHistory = ({
           };
         });
 
-        if (
-          flattenEntries(displayedExecutionProcesses.current).length > batchSize
-        ) {
+        if (loadedEntries > batchSize) {
           anyUpdated = true;
           break;
         }
@@ -333,6 +339,44 @@ export const useConversationHistory = ({
     },
     [executionProcesses]
   );
+
+  const hasUnloadedHistoricProcesses = useCallback(() => {
+    if (!executionProcesses?.current) return false;
+
+    return executionProcesses.current.some((executionProcess) => {
+      return (
+        executionProcess.status !== ExecutionProcessStatus.running &&
+        !displayedExecutionProcesses.current[executionProcess.id]
+      );
+    });
+  }, [executionProcesses]);
+
+  const loadMoreHistory = useCallback(async () => {
+    if (isLoadingMoreHistoryRef.current) return;
+    if (!hasUnloadedHistoricProcesses()) {
+      setHasMoreHistory(false);
+      return;
+    }
+
+    isLoadingMoreHistoryRef.current = true;
+    setIsLoadingHistory(true);
+
+    try {
+      const anyUpdated =
+        await loadRemainingEntriesInBatches(REMAINING_BATCH_SIZE);
+      if (anyUpdated) {
+        emitEntries(displayedExecutionProcesses.current, 'historic', false);
+      }
+      setHasMoreHistory(hasUnloadedHistoricProcesses());
+    } finally {
+      isLoadingMoreHistoryRef.current = false;
+      setIsLoadingHistory(false);
+    }
+  }, [
+    emitEntries,
+    hasUnloadedHistoricProcesses,
+    loadRemainingEntriesInBatches,
+  ]);
 
   const ensureProcessVisible = useCallback((p: ExecutionProcess) => {
     mergeIntoDisplayed((state) => {
@@ -385,6 +429,9 @@ export const useConversationHistory = ({
     emittedEmptyInitialRef.current = false;
     streamingProcessIdsRef.current.clear();
     previousStatusMapRef.current.clear();
+    isLoadingMoreHistoryRef.current = false;
+    setHasMoreHistory(false);
+    setIsLoadingHistory(false);
     emitEntries(displayedExecutionProcesses.current, 'initial', true);
   }, [scopeKey, emitEntries]);
 
@@ -411,16 +458,7 @@ export const useConversationHistory = ({
         Object.assign(state, allInitialEntries);
       });
       emitEntries(displayedExecutionProcesses.current, 'initial', false);
-
-      setIsLoadingHistory(true);
-      while (
-        !cancelled &&
-        (await loadRemainingEntriesInBatches(REMAINING_BATCH_SIZE))
-      ) {
-        if (cancelled) return;
-        emitEntries(displayedExecutionProcesses.current, 'historic', false);
-      }
-      if (!cancelled) setIsLoadingHistory(false);
+      setHasMoreHistory(hasUnloadedHistoricProcesses());
     })();
     return () => {
       cancelled = true;
@@ -429,8 +467,8 @@ export const useConversationHistory = ({
     scopeKey,
     idListKey,
     isLoading,
+    hasUnloadedHistoricProcesses,
     loadHistoricEntries,
-    loadRemainingEntriesInBatches,
     emitEntries,
   ]); // include idListKey so new processes trigger reload
 
@@ -535,5 +573,10 @@ export const useConversationHistory = ({
     }
   }, [scopeKey, idListKey, executionProcessesRaw]);
 
-  return { isFirstTurn, isLoadingHistory: isLoadingHistoryState };
+  return {
+    isFirstTurn,
+    isLoadingHistory: isLoadingHistoryState,
+    hasMoreHistory,
+    loadMoreHistory,
+  };
 };

--- a/packages/web-core/src/features/workspace-chat/ui/ConversationListContainer.tsx
+++ b/packages/web-core/src/features/workspace-chat/ui/ConversationListContainer.tsx
@@ -185,6 +185,7 @@ export const ConversationList = forwardRef<
   // ensuring every frame reflects the latest data.
   const rafIdRef = useRef<number | null>(null);
   const planRevealSpacerRef = useRef<HTMLDivElement | null>(null);
+  const historyLoadSentinelRef = useRef<HTMLDivElement | null>(null);
   const pendingInteractionAnchorRef = useRef<{
     element: HTMLElement;
     top: number;
@@ -383,11 +384,14 @@ export const ConversationList = forwardRef<
     }
   };
 
-  const { isFirstTurn, isLoadingHistory } = useConversationHistory({
-    attempt,
-    onTimelineUpdated,
-    scopeKey: conversationScopeKey,
-  });
+  const { isFirstTurn, isLoadingHistory, hasMoreHistory, loadMoreHistory } =
+    useConversationHistory({
+      attempt,
+      onTimelineUpdated,
+      scopeKey: conversationScopeKey,
+    });
+  const loadMoreHistoryRef = useRef(loadMoreHistory);
+  loadMoreHistoryRef.current = loadMoreHistory;
 
   const prevEntriesRef = useRef<DisplayEntry[]>([]);
   const prevRowsRef = useRef<ConversationRow[]>([]);
@@ -548,6 +552,38 @@ export const ConversationList = forwardRef<
     scrollToAbsoluteIndex,
   });
   scrollOnEntriesChangedRef.current = scrollExecutor.onEntriesChanged;
+
+  useEffect(() => {
+    const sentinel = historyLoadSentinelRef.current;
+    const scrollContainer = tanstackScrollRef.current;
+    if (
+      !sentinel ||
+      !scrollContainer ||
+      !hasMoreHistory ||
+      isLoadingHistory ||
+      loading
+    ) {
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry?.isIntersecting) {
+          void loadMoreHistoryRef.current();
+        }
+      },
+      {
+        root: scrollContainer,
+        rootMargin: '200px 0px 0px 0px',
+      }
+    );
+
+    observer.observe(sentinel);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [hasMoreHistory, isLoadingHistory, loading]);
 
   // Determine if there are entries to show placeholders
   const hasEntries = conversationRows.length > 0;
@@ -767,6 +803,8 @@ export const ConversationList = forwardRef<
           onClickCapture={handleConversationClickCapture}
         >
           <div className="pt-2">
+            {hasMoreHistory && <div ref={historyLoadSentinelRef} />}
+
             {showSetupPlaceholder && (
               <div className="my-base px-double">
                 <ChatScriptPlaceholder


### PR DESCRIPTION
## What changed

This bounds historical conversation replay and removes two follow-on server allocation paths hit while reproducing the reported workspace/session crash.

- Stream raw historical JSONL logs from disk instead of reading the full file into a string and `Vec`.
- Cap historical JSONL record reads so a single oversized saved log line is drained and skipped instead of allocated without bound.
- Give temporary historical normalization stores a bounded retention window.
- Estimate JSON patch size structurally instead of serializing patches just to decide whether history can retain them.
- Skip oversized historical normalized patches before websocket serialization.
- Keep live broadcasting behavior intact while preventing oversized messages from being retained in `MsgStore` history.
- Stop the workspace chat from eagerly loading every older process; older history now loads when the user scrolls near the top.
- Add `VK_DISABLE_PR_MONITOR=1` for local deployments so repro runs can disable background PR polling/fetching when GitHub/network is unavailable.
- Add stats-only Git diff loading for workspace summaries, and bound summary diff fan-out to four workspaces at a time.
- Serve embedded frontend assets without frontend-wide response compression, avoid copying borrowed embedded bytes, and block source-map serving by default unless `VK_SERVE_FRONTEND_SOURCE_MAPS=1` is set.
- Add `VK_DISABLE_AUTO_OPEN_BROWSER=1` and `VK_TRACE_FRONTEND_ASSETS=1` diagnostic gates for local server repro runs.

## Root cause

The original latest-session crash was caused by historical log replay loading large saved process logs through multiple full server-side copies before streaming them to the browser.

While reproducing the exact workspace/session again, two additional allocation paths showed up:

- `/api/workspaces/summaries` is polled by the frontend and previously computed diff counts by materializing full `Diff` objects, including file contents, for every workspace in parallel.
- Firefox/devtools requested the embedded production source map `assets/index-BKQdPAfe.js.map`. That file is about 24 MB in `packages/local-web/dist`, and serving it through the embedded frontend route plus compression caused the server to attempt another ~21 MB allocation and crash.

## Validation

- `pnpm run format`
- `pnpm --filter @vibe/web-core run check`
- `cargo test -p utils bounded_history_keeps_recent_messages_under_limit`
- `cargo test -p utils oversized_message_is_broadcast_but_not_retained`
- `cargo test -p git parse_numstat_counts_text_and_binary_files`
- `cargo check -p services -p utils`
- `cargo check -p local-deployment -p services -p utils` with corrected bindgen args
- `cargo check -p git -p services -p server -p local-deployment` with corrected bindgen args
- `cargo check -p server` after the frontend asset serving changes
- Ran the release server on `http://localhost:13334` with `VK_SHARED_API_BASE=http://localhost:13000`, `VK_DISABLE_PR_MONITOR=1`, and `VK_DISABLE_AUTO_OPEN_BROWSER=1`.
- Verified `GET /api/info`, the target page `/workspaces/76d071e2-15c5-46bc-ab8b-24f1e58bc562?session=3cd570c0-d9f6-421b-b9b1-e095bce3bfa9`, and active/archived `/api/workspaces/summaries` all return 200.
- Replayed normalized-log websockets for the target session processes without server crash.
- Verified `assets/index-BKQdPAfe.js.map` returns 404 by default and logs `Frontend source map request blocked`.
- With the problematic workspace/session open, server memory flattened around 102 MB RSS / 68 MB private memory instead of continuing to climb to crash.

Notes:

- On this Windows host, build-time bindgen requires `LIBCLANG_PATH=C:\tmp\llvm-minimal\bin` and `BINDGEN_EXTRA_CLANG_ARGS=-isystemC:/Users/magne/utils/Tooll-v3.9.3/lib/clang/14.0.0/include`. The no-space `-isystem...` form matters; `-isystem C:/...` failed to locate `stdarg.h` in this build.
- A full `cargo test -p utils` also hits an unrelated existing Windows path assertion in `path::tests::test_make_path_relative`; the new `MsgStore` tests pass individually.
