### PR TITLE
feat: add Forgejo/Gitea git provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3534,6 +3534,7 @@ dependencies = [
  "chrono",
  "db",
  "enum_dispatch",
+ "reqwest 0.13.2",
  "serde",
  "serde_json",
  "tempfile",

--- a/crates/git-host/Cargo.toml
+++ b/crates/git-host/Cargo.toml
@@ -9,6 +9,7 @@ backon = "1.5.1"
 chrono = { version = "0.4", features = ["serde"] }
 db = { path = "../db" }
 enum_dispatch = "0.3.13"
+reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tempfile = "3.21"

--- a/crates/git-host/src/detection.rs
+++ b/crates/git-host/src/detection.rs
@@ -8,6 +8,7 @@ use crate::types::ProviderKind;
 /// - GitHub.com: `https://github.com/owner/repo` or `git@github.com:owner/repo.git`
 /// - GitHub Enterprise: URLs containing `github.` (e.g., `https://github.company.com/owner/repo`)
 /// - Azure DevOps: `https://dev.azure.com/org/project/_git/repo` or legacy `https://org.visualstudio.com/...`
+/// - Forgejo/Gitea: Known instances (codeberg.org, gitea.com) or hostname containing `forgejo` or `gitea`
 pub(crate) fn detect_provider_from_url(url: &str) -> ProviderKind {
     let url_lower = url.to_lowercase();
 
@@ -28,6 +29,16 @@ pub(crate) fn detect_provider_from_url(url: &str) -> ProviderKind {
         return ProviderKind::AzureDevOps;
     }
 
+    // Check Forgejo/Gitea patterns BEFORE GitHub Enterprise (since generic hostnames could false-positive)
+    // Known Forgejo/Gitea hostnames
+    if url_lower.contains("codeberg.org") || url_lower.contains("gitea.com") {
+        return ProviderKind::Forgejo;
+    }
+    // Custom Forgejo/Gitea instances: hostname contains "forgejo" or "gitea"
+    if url_lower.contains("forgejo") || url_lower.contains("gitea") {
+        return ProviderKind::Forgejo;
+    }
+
     // GitHub Enterprise (contains "github." but not the Azure patterns above)
     if url_lower.contains("github.") {
         return ProviderKind::GitHub;
@@ -42,11 +53,24 @@ pub(crate) fn detect_provider_from_url(url: &str) -> ProviderKind {
 /// - GitHub: `https://github.com/owner/repo/pull/123`
 /// - GitHub Enterprise: `https://github.company.com/owner/repo/pull/123`
 /// - Azure DevOps: `https://dev.azure.com/org/project/_git/repo/pullrequest/123`
+/// - Forgejo/Gitea: `https://forgejo.example.com/owner/repo/pulls/123` (plural /pulls/)
 #[cfg(test)]
 fn detect_provider_from_pr_url(pr_url: &str) -> ProviderKind {
     let url_lower = pr_url.to_lowercase();
 
-    // GitHub pattern: contains /pull/ in the path
+    // Forgejo/Gitea pattern: contains /pulls/ (plural) in the path
+    if url_lower.contains("/pulls/") {
+        // Could be codeberg, gitea.com, or custom forgejo/gitea instance
+        if url_lower.contains("codeberg.org")
+            || url_lower.contains("gitea.com")
+            || url_lower.contains("forgejo")
+            || url_lower.contains("gitea")
+        {
+            return ProviderKind::Forgejo;
+        }
+    }
+
+    // GitHub pattern: contains /pull/ (singular) in the path
     if url_lower.contains("/pull/") {
         // Could be github.com or GHE
         if url_lower.contains("github.com") || url_lower.contains("github.") {
@@ -173,6 +197,87 @@ mod tests {
                 "https://org.visualstudio.com/project/_git/repo/pullrequest/456"
             ),
             ProviderKind::AzureDevOps
+        );
+    }
+
+    #[test]
+    fn test_forgejo_url_codeberg() {
+        assert_eq!(
+            detect_provider_from_url("https://codeberg.org/owner/repo"),
+            ProviderKind::Forgejo
+        );
+        assert_eq!(
+            detect_provider_from_url("https://codeberg.org/owner/repo.git"),
+            ProviderKind::Forgejo
+        );
+        assert_eq!(
+            detect_provider_from_url("git@codeberg.org:owner/repo.git"),
+            ProviderKind::Forgejo
+        );
+    }
+
+    #[test]
+    fn test_forgejo_url_gitea_com() {
+        assert_eq!(
+            detect_provider_from_url("https://gitea.com/owner/repo"),
+            ProviderKind::Forgejo
+        );
+        assert_eq!(
+            detect_provider_from_url("git@gitea.com:owner/repo.git"),
+            ProviderKind::Forgejo
+        );
+    }
+
+    #[test]
+    fn test_forgejo_url_custom_instance() {
+        // Custom Forgejo instance
+        assert_eq!(
+            detect_provider_from_url("https://forgejo.example.com/owner/repo"),
+            ProviderKind::Forgejo
+        );
+        assert_eq!(
+            detect_provider_from_url("https://git.forgejo.example.com/owner/repo"),
+            ProviderKind::Forgejo
+        );
+        // Custom Gitea instance
+        assert_eq!(
+            detect_provider_from_url("https://gitea.mycompany.com/owner/repo"),
+            ProviderKind::Forgejo
+        );
+        assert_eq!(
+            detect_provider_from_url("git@gitea.mycompany.com:owner/repo.git"),
+            ProviderKind::Forgejo
+        );
+    }
+
+    #[test]
+    fn test_forgejo_pr_url() {
+        // Forgejo uses /pulls/ (plural) in PR URLs
+        assert_eq!(
+            detect_provider_from_pr_url("https://codeberg.org/owner/repo/pulls/123"),
+            ProviderKind::Forgejo
+        );
+        assert_eq!(
+            detect_provider_from_pr_url("https://forgejo.example.com/owner/repo/pulls/456"),
+            ProviderKind::Forgejo
+        );
+        assert_eq!(
+            detect_provider_from_pr_url("https://gitea.com/owner/repo/pulls/789"),
+            ProviderKind::Forgejo
+        );
+    }
+
+    #[test]
+    fn test_forgejo_different_from_github() {
+        // Forgejo URLs should NOT be detected as GitHub even if they contain similar patterns
+        assert_ne!(
+            detect_provider_from_url("https://codeberg.org/owner/repo"),
+            ProviderKind::GitHub
+        );
+        // GitHub Enterprise should still be detected as GitHub
+        assert_eq!(
+            detect_provider_from_url("https://github.company.com/owner/repo"),
+            ProviderKind::GitHub
         );
     }
 }

--- a/crates/git-host/src/forgejo/cli.rs
+++ b/crates/git-host/src/forgejo/cli.rs
@@ -1,0 +1,466 @@
+//! Forgejo/Gitea REST API client.
+//!
+//! This module provides low-level access to the Forgejo/Gitea REST API.
+//! Forgejo is API-compatible with Gitea, so this client works for both.
+
+use std::env;
+
+use chrono::{DateTime, Utc};
+use db::models::merge::MergeStatus;
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use url::Url;
+
+use crate::types::{CreatePrRequest, PrComment, PrCommentAuthor, PrReviewComment, PullRequestDetail, ReviewCommentUser};
+
+#[derive(Debug, Clone)]
+pub struct ForgejoRepoInfo {
+    pub owner: String,
+    pub repo_name: String,
+    /// Base URL of the Forgejo instance (e.g., "https://codeberg.org" or custom instance)
+    pub base_url: String,
+}
+
+impl ForgejoRepoInfo {
+    /// Returns the API base URL for this repo.
+    pub fn api_url(&self) -> String {
+        format!(
+            "{}/api/v1/repos/{}/{}",
+            self.base_url.trim_end_matches('/'),
+            self.owner,
+            self.repo_name
+        )
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum ForgejoApiError {
+    #[error("FORGEJO_TOKEN environment variable not set")]
+    NotConfigured(String),
+    #[error("HTTP error {0}: {1}")]
+    HttpError(u16, String),
+    #[error("Authentication failed: {0}")]
+    AuthFailed(String),
+    #[error("Unexpected output: {0}")]
+    UnexpectedOutput(String),
+    #[error("Reqwest error: {0}")]
+    ReqwestError(#[from] reqwest::Error),
+}
+
+#[derive(Debug, Clone)]
+pub struct ForgejoApi {
+    client: Client,
+    token: String,
+}
+
+impl ForgejoApi {
+    pub fn new() -> Result<Self, ForgejoApiError> {
+        let token = env::var("FORGEJO_TOKEN")
+            .map_err(|_| ForgejoApiError::NotConfigured("FORGEJO_TOKEN not set".to_string()))?;
+
+        let client = Client::builder()
+            .timeout(std::time::Duration::from_secs(30))
+            .build()
+            .map_err(ForgejoApiError::ReqwestError)?;
+
+        Ok(Self { client, token })
+    }
+
+    /// Parse a remote URL (HTTPS or SSH) into owner, repo, and base URL.
+    pub fn parse_remote_url(&self, url: &str) -> Result<ForgejoRepoInfo, ForgejoApiError> {
+        let url = url.trim().trim_end_matches(".git");
+
+        if url.starts_with("git@") {
+            // SSH format: git@codeberg.org:owner/repo.git
+            let without_prefix = url.strip_prefix("git@").ok_or_else(|| {
+                ForgejoApiError::UnexpectedOutput(format!("Invalid SSH URL: {url}"))
+            })?;
+            let (host, path) = without_prefix.split_once(':').ok_or_else(|| {
+                ForgejoApiError::UnexpectedOutput(format!("Invalid SSH URL format: {url}"))
+            })?;
+            let parts: Vec<&str> = path.split('/').collect();
+            if parts.len() < 2 {
+                return Err(ForgejoApiError::UnexpectedOutput(format!(
+                    "Invalid repo path in SSH URL: {path}"
+                )));
+            }
+            let owner = parts[0].to_string();
+            let repo_name = parts[1].to_string();
+            let base_url = format!("https://{}", host);
+            return Ok(ForgejoRepoInfo {
+                owner,
+                repo_name,
+                base_url,
+            });
+        }
+
+        // HTTPS format: https://codeberg.org/owner/repo
+        let parsed = Url::parse(url).map_err(|e| {
+            ForgejoApiError::UnexpectedOutput(format!("Invalid HTTPS URL: {e}"))
+        })?;
+
+        let host = parsed.host_str().ok_or_else(|| {
+            ForgejoApiError::UnexpectedOutput(format!("No host in URL: {url}"))
+        })?;
+
+        let path_parts: Vec<&str> = parsed
+            .path_segments()
+            .ok_or_else(|| {
+                ForgejoApiError::UnexpectedOutput(format!("No path in URL: {url}"))
+            })?
+            .collect();
+
+        if path_parts.len() < 2 {
+            return Err(ForgejoApiError::UnexpectedOutput(format!(
+                "Invalid repo path in URL: {}",
+                parsed.path()
+            )));
+        }
+
+        let owner = path_parts[0].to_string();
+        let repo_name = path_parts[1].to_string();
+        let base_url = format!("{}://{}", parsed.scheme(), host);
+
+        Ok(ForgejoRepoInfo {
+            owner,
+            repo_name,
+            base_url,
+        })
+    }
+
+    /// Make an authenticated API request.
+    fn api_request(&self, method: reqwest::Method, url: &str) -> reqwest::RequestBuilder {
+        let client = self.client.clone();
+        let token = &self.token;
+
+        client
+            .request(method, url)
+            .header("Authorization", format!("token {token}"))
+            .header("Accept", "application/json")
+    }
+
+    /// Create a pull request.
+    pub fn create_pr(
+&self,
+        request: &CreatePrRequest,
+        repo_info: &ForgejoRepoInfo,
+    ) -> Result<PullRequestDetail, ForgejoApiError> {
+        let url = format!("{}/pulls", repo_info.api_url());
+
+        #[derive(Serialize)]
+        struct CreatePrPayload<'a> {
+            title: &'a str,
+            body: &'a str,
+            head: &'a str,
+            base: &'a str,
+        }
+
+        let body = request.body.as_deref().unwrap_or("");
+        let payload = CreatePrPayload {
+            title: &request.title,
+            body,
+            head: &request.head_branch,
+            base: &request.base_branch,
+        };
+
+        let response = self
+            .api_request(reqwest::Method::POST, &url)
+            .json(&payload)
+            .send()?;
+
+        self.handle_response(response)?
+            .json::<ForgejoPullResponse>()
+            .map_err(ForgejoApiError::ReqwestError)
+            .map(|pr| self.pr_response_to_detail(pr, repo_info))
+    }
+
+    /// Get a pull request by number.
+    pub fn view_pr(
+        &self,
+        repo_info: &ForgejoRepoInfo,
+        pr_number: i64,
+    ) -> Result<PullRequestDetail, ForgejoApiError> {
+        let url = format!("{}/pulls/{}", repo_info.api_url(), pr_number);
+
+        let response = self.api_request(reqwest::Method::GET, &url).send()?;
+
+        self.handle_response(response)?
+            .json::<ForgejoPullResponse>()
+            .map_err(ForgejoApiError::ReqwestError)
+            .map(|pr| self.pr_response_to_detail(pr, repo_info))
+    }
+
+    /// Parse a PR URL to extract repo info and PR number.
+    pub fn parse_pr_url(&self, pr_url: &str) -> Result<(ForgejoRepoInfo, i64), ForgejoApiError> {
+        // Forgejo PR URL format: https://forgejo.example.com/owner/repo/pulls/123
+        let parsed = Url::parse(pr_url).map_err(|e| {
+            ForgejoApiError::UnexpectedOutput(format!("Invalid PR URL: {e}"))
+        })?;
+
+        let path_parts: Vec<&str> = parsed
+            .path_segments()
+            .ok_or_else(|| {
+                ForgejoApiError::UnexpectedOutput(format!("No path in PR URL: {pr_url}"))
+            })?
+            .collect();
+
+        // Find "pulls" in path and extract owner/repo/pr_number
+        let pulls_idx = path_parts.iter().position(|&p| p == "pulls");
+
+        if let Some(idx) = pulls_idx {
+            if idx >= 2 && path_parts.len() > idx + 1 {
+                let owner = path_parts[idx - 2].to_string();
+                let repo_name = path_parts[idx - 1].to_string();
+                let pr_number = path_parts[idx + 1].parse::<i64>().map_err(|_| {
+                    ForgejoApiError::UnexpectedOutput(format!(
+                        "Invalid PR number in URL: {}",
+                        path_parts[idx + 1]
+                    ))
+                })?;
+
+                let host = parsed.host_str().ok_or_else(|| {
+                    ForgejoApiError::UnexpectedOutput(format!("No host in PR URL: {pr_url}"))
+                })?;
+                let base_url = format!("{}://{}", parsed.scheme(), host);
+
+                let repo_info = ForgejoRepoInfo {
+                    owner,
+                    repo_name,
+                    base_url,
+                };
+
+                return Ok((repo_info, pr_number));
+            }
+        }
+
+        Err(ForgejoApiError::UnexpectedOutput(format!(
+            "Could not parse Forgejo PR URL: {pr_url}"
+        )))
+    }
+
+    /// List pull requests for a branch.
+    pub fn list_prs_for_branch(
+       &self,
+        repo_info: &ForgejoRepoInfo,
+        branch: &str,
+    ) -> Result<Vec<PullRequestDetail>, ForgejoApiError> {
+        let url = format!(
+            "{}/pulls?state=all&head={}",
+            repo_info.api_url(),
+            branch
+        );
+
+        let response = self.api_request(reqwest::Method::GET, &url).send()?;
+
+        self.handle_response(response)?
+            .json::<Vec<ForgejoPullResponse>>()
+            .map_err(ForgejoApiError::ReqwestError)
+            .map(|prs| {
+                prs.into_iter()
+                    .map(|pr| self.pr_response_to_detail(pr, repo_info))
+                    .collect()
+            })
+    }
+
+    /// List open pull requests.
+    pub fn list_open_prs(
+        &self,
+        repo_info: &ForgejoRepoInfo,
+    ) -> Result<Vec<PullRequestDetail>, ForgejoApiError> {
+        let url = format!("{}/pulls?state=open&limit=50", repo_info.api_url());
+
+        let response = self.api_request(reqwest::Method::GET, &url).send()?;
+
+        self.handle_response(response)?
+            .json::<Vec<ForgejoPullResponse>>()
+            .map_err(ForgejoApiError::ReqwestError)
+            .map(|prs| {
+                prs.into_iter()
+                    .map(|pr| self.pr_response_to_detail(pr, repo_info))
+                    .collect()
+            })
+    }
+
+    /// Get general comments for a pull request.
+    pub fn get_pr_comments(
+        &self,
+        repo_info: &ForgejoRepoInfo,
+        pr_number: i64,
+    ) -> Result<Vec<PrComment>, ForgejoApiError> {
+        // Forgejo uses /issues/{index}/comments for PR general comments
+        let url = format!("{}/issues/{}/comments", repo_info.api_url(), pr_number);
+
+        let response = self.api_request(reqwest::Method::GET, &url).send()?;
+
+        self.handle_response(response)?
+            .json::<Vec<ForgejoIssueComment>>()
+            .map_err(ForgejoApiError::ReqwestError)
+            .map(|comments| {
+                comments
+                    .into_iter()
+                    .map(|c| PrComment {
+                        id: c.id.to_string(),
+                        author: PrCommentAuthor {
+                            login: c.user.login,
+                        },
+                        author_association: String::new(),
+                        body: c.body,
+                        created_at: c.created_at,
+                        url: c.html_url,
+                    })
+                    .collect()
+            })
+    }
+
+    /// Get inline review comments for a pull request.
+    pub fn get_pr_review_comments(
+       &self,
+        repo_info: &ForgejoRepoInfo,
+        pr_number: i64,
+    ) -> Result<Vec<PrReviewComment>, ForgejoApiError> {
+        let url = format!("{}/pulls/{}/comments", repo_info.api_url(), pr_number);
+
+        let response = self.api_request(reqwest::Method::GET, &url).send()?;
+
+        self.handle_response(response)?
+            .json::<Vec<ForgejoReviewComment>>()
+            .map_err(ForgejoApiError::ReqwestError)
+            .map(|comments| {
+                comments
+                    .into_iter()
+                    .map(|c| PrReviewComment {
+                        id: c.id,
+                        user: ReviewCommentUser {
+                            login: c.user.login,
+                        },
+                        body: c.body,
+                        created_at: c.created_at,
+                        html_url: c.html_url,
+                        path: c.path,
+                        line: c.line,
+                        side: c.side,
+                        diff_hunk: c.diff_hunk,
+                        author_association: String::new(),
+                    })
+                    .collect()
+            })
+    }
+
+    fn handle_response(
+&self,
+        response: reqwest::Response,
+    ) -> Result<reqwest::Response, ForgejoApiError> {
+        let status = response.status();
+
+        if status.as_u16() == 401 {
+            let text = response.text().await.unwrap_or_default();
+            return Err(ForgejoApiError::AuthFailed(text));
+        }
+
+        if !status.is_success() {
+            let text = response.text().await.unwrap_or_default();
+            return Err(ForgejoApiError::HttpError(status.as_u16(), text));
+        }
+
+        Ok(response)
+    }
+
+    fn pr_response_to_detail(
+        &self,
+        pr: ForgejoPullResponse,
+        repo_info: &ForgejoRepoInfo,
+    ) -> PullRequestDetail {
+        let url = format!(
+            "{}/{}/{}/pulls/{}",
+            repo_info.base_url.trim_end_matches('/'),
+            repo_info.owner,
+            repo_info.repo_name,
+            pr.index
+        );
+
+        let status = if pr.merged {
+            MergeStatus::Merged
+        } else if pr.state == "closed" {
+            MergeStatus::Closed
+        } else {
+            MergeStatus::Open
+        };
+
+        PullRequestDetail {
+            number: pr.index,
+            url,
+            status,
+            merged_at: pr.merged_at,
+            merge_commit_sha: pr.merge_commit.and_then(|c| c.oid),
+            title: pr.title,
+            base_branch: pr.base_branch,
+            head_branch: pr.head_branch,
+        }
+    }
+}
+
+// ============================================================================
+// Forgejo API response types
+// ============================================================================
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ForgejoPullResponse {
+    /// Forgejo uses "index" not "number" for PR identifier
+    index: i64,
+    #[serde(default)]
+    url: String,
+    #[serde(default)]
+    state: String,
+    merged: bool,
+    merged_at: Option<DateTime<Utc>>,
+    #[serde(default)]
+    merge_commit: Option<ForgejoCommit>,
+    #[serde(default)]
+    title: String,
+    #[serde(default)]
+    base_branch: String,
+    #[serde(default)]
+    head_branch: String,
+}
+
+#[derive(Deserialize)]
+struct ForgejoCommit {
+    oid: Option<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ForgejoIssueComment {
+    id: i64,
+    user: ForgejoUser,
+    #[serde(default)]
+    body: String,
+    created_at: DateTime<Utc>,
+    #[serde(default)]
+    html_url: String,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ForgejoReviewComment {
+    id: i64,
+    user: ForgejoUser,
+    #[serde(default)]
+    body: String,
+    created_at: DateTime<Utc>,
+    #[serde(default)]
+    html_url: String,
+    #[serde(default)]
+    path: String,
+    line: Option<i64>,
+    side: Option<String>,
+    #[serde(default)]
+    diff_hunk: String,
+}
+
+#[derive(Deserialize)]
+struct ForgejoUser {
+    login: String,
+}

--- a/crates/git-host/src/forgejo/mod.rs
+++ b/crates/git-host/src/forgejo/mod.rs
@@ -1,0 +1,403 @@
+//! Forgejo/Gitea hosting service implementation.
+
+mod cli;
+
+use std::{path::Path, time::Duration};
+
+use async_trait::async_trait;
+use backon::{ExponentialBuilder, Retryable};
+pub use cli::ForgejoApi;
+use cli::{ForgejoApiError, ForgejoRepoInfo};
+use tokio::task;
+use tracing::info;
+
+use crate::{
+    GitHostProvider,
+    types::{
+        CreatePrRequest, GitHostError, PrComment, PrReviewComment, ProviderKind, PullRequestDetail,
+        UnifiedPrComment,
+    },
+};
+
+#[derive(Debug, Clone)]
+pub struct ForgejoProvider {
+    api: ForgejoApi,
+}
+
+impl ForgejoProvider {
+    pub fn new() -> Result<Self, GitHostError> {
+        Ok(Self {
+            api: ForgejoApi::new().map_err(GitHostError::from)?,
+        })
+    }
+
+    async fn get_repo_info(
+&self,
+        remote_url: &str,
+    ) -> Result<ForgejoRepoInfo, GitHostError> {
+        let api = self.api.clone();
+        let url = remote_url.to_string();
+        task::spawn_blocking(move || api.parse_remote_url(&url))
+            .await
+            .map_err(|err| {
+                GitHostError::Repository(format!("Failed to parse repo URL: {err}"))
+            })?
+            .map_err(Into::into)
+    }
+
+    async fn get_repo_info_from_pr_url(
+        &self,
+        pr_url: &str,
+    ) -> Result<(ForgejoRepoInfo, i64), GitHostError> {
+        let api = self.api.clone();
+        let url = pr_url.to_string();
+        task::spawn_blocking(move || api.parse_pr_url(&url))
+            .await
+            .map_err(|err| {
+                GitHostError::Repository(format!("Failed to parse PR URL: {err}"))
+            })?
+            .map_err(Into::into)
+    }
+
+    async fn fetch_general_comments(
+        &self,
+        api: &ForgejoApi,
+        repo_info: &ForgejoRepoInfo,
+        pr_number: i64,
+    ) -> Result<Vec<PrComment>, GitHostError> {
+        let api = api.clone();
+        let repo_info = repo_info.clone();
+
+        (|| async {
+            let api = api.clone();
+            let repo_info = repo_info.clone();
+
+            let comments = task::spawn_blocking(move || {
+                api.get_pr_comments(&repo_info, pr_number)
+            })
+            .await
+            .map_err(|err| {
+                GitHostError::PullRequest(format!(
+                    "Failed to execute Forgejo API for fetching PR comments: {err}"
+                ))
+            })?
+            .map_err(GitHostError::from)?;
+
+            Ok(comments)
+        })
+        .retry(
+&ExponentialBuilder::default()
+                .with_min_delay(Duration::from_secs(1))
+                .with_max_delay(Duration::from_secs(30))
+                .with_max_times(3)
+                .with_jitter(),
+        )
+        .when(|e: &GitHostError| e.should_retry())
+        .notify(|err: &GitHostError, dur: Duration| {
+            tracing::warn!(
+                "Forgejo API call failed, retrying after {:.2}s: {}",
+                dur.as_secs_f64(),
+                err
+            );
+        })
+        .await
+    }
+
+    async fn fetch_review_comments(
+       &self,
+        api: &ForgejoApi,
+        repo_info: &ForgejoRepoInfo,
+        pr_number: i64,
+    ) -> Result<Vec<PrReviewComment>, GitHostError> {
+        let api = api.clone();
+        let repo_info = repo_info.clone();
+
+        (|| async {
+            let api = api.clone();
+            let repo_info = repo_info.clone();
+
+            let comments = task::spawn_blocking(move || {
+                api.get_pr_review_comments(&repo_info, pr_number)
+            })
+            .await
+            .map_err(|err| {
+                GitHostError::PullRequest(format!(
+                    "Failed to execute Forgejo API for fetching review comments: {err}"
+                ))
+            })?
+            .map_err(GitHostError::from)?;
+
+            Ok(comments)
+        })
+        .retry(
+            &ExponentialBuilder::default()
+                .with_min_delay(Duration::from_secs(1))
+                .with_max_delay(Duration::from_secs(30))
+                .with_max_times(3)
+                .with_jitter(),
+        )
+        .when(|e: &GitHostError| e.should_retry())
+        .notify(|err: &GitHostError, dur: Duration| {
+            tracing::warn!(
+                "Forgejo API call failed, retrying after {:.2}s: {}",
+                dur.as_secs_f64(),
+                err
+            );
+        })
+        .await
+    }
+}
+
+impl From<ForgejoApiError> for GitHostError {
+    fn from(error: ForgejoApiError) -> Self {
+        match &error {
+            ForgejoApiError::NotConfigured(msg) => {
+                GitHostError::Repository(format!("Forgejo not configured: {msg}"))
+            }
+            ForgejoApiError::AuthFailed(msg) => GitHostError::AuthFailed(msg.clone()),
+            ForgejoApiError::HttpError(status, msg) => {
+                let lower = msg.to_ascii_lowercase();
+                if *status == 403 || lower.contains("forbidden") {
+                    GitHostError::InsufficientPermissions(msg.clone())
+                } else if *status == 404 || lower.contains("not found") {
+                    GitHostError::RepoNotFoundOrNoAccess(msg.clone())
+                } else {
+                    GitHostError::PullRequest(format!("HTTP {status}: {msg}"))
+                }
+            }
+            ForgejoApiError::UnexpectedOutput(msg) => GitHostError::UnexpectedOutput(msg.clone()),
+            ForgejoApiError::ReqwestError(err) => {
+                GitHostError::PullRequest(format!("Request failed: {err}"))
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl GitHostProvider for ForgejoProvider {
+    async fn create_pr(
+        &self,
+        _repo_path: &Path,
+        remote_url: &str,
+        request: &CreatePrRequest,
+    ) -> Result<PullRequestDetail, GitHostError> {
+        let repo_info = self.get_repo_info(remote_url).await?;
+
+        (|| async {
+            let api = self.api.clone();
+            let request = request.clone();
+            let repo_info = repo_info.clone();
+
+            let result = task::spawn_blocking(move || api.create_pr(&request, &repo_info))
+                .await
+                .map_err(|err| {
+                    GitHostError::PullRequest(format!(
+                        "Failed to execute Forgejo API for PR creation: {err}"
+                    ))
+                })?
+                .map_err(GitHostError::from)?;
+
+            info!(
+                "Created Forgejo PR #{} for branch {}",
+                result.number, request.head_branch
+            );
+
+            Ok(result)
+        })
+        .retry(
+            &ExponentialBuilder::default()
+                .with_min_delay(Duration::from_secs(1))
+                .with_max_delay(Duration::from_secs(30))
+                .with_max_times(3)
+                .with_jitter(),
+        )
+        .when(|e: &GitHostError| e.should_retry())
+        .notify(|err: &GitHostError, dur: Duration| {
+            tracing::warn!(
+                "Forgejo API call failed, retrying after {:.2}s: {}",
+                dur.as_secs_f64(),
+                err
+            );
+        })
+        .await
+    }
+
+    async fn get_pr_status(&self, pr_url: &str) -> Result<PullRequestDetail, GitHostError> {
+        let (repo_info, pr_number) = self.get_repo_info_from_pr_url(pr_url).await?;
+
+        (|| async {
+            let api = self.api.clone();
+            let repo_info = repo_info.clone();
+
+            let pr = task::spawn_blocking(move || api.view_pr(&repo_info, pr_number))
+                .await
+                .map_err(|err| {
+                    GitHostError::PullRequest(format!(
+                        "Failed to execute Forgejo API for viewing PR: {err}"
+                    ))
+                })?
+                .map_err(GitHostError::from)?;
+
+            Ok(pr)
+        })
+        .retry(
+&ExponentialBuilder::default()
+                .with_min_delay(Duration::from_secs(1))
+                .with_max_delay(Duration::from_secs(30))
+                .with_max_times(3)
+                .with_jitter(),
+        )
+        .when(|err: &GitHostError| err.should_retry())
+        .notify(|err: &GitHostError, dur: Duration| {
+            tracing::warn!(
+                "Forgejo API call failed, retrying after {:.2}s: {}",
+                dur.as_secs_f64(),
+                err
+            );
+        })
+        .await
+    }
+
+    async fn list_prs_for_branch(
+        &self,
+        _repo_path: &Path,
+        remote_url: &str,
+        branch_name: &str,
+    ) -> Result<Vec<PullRequestDetail>, GitHostError> {
+        let repo_info = self.get_repo_info(remote_url).await?;
+
+        (|| async {
+            let api = self.api.clone();
+            let repo_info = repo_info.clone();
+            let branch = branch_name.to_string();
+
+            let prs = task::spawn_blocking(move || {
+                api.list_prs_for_branch(&repo_info, &branch)
+            })
+            .await
+            .map_err(|err| {
+                GitHostError::PullRequest(format!(
+                    "Failed to execute Forgejo API for listing PRs: {err}"
+                ))
+            })?
+            .map_err(GitHostError::from)?;
+
+            Ok(prs)
+        })
+        .retry(
+&ExponentialBuilder::default()
+                .with_min_delay(Duration::from_secs(1))
+                .with_max_delay(Duration::from_secs(30))
+                .with_max_times(3)
+                .with_jitter(),
+        )
+        .when(|e: &GitHostError| e.should_retry())
+        .notify(|err: &GitHostError, dur: Duration| {
+            tracing::warn!(
+                "Forgejo API call failed, retrying after {:.2}s: {}",
+                dur.as_secs_f64(),
+                err
+            );
+        })
+        .await
+    }
+
+    async fn get_pr_comments(
+       &self,
+        _repo_path: &Path,
+        remote_url: &str,
+        pr_number: i64,
+    ) -> Result<Vec<UnifiedPrComment>, GitHostError> {
+        let repo_info = self.get_repo_info(remote_url).await?;
+
+        // Fetch both types of comments in parallel
+        let api1 = self.api.clone();
+        let api2 = self.api.clone();
+
+        let (general_result, review_result) = tokio::join!(
+            self.fetch_general_comments(&api1, &repo_info, pr_number),
+            self.fetch_review_comments(&api2, &repo_info, pr_number)
+        );
+
+        let general_comments = general_result?;
+        let review_comments = review_result?;
+
+        // Convert and merge into unified timeline
+        let mut unified: Vec<UnifiedPrComment> = Vec::new();
+
+        for c in general_comments {
+            unified.push(UnifiedPrComment::General {
+                id: c.id,
+                author: c.author.login,
+                author_association: Some(c.author_association),
+                body: c.body,
+                created_at: c.created_at,
+                url: Some(c.url),
+            });
+        }
+
+        for c in review_comments {
+            unified.push(UnifiedPrComment::Review {
+                id: c.id,
+                author: c.user.login,
+                author_association: Some(c.author_association),
+                body: c.body,
+                created_at: c.created_at,
+                url: Some(c.html_url),
+                path: c.path,
+                line: c.line,
+                side: c.side,
+                diff_hunk: Some(c.diff_hunk),
+            });
+        }
+
+        // Sort by creation time
+        unified.sort_by_key(|c| c.created_at());
+
+        Ok(unified)
+    }
+
+    async fn list_open_prs(
+&self,
+        _repo_path: &Path,
+        remote_url: &str,
+    ) -> Result<Vec<PullRequestDetail>, GitHostError> {
+        let repo_info = self.get_repo_info(remote_url).await?;
+
+        (|| async {
+            let api = self.api.clone();
+            let repo_info = repo_info.clone();
+
+            let prs = task::spawn_blocking(move || api.list_open_prs(&repo_info))
+                .await
+                .map_err(|err| {
+                    GitHostError::PullRequest(format!(
+                        "Failed to execute Forgejo API for listing PRs: {err}"
+                    ))
+                })?
+                .map_err(GitHostError::from)?;
+
+            Ok(prs)
+        })
+        .retry(
+&ExponentialBuilder::default()
+                .with_min_delay(Duration::from_secs(1))
+                .with_max_delay(Duration::from_secs(30))
+                .with_max_times(3)
+                .with_jitter(),
+        )
+        .when(|e: &GitHostError| e.should_retry())
+        .notify(|err: &GitHostError, dur: Duration| {
+            tracing::warn!(
+                "Forgejo API call failed, retrying after {:.2}s: {}",
+                dur.as_secs_f64(),
+                err
+            );
+        })
+        .await
+    }
+
+    fn provider_kind(&self) -> ProviderKind {
+        ProviderKind::Forgejo
+    }
+}

--- a/crates/git-host/src/lib.rs
+++ b/crates/git-host/src/lib.rs
@@ -2,6 +2,7 @@ mod detection;
 mod types;
 
 pub mod azure;
+pub mod forgejo;
 pub mod github;
 
 use std::path::Path;
@@ -14,7 +15,7 @@ pub use types::{
     PullRequestDetail, ReviewCommentUser, UnifiedPrComment,
 };
 
-use self::{azure::AzureDevOpsProvider, github::GitHubProvider};
+use self::{azure::AzureDevOpsProvider, forgejo::ForgejoProvider, github::GitHubProvider};
 
 #[async_trait]
 #[enum_dispatch(GitHostService)]
@@ -55,6 +56,7 @@ pub trait GitHostProvider: Send + Sync {
 pub enum GitHostService {
     GitHub(GitHubProvider),
     AzureDevOps(AzureDevOpsProvider),
+    Forgejo(ForgejoProvider),
 }
 
 impl GitHostService {
@@ -62,6 +64,7 @@ impl GitHostService {
         match detect_provider_from_url(url) {
             ProviderKind::GitHub => Ok(Self::GitHub(GitHubProvider::new()?)),
             ProviderKind::AzureDevOps => Ok(Self::AzureDevOps(AzureDevOpsProvider::new()?)),
+            ProviderKind::Forgejo => Ok(Self::Forgejo(ForgejoProvider::new()?)),
             ProviderKind::Unknown => Err(GitHostError::UnsupportedProvider),
         }
     }

--- a/crates/git-host/src/types.rs
+++ b/crates/git-host/src/types.rs
@@ -9,6 +9,7 @@ use ts_rs::TS;
 pub enum ProviderKind {
     GitHub,
     AzureDevOps,
+    Forgejo,
     Unknown,
 }
 
@@ -17,6 +18,7 @@ impl std::fmt::Display for ProviderKind {
         match self {
             ProviderKind::GitHub => write!(f, "GitHub"),
             ProviderKind::AzureDevOps => write!(f, "Azure DevOps"),
+            ProviderKind::Forgejo => write!(f, "Forgejo"),
             ProviderKind::Unknown => write!(f, "Unknown"),
         }
     }


### PR DESCRIPTION
- Add ProviderKind::Forgejo to enum and display impl
- Add Forgejo URL detection (codeberg.org, gitea.com, custom instances)
- Implement ForgejoApi REST client via reqwest
- Implement ForgejoProvider with GitHostProvider trait
- Add retry logic matching GitHub/Azure patterns
- Support Forgejo PR URL format (/pulls/ vs /pull/)
- Forgejo API auth via FORGEJO_TOKEN env var
- Compatible with both Forgejo and Gitea instances