### PR TITLE
Fix docker build: copy pnpm patches/ and all workspace crates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,10 @@ COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
 COPY packages/local-web/package.json packages/local-web/package.json
 COPY packages/ui/package.json packages/ui/package.json
 COPY packages/web-core/package.json packages/web-core/package.json
+# pnpm-workspace.yaml's patchedDependencies references
+# patches/@pierre__diffs@1.1.4.patch, so the frozen-lockfile install needs the
+# patch present in the build context (otherwise ENOENT, pnpm exits 254).
+COPY patches/ patches/
 
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
     pnpm install --frozen-lockfile
@@ -63,54 +67,14 @@ COPY rust-toolchain.toml ./
 RUN cargo --version >/dev/null
 
 COPY Cargo.toml Cargo.lock ./
-COPY crates/api-types/Cargo.toml crates/api-types/Cargo.toml
-COPY crates/db/Cargo.toml crates/db/Cargo.toml
-COPY crates/deployment/Cargo.toml crates/deployment/Cargo.toml
-COPY crates/executors/Cargo.toml crates/executors/Cargo.toml
-COPY crates/git/Cargo.toml crates/git/Cargo.toml
-COPY crates/git-host/Cargo.toml crates/git-host/Cargo.toml
-COPY crates/local-deployment/Cargo.toml crates/local-deployment/Cargo.toml
-COPY crates/mcp/Cargo.toml crates/mcp/Cargo.toml
-COPY crates/relay-control/Cargo.toml crates/relay-control/Cargo.toml
-COPY crates/relay-hosts/Cargo.toml crates/relay-hosts/Cargo.toml
-COPY crates/relay-protocol/Cargo.toml crates/relay-protocol/Cargo.toml
-COPY crates/relay-tunnel-core/Cargo.toml crates/relay-tunnel-core/Cargo.toml
-COPY crates/relay-webrtc/Cargo.toml crates/relay-webrtc/Cargo.toml
-COPY crates/relay-ws/Cargo.toml crates/relay-ws/Cargo.toml
-COPY crates/review/Cargo.toml crates/review/Cargo.toml
-COPY crates/server/Cargo.toml crates/server/Cargo.toml
-COPY crates/server-info/Cargo.toml crates/server-info/Cargo.toml
-COPY crates/services/Cargo.toml crates/services/Cargo.toml
-COPY crates/tauri-app/Cargo.toml crates/tauri-app/Cargo.toml
-COPY crates/trusted-key-auth/Cargo.toml crates/trusted-key-auth/Cargo.toml
-COPY crates/utils/Cargo.toml crates/utils/Cargo.toml
-COPY crates/workspace-manager/Cargo.toml crates/workspace-manager/Cargo.toml
-COPY crates/worktree-manager/Cargo.toml crates/worktree-manager/Cargo.toml
-COPY crates/ws-bridge/Cargo.toml crates/ws-bridge/Cargo.toml
-
-COPY crates/api-types/ crates/api-types/
-COPY crates/db/ crates/db/
-COPY crates/deployment/ crates/deployment/
-COPY crates/executors/ crates/executors/
-COPY crates/git/ crates/git/
-COPY crates/git-host/ crates/git-host/
-COPY crates/local-deployment/ crates/local-deployment/
-COPY crates/mcp/ crates/mcp/
-COPY crates/relay-control/ crates/relay-control/
-COPY crates/relay-hosts/ crates/relay-hosts/
-COPY crates/relay-protocol/ crates/relay-protocol/
-COPY crates/relay-tunnel-core/ crates/relay-tunnel-core/
-COPY crates/relay-webrtc/ crates/relay-webrtc/
-COPY crates/relay-ws/ crates/relay-ws/
-COPY crates/review/ crates/review/
-COPY crates/server/ crates/server/
-COPY crates/server-info/ crates/server-info/
-COPY crates/services/ crates/services/
-COPY crates/trusted-key-auth/ crates/trusted-key-auth/
-COPY crates/utils/ crates/utils/
-COPY crates/workspace-manager/ crates/workspace-manager/
-COPY crates/worktree-manager/ crates/worktree-manager/
-COPY crates/ws-bridge/ crates/ws-bridge/
+# Copy the whole crates/ tree in one shot. The previous hand-maintained per-crate
+# COPY list had drifted out of sync with Cargo.toml's [workspace] members —
+# relay-client, relay-types, client-info, remote-info, embedded-ssh,
+# desktop-bridge and preview-proxy were never copied — so `cargo build --locked`
+# failed to load the workspace ("failed to load manifest for workspace member
+# `/app/crates/relay-client`"). A single recursive copy can't drift out of sync.
+# (.dockerignore already excludes target/ and node_modules/.)
+COPY crates/ crates/
 COPY assets/ assets/
 COPY --from=fe-builder /app/packages/local-web/dist packages/local-web/dist
 


### PR DESCRIPTION
## What

`docker build .` fails on a clean checkout of `main` for two independent, unrelated reasons in the `Dockerfile`. This fixes both so the image builds end to end.

## 1. `pnpm install --frozen-lockfile` can't find the patch

`pnpm-workspace.yaml` declares a patched dependency:

```yaml
patchedDependencies:
  '@pierre/diffs@1.1.4': patches/@pierre__diffs@1.1.4.patch
```

…but the `fe-builder` stage copies the lockfile/manifests without `patches/`, so the install aborts:

```
 ENOENT  ENOENT: no such file or directory, open '/app/patches/@pierre__diffs@1.1.4.patch'
 ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  @vibe/local-web build ...  exit code: 254
```

**Fix:** `COPY patches/ patches/` before the install.

## 2. The per-crate `COPY` list is missing 7 workspace members

The `builder` stage copies crate manifests and sources one-by-one, but the list has drifted from `Cargo.toml`'s `[workspace] members`. These members are never copied: `relay-client`, `relay-types`, `client-info`, `remote-info`, `embedded-ssh`, `desktop-bridge`, `preview-proxy`. So `cargo build --locked` fails immediately:

```
error: failed to load manifest for workspace member `/app/crates/relay-client`
  failed to read `/app/crates/relay-client/Cargo.toml`: No such file or directory
```

**Fix:** replace the enumerated `COPY crates/<name>/…` lines with a single `COPY crates/ crates/`, which can't drift out of sync with the workspace. The manifest-then-source split wasn't enabling dependency-layer caching here (there's no intermediate `cargo build` between the two copy groups), so collapsing it has no caching downside, and `.dockerignore` already excludes `target/` and `node_modules/`. If you'd rather keep the split, I'm happy to instead just add the seven missing crates to the existing lists.

## Verified

- Both failures reproduce on a clean `main` checkout.
- `cargo metadata --locked` resolves the workspace with the change.
- `docker build .` completes end-to-end and the resulting image boots — `/health` returns 200 and the web UI is served.

— Rafael (rafaelfiguereod-stack)
