### PR TITLE
fix: exclude ambiguous characters from relay pairing codes

### DIFF
--- a/crates/trusted-key-auth/src/spake2.rs
+++ b/crates/trusted-key-auth/src/spake2.rs
@@ -7,7 +7,8 @@ use crate::error::TrustedKeyAuthError;
 const SPAKE2_CLIENT_ID: &[u8] = b"vibe-kanban-browser";
 const SPAKE2_SERVER_ID: &[u8] = b"vibe-kanban-server";
 pub const ENROLLMENT_CODE_LENGTH: usize = 6;
-const ENROLLMENT_CODE_CHARSET: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+// Excludes visually ambiguous characters: O (vs 0), I (vs 1), L (vs 1), U (vs V)
+const ENROLLMENT_CODE_CHARSET: &[u8] = b"ABCDEFGHJKMNPQRSTVWXYZ0123456789";
 
 #[derive(Debug)]
 pub struct Spake2StartOutcome {
@@ -68,6 +69,14 @@ pub fn normalize_enrollment_code(raw_code: &str) -> Result<String, TrustedKeyAut
         ));
     }
 
+    // Map visually ambiguous characters to their intended equivalents.
+    // New codes no longer contain O/I/L/U, but users may still type them
+    // when reading a code displayed in a font where 0≈O or 1≈I≈L.
+    let code = code
+        .replace('O', "0")
+        .replace(['I', 'L'], "1")
+        .replace('U', "V");
+
     Ok(code)
 }
 
@@ -98,7 +107,31 @@ mod tests {
         assert_eq!(code.len(), ENROLLMENT_CODE_LENGTH);
         assert!(
             code.bytes()
-                .all(|byte| byte.is_ascii_uppercase() || byte.is_ascii_digit())
+                .all(|byte| ENROLLMENT_CODE_CHARSET.contains(&byte))
         );
+    }
+
+    #[test]
+    fn generate_one_time_code_excludes_ambiguous_characters() {
+        // Generate many codes and verify none contain O, I, L, or U
+        for _ in 0..1000 {
+            let code = generate_one_time_code();
+            assert!(!code.contains('O'), "Code should not contain 'O': {code}");
+            assert!(!code.contains('I'), "Code should not contain 'I': {code}");
+            assert!(!code.contains('L'), "Code should not contain 'L': {code}");
+            assert!(!code.contains('U'), "Code should not contain 'U': {code}");
+        }
+    }
+
+    #[test]
+    fn normalize_enrollment_code_maps_ambiguous_characters() {
+        // O → 0
+        assert_eq!(normalize_enrollment_code("ABO1Z9").unwrap(), "AB01Z9");
+        // I → 1
+        assert_eq!(normalize_enrollment_code("ABI2Z9").unwrap(), "AB12Z9");
+        // L → 1
+        assert_eq!(normalize_enrollment_code("ABL2Z9").unwrap(), "AB12Z9");
+        // U → V
+        assert_eq!(normalize_enrollment_code("ABU2Z9").unwrap(), "ABV2Z9");
     }
 }

--- a/packages/web-core/src/shared/lib/relayPake.ts
+++ b/packages/web-core/src/shared/lib/relayPake.ts
@@ -31,10 +31,18 @@ export interface Spake2EnrollmentClientState {
 }
 
 export function normalizeEnrollmentCode(rawCode: string): string {
-  return rawCode
-    .trim()
-    .toUpperCase()
-    .replace(/[^A-Z0-9]/g, '');
+  return (
+    rawCode
+      .trim()
+      .toUpperCase()
+      .replace(/[^A-Z0-9]/g, '')
+      // Map visually ambiguous characters to their intended equivalents.
+      // New codes no longer contain O/I/L/U, but users may still type them.
+      .replace(/O/g, '0')
+      .replace(/I/g, '1')
+      .replace(/L/g, '1')
+      .replace(/U/g, 'V')
+  );
 }
 
 export async function startSpake2Enrollment(


### PR DESCRIPTION
## What changed

Dropped the visually ambiguous characters `O`, `I`, `L`, `U` from `ENROLLMENT_CODE_CHARSET`, so newly generated pairing codes draw from a Crockford Base32–style alphabet (`ABCDEFGHJKMNPQRSTVWXYZ0123456789`).

For backward compatibility with codes that get read off another screen, `normalize_enrollment_code` (Rust) and `normalizeEnrollmentCode` (TS) now fold the ambiguous glyphs onto their intended twins before matching: `O→0`, `I→1`, `L→1`, `U→V`. Since those four characters can no longer appear in a real code, folding them is always a safe correction of a mistype — existing codes keep validating.

## Why

Pairing codes are six characters, typed by hand from a second device. `O/0`, `I/1/L`, and `U/V` are the classic confusions and make pairing fail with no useful signal to the user. Removing the ambiguous glyphs at generation time plus folding them on input fixes both directions.

Keyspace stays ample: 32^6 ≈ 1.07 billion combinations for a short-lived one-time code.

Fixes https://github.com/BloopAI/vibe-kanban/issues/3359

## Testing

Two unit tests in `spake2.rs` (`cargo test -p trusted-key-auth`):
- `generate_one_time_code_excludes_ambiguous_characters` — 1,000 generated codes, none contain `O/I/L/U`.
- `normalize_enrollment_code_maps_ambiguous_characters` — asserts the four foldings.

The frontend `normalizeEnrollmentCode` change mirrors the backend so a code typed in the browser normalizes identically before it hits SPAKE2.
