### PR TITLE
feat: add start_date and target_date to update_issue MCP tool

### DIFF
--- a/crates/mcp/Cargo.toml
+++ b/crates/mcp/Cargo.toml
@@ -29,4 +29,5 @@ sentry = { version = "0.46.2", default-features = false, features = ["anyhow", "
 reqwest = { workspace = true }
 rustls = { workspace = true }
 regex = "1"
+chrono = { version = "0.4", features = ["serde"] }
 thiserror = { workspace = true }

--- a/crates/mcp/src/task_server/tools/remote_issues.rs
+++ b/crates/mcp/src/task_server/tools/remote_issues.rs
@@ -216,6 +216,14 @@ struct McpUpdateIssueRequest {
         description = "Parent issue ID to set this as a subissue. Pass null to un-nest from parent."
     )]
     parent_issue_id: Option<Option<Uuid>>,
+    #[schemars(
+        description = "Start date for the issue as an ISO 8601 date string (e.g. '2025-06-01T00:00:00Z'). Pass null to clear."
+    )]
+    start_date: Option<Option<String>>,
+    #[schemars(
+        description = "Target/due date for the issue as an ISO 8601 date string (e.g. '2025-06-15T00:00:00Z'). Pass null to clear."
+    )]
+    target_date: Option<Option<String>>,
 }
 
 #[derive(Debug, Serialize, schemars::JsonSchema)]
@@ -492,6 +500,8 @@ impl McpServer {
             status,
             priority,
             parent_issue_id,
+            start_date,
+            target_date,
         }): Parameters<McpUpdateIssueRequest>,
     ) -> Result<CallToolResult, ErrorData> {
         // First get the issue to know its project_id for status resolution
@@ -529,13 +539,39 @@ impl McpServer {
             None
         };
 
+        // Parse optional date strings into DateTime<Utc>
+        let start_date = match start_date {
+            Some(Some(s)) => match s.parse::<chrono::DateTime<chrono::Utc>>() {
+                Ok(dt) => Some(Some(dt)),
+                Err(_) => {
+                    return Ok(McpServer::tool_error(ToolError::message(format!(
+                        "Invalid start_date format. Expected ISO 8601 (e.g. '2025-06-01T00:00:00Z'), got: {s}"
+                    ))));
+                }
+            },
+            Some(None) => Some(None), // explicitly clear the date
+            None => None,             // not provided, don't change
+        };
+        let target_date = match target_date {
+            Some(Some(s)) => match s.parse::<chrono::DateTime<chrono::Utc>>() {
+                Ok(dt) => Some(Some(dt)),
+                Err(_) => {
+                    return Ok(McpServer::tool_error(ToolError::message(format!(
+                        "Invalid target_date format. Expected ISO 8601 (e.g. '2025-06-15T00:00:00Z'), got: {s}"
+                    ))));
+                }
+            },
+            Some(None) => Some(None),
+            None => None,
+        };
+
         let payload = UpdateIssueRequest {
             status_id,
             title,
             description: expanded_description,
             priority,
-            start_date: None,
-            target_date: None,
+            start_date,
+            target_date,
             completed_at: None,
             sort_order: None,
             parent_issue_id,


### PR DESCRIPTION
## What changed

`update_issue` now accepts optional `start_date` and `target_date` parameters (ISO 8601 strings, or `null` to clear). They're parsed into `DateTime<Utc>` and forwarded on `UpdateIssueRequest`. Previously both fields were hardcoded to `None` in the handler, so there was no way to set them through MCP.

## Why

`get_issue` already returns `start_date` and `target_date`, so an agent could read an issue's dates but never write them back — you could see a due date but not set or move one. This closes that gap.

Details:
- Uses the same `Option<Option<T>>` convention already used by `parent_issue_id` on this struct: field omitted = leave unchanged, `null` = clear, value = set.
- Invalid date strings return a clear tool error naming the field and the expected format, rather than failing silently or 500-ing.
- Adds `chrono = { version = "0.4", features = ["serde"] }` to the `mcp` crate, matching how the rest of the workspace pulls in chrono.

Fixes https://github.com/BloopAI/vibe-kanban/issues/3341

## Testing

`cargo check -p mcp` / `cargo clippy -p mcp`. No new unit test: the wiring mirrors the existing `parent_issue_id` path and the parsing is a standard `chrono` `parse::<DateTime<Utc>>()` with an explicit error branch. Happy to add a schema/round-trip test if you'd prefer one.
