### PR TITLE
fix: validate MCP backend URL with health-check probe before use

### DIFF
--- a/crates/mcp/src/bin/vibe_kanban_mcp.rs
+++ b/crates/mcp/src/bin/vibe_kanban_mcp.rs
@@ -97,6 +97,28 @@ where
     Ok(LaunchConfig { mode })
 }
 
+/// Probe a candidate backend URL by sending a lightweight GET request.
+/// Returns `true` if the backend responds (any HTTP status), `false` on
+/// connection failure or timeout.
+async fn probe_backend(url: &str, log_prefix: &str) -> bool {
+    let probe_url = format!("{}/api/health", url.trim_end_matches('/'));
+    tracing::debug!("[{}] Probing backend at {}", log_prefix, probe_url);
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(2))
+        .build()
+        .unwrap_or_default();
+    match client.get(&probe_url).send().await {
+        Ok(_) => {
+            tracing::debug!("[{}] Backend alive at {}", log_prefix, url);
+            true
+        }
+        Err(e) => {
+            tracing::debug!("[{}] Backend probe failed at {}: {}", log_prefix, url, e);
+            false
+        }
+    }
+}
+
 async fn resolve_base_url(log_prefix: &str) -> anyhow::Result<String> {
     if let Ok(url) = std::env::var("VIBE_BACKEND_URL") {
         tracing::info!(
@@ -128,9 +150,46 @@ async fn resolve_base_url(log_prefix: &str) -> anyhow::Result<String> {
         }
     };
 
-    let url = format!("http://{}:{}", host, port);
-    tracing::info!("[{}] Using backend URL: {}", log_prefix, url);
-    Ok(url)
+    // Build candidate URL and validate it with a health-check probe.
+    // If the primary host fails, try alternate loopback addresses to handle
+    // the case where the backend binds to `localhost` (which may resolve to
+    // `::1` on macOS) while we default to `127.0.0.1`, or vice versa.
+    let primary_url = format!("http://{}:{}", host, port);
+    if probe_backend(&primary_url, log_prefix).await {
+        tracing::info!("[{}] Using backend URL: {}", log_prefix, primary_url);
+        return Ok(primary_url);
+    }
+
+    // Try alternate loopback hosts
+    let alternates: &[&str] = if host == "127.0.0.1" {
+        &["localhost", "[::1]"]
+    } else if host == "localhost" {
+        &["127.0.0.1", "[::1]"]
+    } else {
+        &["localhost", "127.0.0.1"]
+    };
+
+    for alt_host in alternates {
+        let alt_url = format!("http://{}:{}", alt_host, port);
+        if probe_backend(&alt_url, log_prefix).await {
+            tracing::info!(
+                "[{}] Primary host {} unreachable, using alternate: {}",
+                log_prefix,
+                host,
+                alt_url
+            );
+            return Ok(alt_url);
+        }
+    }
+
+    // Fall through to original URL — downstream will report the real error
+    tracing::warn!(
+        "[{}] No backend responded on port {}. Using {} (may fail).",
+        log_prefix,
+        port,
+        primary_url
+    );
+    Ok(primary_url)
 }
 
 fn init_process_logging(log_prefix: &str, version: &str) {


### PR DESCRIPTION
## What changed

Added `probe_backend()` — a `GET /api/health` with a 2-second timeout — and made `resolve_base_url()` validate the URL it hands back:

1. Probe the primary `http://{host}:{port}`. If it answers, use it.
2. If not, try the other loopback forms (`localhost` ↔ `127.0.0.1` ↔ `[::1]`) and use the first that responds.
3. If none respond, fall through to the original URL with a warning.

The probe treats *any* HTTP response as "reachable" — it's disambiguating the host, not checking health semantics — so it still works even though `/api/health` sits behind the relay-signature middleware and returns an auth error to an unsigned request. Behavior is never worse than before: the fall-through path is the old behavior.

## Why

MCP reconstructs the backend URL from a port file / env as `http://{host}:{port}` and used it blind. When the port file is stale, or the host guess is wrong — e.g. the desktop backend binds `localhost`, which resolves to `::1` on macOS, while MCP defaults to `127.0.0.1` — the tool talks to nothing and fails silently with no actionable error. Probing before committing to a URL makes discovery self-correct across the loopback mismatch.

Fixes https://github.com/BloopAI/vibe-kanban/issues/3349

## Testing

`cargo check -p mcp` / `cargo clippy -p mcp`. The happy path adds a single request; only the miss case pays the retry, each bounded to 2s. No new unit test — the logic is network I/O against loopback — but I reasoned through the three host cases (primary `127.0.0.1`, primary `localhost`, other). Open to adding an injectable-probe test if you'd like coverage there.
