### PR TITLE
fix(docker,npx-cli): unbreak self-host build and allow binary CDN override

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,8 @@ COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
 COPY packages/local-web/package.json packages/local-web/package.json
 COPY packages/ui/package.json packages/ui/package.json
 COPY packages/web-core/package.json packages/web-core/package.json
+# pnpm-workspace.yaml patchedDependencies needs this file present for frozen install.
+COPY patches/ patches/
 
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
     pnpm install --frozen-lockfile
@@ -63,54 +65,12 @@ COPY rust-toolchain.toml ./
 RUN cargo --version >/dev/null
 
 COPY Cargo.toml Cargo.lock ./
-COPY crates/api-types/Cargo.toml crates/api-types/Cargo.toml
-COPY crates/db/Cargo.toml crates/db/Cargo.toml
-COPY crates/deployment/Cargo.toml crates/deployment/Cargo.toml
-COPY crates/executors/Cargo.toml crates/executors/Cargo.toml
-COPY crates/git/Cargo.toml crates/git/Cargo.toml
-COPY crates/git-host/Cargo.toml crates/git-host/Cargo.toml
-COPY crates/local-deployment/Cargo.toml crates/local-deployment/Cargo.toml
-COPY crates/mcp/Cargo.toml crates/mcp/Cargo.toml
-COPY crates/relay-control/Cargo.toml crates/relay-control/Cargo.toml
-COPY crates/relay-hosts/Cargo.toml crates/relay-hosts/Cargo.toml
-COPY crates/relay-protocol/Cargo.toml crates/relay-protocol/Cargo.toml
-COPY crates/relay-tunnel-core/Cargo.toml crates/relay-tunnel-core/Cargo.toml
-COPY crates/relay-webrtc/Cargo.toml crates/relay-webrtc/Cargo.toml
-COPY crates/relay-ws/Cargo.toml crates/relay-ws/Cargo.toml
-COPY crates/review/Cargo.toml crates/review/Cargo.toml
-COPY crates/server/Cargo.toml crates/server/Cargo.toml
-COPY crates/server-info/Cargo.toml crates/server-info/Cargo.toml
-COPY crates/services/Cargo.toml crates/services/Cargo.toml
-COPY crates/tauri-app/Cargo.toml crates/tauri-app/Cargo.toml
-COPY crates/trusted-key-auth/Cargo.toml crates/trusted-key-auth/Cargo.toml
-COPY crates/utils/Cargo.toml crates/utils/Cargo.toml
-COPY crates/workspace-manager/Cargo.toml crates/workspace-manager/Cargo.toml
-COPY crates/worktree-manager/Cargo.toml crates/worktree-manager/Cargo.toml
-COPY crates/ws-bridge/Cargo.toml crates/ws-bridge/Cargo.toml
-
-COPY crates/api-types/ crates/api-types/
-COPY crates/db/ crates/db/
-COPY crates/deployment/ crates/deployment/
-COPY crates/executors/ crates/executors/
-COPY crates/git/ crates/git/
-COPY crates/git-host/ crates/git-host/
-COPY crates/local-deployment/ crates/local-deployment/
-COPY crates/mcp/ crates/mcp/
-COPY crates/relay-control/ crates/relay-control/
-COPY crates/relay-hosts/ crates/relay-hosts/
-COPY crates/relay-protocol/ crates/relay-protocol/
-COPY crates/relay-tunnel-core/ crates/relay-tunnel-core/
-COPY crates/relay-webrtc/ crates/relay-webrtc/
-COPY crates/relay-ws/ crates/relay-ws/
-COPY crates/review/ crates/review/
-COPY crates/server/ crates/server/
-COPY crates/server-info/ crates/server-info/
-COPY crates/services/ crates/services/
-COPY crates/trusted-key-auth/ crates/trusted-key-auth/
-COPY crates/utils/ crates/utils/
-COPY crates/workspace-manager/ crates/workspace-manager/
-COPY crates/worktree-manager/ crates/worktree-manager/
-COPY crates/ws-bridge/ crates/ws-bridge/
+# Copy the whole crates/ tree. A hand-maintained per-crate list drifted from
+# Cargo.toml workspace members (relay-client, relay-types, client-info,
+# remote-info, embedded-ssh, desktop-bridge, preview-proxy were missing), so
+# `cargo build --locked --bin server` failed to load the workspace.
+# .dockerignore already excludes target/ and node_modules/.
+COPY crates/ crates/
 COPY assets/ assets/
 COPY --from=fe-builder /app/packages/local-web/dist packages/local-web/dist
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,14 @@ Make sure you have authenticated with your favourite coding agent. A full list o
 npx vibe-kanban
 ```
 
+If binary download fails (CDN/TLS issues after the commercial sunset), point the CLI at a mirror that hosts the same `binaries/<tag>/...` layout:
+
+```bash
+VIBE_KANBAN_BINARY_BASE_URL=https://your-mirror.example npx vibe-kanban
+```
+
+Or build from source with `./local-build.sh` and run with `VIBE_KANBAN_LOCAL=1`.
+
 ## Documentation
 
 Head to the [website](https://vibekanban.com/docs) for the latest documentation and user guides.

--- a/npx-cli/src/binary-base-url.test.mjs
+++ b/npx-cli/src/binary-base-url.test.mjs
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+// Mirror of resolveBinaryBaseUrl — keep in sync with download.ts helper.
+function resolveBinaryBaseUrl(baked, envValue) {
+  const raw = (envValue && envValue.trim()) || baked;
+  return raw.replace(/\/$/, '');
+}
+
+test('uses baked URL when env unset', () => {
+  assert.equal(
+    resolveBinaryBaseUrl('https://npm-cdn.example.com', undefined),
+    'https://npm-cdn.example.com'
+  );
+});
+
+test('env override wins and strips trailing slash', () => {
+  assert.equal(
+    resolveBinaryBaseUrl('https://npm-cdn.example.com', 'https://mirror.example/binaries/'),
+    'https://mirror.example/binaries'
+  );
+});
+
+test('blank env falls back to baked', () => {
+  assert.equal(
+    resolveBinaryBaseUrl('https://npm-cdn.example.com', '   '),
+    'https://npm-cdn.example.com'
+  );
+});

--- a/npx-cli/src/cli.ts
+++ b/npx-cli/src/cli.ts
@@ -152,6 +152,9 @@ async function extractAndRun(
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);
       console.error(`\nDownload failed: ${msg}`);
+      console.error(
+        'Hint: set VIBE_KANBAN_BINARY_BASE_URL to a reachable binary mirror, or build from source with ./local-build.sh and VIBE_KANBAN_LOCAL=1.',
+      );
       process.exit(1);
     }
   }

--- a/npx-cli/src/download.ts
+++ b/npx-cli/src/download.ts
@@ -4,8 +4,12 @@ import path from 'path';
 import crypto from 'crypto';
 import os from 'os';
 
-// Replaced during npm pack by workflow
-export const R2_BASE_URL = '__R2_PUBLIC_URL__';
+// Replaced during npm pack by workflow. Operators can override at runtime via
+// VIBE_KANBAN_BINARY_BASE_URL when the baked CDN is unreachable (expired cert,
+// 403/404, corporate TLS inspection, or community mirrors after sunset).
+const BAKED_R2_BASE_URL = '__R2_PUBLIC_URL__';
+
+export const R2_BASE_URL = resolveBinaryBaseUrl();
 export const BINARY_TAG = '__BINARY_TAG__'; // e.g., v0.0.135-20251215122030
 export const CACHE_DIR = path.join(os.homedir(), '.vibe-kanban', 'bin');
 
@@ -54,7 +58,13 @@ function fetchJson<T>(url: string): Promise<T> {
             .catch(reject);
         }
         if (res.statusCode !== 200) {
-          return reject(new Error(`HTTP ${res.statusCode} fetching ${url}`));
+          return reject(
+            new Error(
+              `HTTP ${res.statusCode} fetching ${url}. ` +
+                `If the default binary CDN is down, set VIBE_KANBAN_BINARY_BASE_URL ` +
+                `to a mirror that hosts binaries/<tag>/manifest.json.`
+            )
+          );
         }
         let data = '';
         res.on('data', (chunk: string) => (data += chunk));
@@ -106,7 +116,10 @@ function downloadFile(
           file.close();
           cleanup();
           return reject(
-            new Error(`HTTP ${res.statusCode} downloading ${url}`)
+            new Error(
+              `HTTP ${res.statusCode} downloading ${url}. ` +
+                `Override with VIBE_KANBAN_BINARY_BASE_URL if needed.`
+            )
           );
         }
 
@@ -273,3 +286,14 @@ export async function getLatestVersion(): Promise<string | undefined> {
   );
   return manifest.latest;
 }
+
+
+/** Resolve binary CDN base URL (baked publish value or runtime override). */
+export function resolveBinaryBaseUrl(
+  baked: string = BAKED_R2_BASE_URL,
+  envValue: string | undefined = process.env.VIBE_KANBAN_BINARY_BASE_URL
+): string {
+  const raw = (envValue && envValue.trim()) || baked;
+  return raw.replace(/\/$/, '');
+}
+

--- a/scripts/check-dockerfile-workspace.mjs
+++ b/scripts/check-dockerfile-workspace.mjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+/**
+ * Guard: root Dockerfile must keep Docker buildable after workspace drift.
+ * - COPY patches/ required when pnpm-workspace.yaml declares patchedDependencies
+ * - crates/ must be fully present for Cargo workspace members used by --bin server
+ *
+ * Usage: node scripts/check-dockerfile-workspace.mjs
+ * Exit 0 on pass, 1 on fail.
+ */
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const dockerfile = fs.readFileSync(path.join(root, 'Dockerfile'), 'utf8');
+const cargoToml = fs.readFileSync(path.join(root, 'Cargo.toml'), 'utf8');
+const pnpmWs = fs.readFileSync(path.join(root, 'pnpm-workspace.yaml'), 'utf8');
+
+const errors = [];
+
+// 1) patches/
+const hasPatchedDeps = /patchedDependencies\s*:/.test(pnpmWs);
+if (hasPatchedDeps && !/COPY\s+patches\/\s+patches\//.test(dockerfile)) {
+  errors.push(
+    'Dockerfile must COPY patches/ patches/ because pnpm-workspace.yaml declares patchedDependencies'
+  );
+}
+
+// 2) workspace members under crates/ must be available in Docker build context
+const workspaceBlock = cargoToml.match(/\[workspace\][\s\S]*?(?=\n\[|$)/)?.[0] || '';
+const membersBlock = workspaceBlock.match(/members\s*=\s*\[([\s\S]*?)\]/)?.[1] || '';
+const memberRe = /"crates\/([^"]+)"/g;
+const members = [];
+let m;
+while ((m = memberRe.exec(membersBlock)) !== null) {
+  members.push(m[1]);
+}
+
+const copiesWholeTree = /COPY\s+crates\/\s+crates\//.test(dockerfile);
+if (!copiesWholeTree) {
+  for (const member of members) {
+    // Accept either recursive copy of that crate or Cargo.toml-only + full later
+    const hasToml = new RegExp(
+      String.raw`COPY\s+crates/${member}/Cargo\.toml\s+crates/${member}/Cargo\.toml`
+    ).test(dockerfile);
+    const hasDir = new RegExp(
+      String.raw`COPY\s+crates/${member}/\s+crates/${member}/`
+    ).test(dockerfile);
+    if (!hasToml && !hasDir) {
+      errors.push(
+        `Dockerfile missing crate workspace member: crates/${member} (COPY crates/ crates/ recommended)`
+      );
+    }
+  }
+}
+
+if (errors.length) {
+  console.error('check-dockerfile-workspace FAILED:');
+  for (const e of errors) console.error(' -', e);
+  process.exit(1);
+}
+
+console.log(
+  `check-dockerfile-workspace OK (patchedDeps=${hasPatchedDeps}, members=${members.length}, wholeTree=${copiesWholeTree})`
+);


### PR DESCRIPTION
## Summary

Post-sunset self-host / distribution fixes for community maintenance.

1. **Dockerfile is broken on `main`** for two independent reasons:
   - `pnpm-workspace.yaml` declares `patchedDependencies` for `@pierre/diffs`, but the `fe-builder` stage never `COPY`s `patches/` → `pnpm install --frozen-lockfile` exits with `ENOENT`.
   - Hand-maintained per-crate `COPY` list drifted from `Cargo.toml` workspace members (`relay-client`, `relay-types`, `client-info`, `remote-info`, `embedded-ssh`, `desktop-bridge`, `preview-proxy`) → `cargo build --locked --bin server` cannot load the workspace.
2. **npx binary CDN has no runtime escape hatch** when the baked `npm-cdn.vibekanban.com` URL fails for some environments (see #3435 class failures). Adds `VIBE_KANBAN_BINARY_BASE_URL` override + clearer errors + README note. Default CDN path is unchanged.

Also adds `scripts/check-dockerfile-workspace.mjs` so the COPY drift class fails red in CI/local before another release.

## Coordination / process

- README asks contributors to discuss first. Opening this as a **draft** so maintainers/community can accept, reshape, or close in favor of existing work.
- **Open PR #3436** already targets the same Dockerfile root causes. Happy to:
  - close this Docker half if #3436 is preferred and only keep the guard + npx commits, or
  - co-author / rebase onto #3436, or
  - supersede if maintainers want the combined packet.
- Related user demand: #3440 (official plug-and-play image) — this unblocks `docker build .` as a prerequisite; GHCR/Docker Hub publish is **out of scope** here.

## Commits

- `d47a6cf` fix(docker): copy pnpm patches and full crates tree
- `84f334b` fix(npx-cli): allow VIBE_KANBAN_BINARY_BASE_URL override

## Verification

| Check | Result |
|-------|--------|
| `pnpm install --frozen-lockfile` without `patches/` | RED `ENOENT .../@pierre__diffs@1.1.4.patch` |
| same with `patches/` present (fe-sim) | GREEN (~30s Done) |
| `node scripts/check-dockerfile-workspace.mjs` on `main` Dockerfile | RED (patches + missing crates) |
| same on this branch | GREEN `members=30 wholeTree=true` |
| `node --test npx-cli/src/binary-base-url.test.mjs` | 3/3 pass |
| `npx-cli` esbuild build | OK (44.7kb) |
| full multi-stage `docker build` / release cargo | not run in this environment (long); structural correctness locked by the guard |

## Risk / rollback

- Recursive `COPY crates/` slightly larger context; `.dockerignore` already excludes `**/target` and `node_modules`.
- Binary base URL override is opt-in.
- Revert = drop the two commits.

## Test plan

- [ ] `node scripts/check-dockerfile-workspace.mjs`
- [ ] `node --test npx-cli/src/binary-base-url.test.mjs`
- [ ] `docker build .` on a clean checkout of this branch (fe-builder should pass pnpm; builder should see full workspace)
- [ ] Optional: `VIBE_KANBAN_BINARY_BASE_URL=https://… npx vibe-kanban` against a mirror hosting `binaries/<tag>/manifest.json`

Refs: #3435 #3440 #3436
