### PR TITLE
fix: correct swapped stderr/stdout labels in git CLI error output

### DIFF
--- a/crates/git/src/cli.rs
+++ b/crates/git/src/cli.rs
@@ -824,8 +824,8 @@ impl GitCli {
             let combined = match (stdout.is_empty(), stderr.is_empty()) {
                 (true, true) => "Command failed with no output".to_string(),
                 (false, false) => format!("--- stderr\n{stderr}\n--- stdout\n{stdout}"),
-                (false, true) => format!("--- stderr\n{stdout}"),
-                (true, false) => format!("--- stdout\n{stderr}"),
+                (false, true) => format!("--- stdout\n{stdout}"),
+                (true, false) => format!("--- stderr\n{stderr}"),
             };
             return Err(GitCliError::CommandFailed(combined));
         }


### PR DESCRIPTION
When a git command fails with output on only one stream, the labels are reversed. A stdout-only failure prints under `--- stderr`, and a stderr-only failure under `--- stdout`. The both-streams case is already correct.

The effect is that git failures point the reader at the wrong stream.

Split out of #3423, which bundled several unrelated changes under a single title. Filing them separately so each can be reviewed on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
