### PR TITLE
docs: add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,20 @@
+# Security Policy
+
+## Supported Versions
+
+The latest release is always supported with security updates. Older releases
+receive fixes on a best-effort basis.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| latest  | :white_check_mark: |
+
+## Reporting a Vulnerability
+
+Please report security vulnerabilities by opening a **private** GitHub Security
+Advisory at `https://github.com/BloopAI/vibe-kanban/security/advisories/new`.
+
+Include a description of the issue, steps to reproduce, and your assessment of
+impact. You will receive an acknowledgement within 72 hours. If the report is
+accepted, a patch will be released as soon as possible and you will be credited
+in the release notes.


### PR DESCRIPTION
Adds a security policy, so vulnerability reports have a documented private channel instead of arriving as public issues.

Split out of #3423.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
