### PR TITLE
fix: route server startup through startup::initialize_deployment

### DIFF
--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -3,6 +3,7 @@ use axum::Router;
 use deployment::{Deployment, DeploymentError};
 use server::{
     DeploymentImpl, middleware::origin::validate_origin, routes, runtime::relay_registration,
+    startup,
 };
 use services::services::container::ContainerService;
 use sqlx::Error as SqlxError;
@@ -12,7 +13,6 @@ use tokio_util::sync::CancellationToken;
 use tower_http::validate_request::ValidateRequestHeaderLayer;
 use tracing_subscriber::{EnvFilter, prelude::*};
 use utils::{
-    assets::asset_dir,
     port_file::write_port_file_with_proxy,
     sentry::{self as sentry_utils, SentrySource, sentry_layer},
 };
@@ -49,46 +49,9 @@ async fn main() -> Result<(), VibeKanbanError> {
         .with(sentry_layer())
         .init();
 
-    // Create asset directory if it doesn't exist
-    if !asset_dir().exists() {
-        std::fs::create_dir_all(asset_dir())?;
-    }
-
-    // Copy old database to new location for safe downgrades
-    let old_db = asset_dir().join("db.sqlite");
-    let new_db = asset_dir().join("db.v2.sqlite");
-    if !new_db.exists() && old_db.exists() {
-        tracing::info!(
-            "Copying database to new location: {:?} -> {:?}",
-            old_db,
-            new_db
-        );
-        std::fs::copy(&old_db, &new_db).expect("Failed to copy database file");
-        tracing::info!("Database copy complete");
-    }
-
     let shutdown_token = CancellationToken::new();
 
-    let deployment = DeploymentImpl::new(shutdown_token.clone()).await?;
-    deployment.update_sentry_scope().await?;
-    deployment
-        .container()
-        .cleanup_orphan_executions()
-        .await
-        .map_err(DeploymentError::from)?;
-    deployment
-        .container()
-        .backfill_before_head_commits()
-        .await
-        .map_err(DeploymentError::from)?;
-    deployment
-        .container()
-        .backfill_repo_names()
-        .await
-        .map_err(DeploymentError::from)?;
-    deployment
-        .track_if_analytics_allowed("session_start", serde_json::json!({}))
-        .await;
+    let deployment = startup::initialize_deployment(shutdown_token.clone()).await?;
     // Preload global executor options cache for all executors with DEFAULT presets
     tokio::spawn(async move {
         executors::executors::utils::preload_global_executor_options_cache().await;


### PR DESCRIPTION
`crates/server/src/main.rs` open-codes its own initialization sequence, and that sequence has drifted from `server::startup::initialize_deployment`.

The inline path never calls `migrate_legacy_attachment_directories`, so the legacy attachment directory migration does not run for anyone starting the server through this binary.

This replaces the duplicated block with the shared function. `initialize_deployment` already covers everything the inline version did (asset directory creation, the legacy database copy, sentry scope, orphan execution cleanup, and the head-commit and repo-name backfills) and adds the attachment migration on top.

Split out of #3423.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
