### PR TITLE
fix: reject non-positive installation_id in GitHub App callback

### DIFF
--- a/crates/remote/src/routes/github_app.rs
+++ b/crates/remote/src/routes/github_app.rs
@@ -500,6 +500,9 @@ async fn handle_callback(
     let Some(installation_id) = query.installation_id else {
         return redirect_error(None, "Missing installation_id");
     };
+    if installation_id <= 0 {
+        return redirect_error(None, "Invalid installation_id");
+    }
 
     let Some(state_token) = query.state else {
         return redirect_error(None, "Missing state parameter");


### PR DESCRIPTION
The GitHub App callback accepts any `i64` `installation_id` from the query string and carries it forward with only a missing-parameter check. This adds a range check rejecting values less than or equal to zero.

A code scanning alert classified this as SSRF. To be accurate about scope, it is not: the value is an integer and cannot inject a host. Filing it as plain input validation rather than as a security fix. Happy to close it if you consider the check unnecessary.

Split out of #3423.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
