### PR TITLE
fix: serialize PATH mutation and document unsafe fd conversions

### DIFF
--- a/crates/executors/src/actions/script.rs
+++ b/crates/executors/src/actions/script.rs
@@ -54,6 +54,10 @@ impl Executable for ScriptRequest {
 
         let (shell_cmd, shell_arg) = get_shell_command();
         let mut command = Command::new(shell_cmd);
+        // Script content is passed verbatim to the shell's -c argument.
+        // Trust boundary: scripts originate from authenticated user sessions
+        // and run in isolated per-workspace directories. No untrusted input
+        // reaches this path.
         command
             .kill_on_drop(true)
             .stdin(std::process::Stdio::null())

--- a/crates/executors/src/stdout_dup.rs
+++ b/crates/executors/src/stdout_dup.rs
@@ -97,6 +97,9 @@ fn wrap_fd_as_child_stdout(
     {
         // On Unix: PipeReader -> raw fd -> OwnedFd -> std::process::ChildStdout -> tokio::process::ChildStdout
         let raw_fd = pipe_reader.into_raw_fd();
+        // SAFETY: raw_fd is a valid, open file descriptor produced by
+        // os_pipe::pipe(). into_raw_fd() transfers ownership, so we are the
+        // sole owner and OwnedFd takes over lifetime management.
         let owned_fd = unsafe { OwnedFd::from_raw_fd(raw_fd) };
         let std_stdout = std::process::ChildStdout::from(owned_fd);
         tokio::process::ChildStdout::from_std(std_stdout).map_err(ExecutorError::Io)
@@ -106,6 +109,8 @@ fn wrap_fd_as_child_stdout(
     {
         // On Windows: PipeReader -> raw handle -> OwnedHandle -> std::process::ChildStdout -> tokio::process::ChildStdout
         let raw_handle = pipe_reader.into_raw_handle();
+        // SAFETY: raw_handle is a valid HANDLE produced by os_pipe::pipe().
+        // into_raw_handle() transfers ownership, so OwnedHandle is the sole owner.
         let owned_handle = unsafe { OwnedHandle::from_raw_handle(raw_handle) };
         let std_stdout = std::process::ChildStdout::from(owned_handle);
         tokio::process::ChildStdout::from_std(std_stdout).map_err(ExecutorError::Io)
@@ -120,6 +125,8 @@ fn wrap_fd_as_tokio_writer(
     {
         // On Unix: PipeWriter -> raw fd -> OwnedFd -> std::fs::File -> tokio::fs::File
         let raw_fd = pipe_writer.into_raw_fd();
+        // SAFETY: raw_fd is a valid, open file descriptor produced by
+        // os_pipe::pipe(). into_raw_fd() transfers ownership, so OwnedFd is sole owner.
         let owned_fd = unsafe { OwnedFd::from_raw_fd(raw_fd) };
         let std_file = std::fs::File::from(owned_fd);
         Ok(tokio::fs::File::from_std(std_file))
@@ -129,6 +136,8 @@ fn wrap_fd_as_tokio_writer(
     {
         // On Windows: PipeWriter -> raw handle -> OwnedHandle -> std::fs::File -> tokio::fs::File
         let raw_handle = pipe_writer.into_raw_handle();
+        // SAFETY: raw_handle is a valid HANDLE produced by os_pipe::pipe().
+        // into_raw_handle() transfers ownership, so OwnedHandle is the sole owner.
         let owned_handle = unsafe { OwnedHandle::from_raw_handle(raw_handle) };
         let std_file = std::fs::File::from(owned_handle);
         Ok(tokio::fs::File::from_std(std_file))

--- a/crates/utils/src/jwt.rs
+++ b/crates/utils/src/jwt.rs
@@ -1,4 +1,6 @@
 use chrono::{DateTime, Utc};
+// insecure_decode skips signature verification intentionally — these helpers
+// extract metadata only and must never be used for authentication decisions.
 use jsonwebtoken::dangerous::insecure_decode;
 use serde::Deserialize;
 use thiserror::Error;

--- a/crates/utils/src/shell.rs
+++ b/crates/utils/src/shell.rs
@@ -5,6 +5,7 @@ use std::{
     env::{join_paths, split_paths},
     ffi::{OsStr, OsString},
     path::{Path, PathBuf},
+    sync::{Mutex, OnceLock},
 };
 
 use crate::tokio::block_on;
@@ -93,10 +94,21 @@ pub fn merge_paths(primary: impl AsRef<OsStr>, secondary: impl AsRef<OsStr>) -> 
     join_paths(merged).unwrap_or_default()
 }
 
+// Serializes concurrent PATH mutations so no two tasks race on set_var.
+// A residual risk of concurrent readers on POSIX remains, but is acceptable
+// for a single-user local tool that refreshes PATH at most once at startup.
+static PATH_MUTATION_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
 async fn refresh_path() -> bool {
     let Some(refreshed) = get_fresh_path().await else {
         return false;
     };
+
+    // Acquire the lock after the async work so we never hold a non-Send
+    // MutexGuard across an await point.
+    let lock = PATH_MUTATION_LOCK.get_or_init(|| Mutex::new(()));
+    let _guard = lock.lock().unwrap_or_else(|p| p.into_inner());
+
     let existing = std::env::var_os("PATH").unwrap_or_default();
     let refreshed_os = OsString::from(&refreshed);
     let merged = merge_paths(&existing, refreshed_os);
@@ -104,6 +116,10 @@ async fn refresh_path() -> bool {
         return false;
     }
     tracing::debug!(?existing, ?refreshed, ?merged, "Refreshed PATH");
+    // SAFETY: PATH_MUTATION_LOCK prevents concurrent mutations of PATH from
+    // this function. The remaining risk (concurrent readers on POSIX) is
+    // acceptable: this is a single-user local tool and PATH is refreshed at
+    // most once per process lifetime, before any user workloads begin.
     unsafe {
         std::env::set_var("PATH", &merged);
     }


### PR DESCRIPTION
Two things in here.

`refresh_path` mutates `PATH` through `std::env::set_var` with no synchronisation, so concurrent callers can race on it. This adds a mutex around the mutation, acquired after the async work so no guard is held across an await. A residual risk of concurrent readers on POSIX remains and is called out in the comment.

The rest is documentation: SAFETY comments on the four raw fd and raw handle conversions in `stdout_dup.rs`, a note on `insecure_decode` in `jwt.rs`, and a note on the trust boundary for script content in `script.rs`.

On that last comment, it states an assumption about where script content originates. That is my reading of the code, not something I can confirm from outside. If it does not match your intent, say so and I will reword or drop it.

Split out of #3423.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
